### PR TITLE
[#1] spec を改訂し評価 3 層・ADR の根拠を揃える

### DIFF
--- a/docs/adr/0001-internal-representation.md
+++ b/docs/adr/0001-internal-representation.md
@@ -1,0 +1,77 @@
+# ADR-0001: 内部表現は NumPy 並列配列 + 差分更新
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+
+## Context
+
+`docs/spec/spec.md` 旧版の §8 データモデルは `Household.members: list[Person]` という OOP 表現を採用しており、§11.4 の目的関数はその上で `observed[s, j]` を都度集計する形を想定していた。一方、§12 の SA は `max_iters: 200000` を想定し、§15.1 の実験では `evals_per_agent ∈ {1000, ..., 16000}` を回す。
+
+この構造のまま進めると、1 遷移ごとに `list[Household]` を全走査して集計し直す必要があり、N = 数千世帯 × 20 万反復で**非現実的な速度**になる。`Person` を pydantic モデルにするとさらに数倍遅くなる。§11.5 の親子年齢・夫婦年齢制約判定も世帯内ペアを都度走査すると重い。
+
+レビュー `docs/reviews/review-python.md` 指摘 1 は、Phase 1 着手前に SA 内部表現を「NumPy 並列配列 + 差分更新」に固定することを強く求めている。これを先送りすると Phase 2 で必ず大規模な手戻りが発生する。
+
+## Decision
+
+**I/O・外部 API** と **SA 内部表現** を二層に分離する。
+
+### I/O・外部 API 層
+
+- pydantic v2 `BaseModel`（バリデーション目的のみ）
+- `Household`, `Person` は §8 の外部データモデルとして残す
+- CSV ローダ・`writers.py`・CLI 境界・config でのみ使う
+
+### SA 内部表現層（`optimize/state.py`）
+
+```python
+@dataclass
+class PopulationArrays:
+    age: np.ndarray           # int16, shape=(n_persons,)
+    sex: np.ndarray           # int8  (0=M, 1=F)
+    role: np.ndarray          # int8  (enum)
+    household_id: np.ndarray  # int32
+    family_type: np.ndarray   # int8  (enum, person-broadcast)
+```
+
+- NumPy 並列配列（Structure of Arrays）で固定
+- dtype を明示（int16 / int8 / int32）してメモリ局所性を最大化
+- person-broadcast された `family_type` を冗長に持ち、family type ごとの集計を vectorize できるようにする
+
+### 差分更新版目的関数（`optimize/objective.py`）
+
+- `observed[s, j]` を保持変数として持ち、遷移前後で影響を受けるビンのみ `+1 / -1` する
+- `abs(observed - target)` の総和 `score` も差分で反映（1 遷移 O(1)）
+- `ObjectiveState` クラスが `propose / apply / revert` の 3 メソッド API で SA の全遷移を扱う
+- この API は `domain/protocols.py` の `Transition` Protocol と整合する
+
+### ドメイン層 ↔ 並列配列 の変換
+
+- `optimize/state.py` に `from_households(list[Household]) -> PopulationArrays` と `to_households(...) -> list[Household]`
+- I/O 境界でのみ変換し、SA 内部では変換しない
+
+## Consequences
+
+### 肯定的な結果
+
+- **性能**: 1 遷移 O(1) の差分更新が成立し、20 万反復が 30 秒オーダで回る見込み（pytest-benchmark で Phase 2 の Exit 条件として確認する）
+- **決定性テスト**: NumPy 配列なので seed 固定で bitwise 一致を assert しやすい
+- **property test**: hypothesis で「差分更新と全再計算の結果が一致する」を検証できる
+- **メモリ**: dtype を絞った並列配列で N = 10 万人程度まで RAM 内で扱える
+
+### 否定的な結果
+
+- **OOP 的な可読性は下がる**: SA 内部コードで `person.age` ではなく `arrays.age[i]` を読む必要がある
+- **I/O 層との往復コスト**: CSV → pydantic → `PopulationArrays` の変換が必要（ただし 1 run に 1 回のみ）
+- **遷移実装の認知負荷**: `propose / apply / revert` の対応関係を正しく保つ property test が必須
+
+### 将来の差分プライバシー (DP) 拡張
+
+- 並列配列はそのまま、目的関数側を noisy target を受けられるよう `Distribution` Protocol で抽象化する（`domain/protocols.py`）
+- 本 ADR の決定は DP 拡張と衝突しない
+
+## References
+
+- レビュー指摘の逆参照: `docs/reviews/review-python.md` 指摘 1（最重要）、指摘 5（Protocol 切り出し）、追加タスク B（差分更新 PoC）、追加タスク D（hypothesis property test）
+- `docs/reviews/action-plan.md` §1.2「内部表現 vs 拡張性」
+- `docs/spec/spec.md` §9（ディレクトリ）、§12.1（SA 共通）
+- 関連 ADR: なし（本 ADR が初）

--- a/docs/adr/0002-objective-normalization.md
+++ b/docs/adr/0002-objective-normalization.md
@@ -1,0 +1,92 @@
+# ADR-0002: 目的関数は 2 モード（原論文準拠 / 研究拡張）
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+
+## Context
+
+`docs/spec/spec.md` 旧版 §11.4 は目的関数を次の式で書いていた。
+
+```text
+objective = Σ_s Σ_j weight_s * abs(observed[s, j] - target[s, j])
+```
+
+この式には 2 つの問題がある。
+
+1. **原論文との不整合**（`docs/reviews/review-privacy.md` 指摘 1）: Murata 2017 の式(1) は `f(A) = Σ_s Σ_j |c_{sj}(A) - Round(r_{sj} · m_{sj}(A))|` であり、21 統計拡張の式(3) は `f'(A) = Σ_s Σ_j |c_{sj}(A) - R_{sj}|`（`R_{sj}` は率ではなく実数値の実統計）である。原論文に `weight_s` は存在しない。`weight_s` を混ぜた式のまま「Murata 再現」を主張すると、再現性の根拠が弱くなる。
+2. **統計間スケール不一致**（`docs/reviews/review-python.md` 指摘 4）: demographic pyramid（200 セル）と couple_gap（40 セル）を同じ L1 和で合算すると、セル数の多い統計が支配する。生の L1 では weight 調整が数日分の迷路になる。
+
+両方の指摘を同時に満たすには、1 つの目的関数で頑張るのではなく、**2 モードに分離**するのが素直である。
+
+## Decision
+
+目的関数を次の 2 モードで併記する。config の `objective.mode` で切り替える。
+
+### モード A: 原論文準拠モード（`mode: paper`）
+
+Murata 2017 の式(1) / 式(3) に忠実な実装。
+
+9 統計版（式(1)）:
+
+```text
+f(A) = Σ_s Σ_j | c_{sj}(A) - Round( r_{sj} · m_{sj}(A) ) |
+```
+
+21 統計版（式(3)）:
+
+```text
+f'(A) = Σ_s Σ_j | c_{sj}(A) - R_{sj} |
+```
+
+- `weight_s` は **使わない**
+- `Round(r_{sj} · m_{sj}(A))` は **動的ターゲット**（生成集団側の分母 `m_{sj}(A)` に依存）であり、target を静的定数として実装する誤実装を防ぐためにこの点を spec §11.4 で明記した
+- **§15.1 の実験 1（Murata 再現）は本モードのみで実施する**
+
+### モード B: 研究拡張モード（`mode: research_extended`）
+
+セル数正規化 + 統計間重みによる、実用チューニング向けの拡張。
+
+```text
+loss_s    = (1 / |cells_s|) * Σ_j | observed_rate[s, j] - target_rate[s, j] |
+objective = Σ_s weight_s * loss_s
+```
+
+- `observed_rate` は合成集団の count を人口総数で割った率
+- `weight_s` は §18 の `objective.weights` と対応し、**統計間の相対重要度** として解釈する
+- セル数正規化により demographic pyramid と couple_gap が同スケールで合算される
+- エントロピー正則化 `objective.entropy_regularization` オプションも本モードで有効（§11.6）
+
+### 評価レポートの扱い
+
+- `metrics.json` には `best_score_paper` と `best_score_research` を**両方**記録する
+- `report.md` も両方を併記し、Murata 再現性と実用チューニングの両面が読めるようにする
+
+## Consequences
+
+### 肯定的な結果
+
+- **Murata 再現性が担保される**: 式(1) / 式(3) を正しく実装できていることが実験 1 の結果で示される
+- **実用チューニングが可能**: 研究拡張モードで重みを振り、統計整合性・有用性・秘匿性の多目的バランスを取れる
+- **読者にとって透明**: どちらの主張をしているかが config の `mode` で明示される
+
+### 否定的な結果
+
+- **コード上は 2 実装が並走する**: `objective.py` が if/else で分岐するか、Protocol で差し替える形になる。`domain/protocols.py` の `Objective` Protocol で抽象化する予定
+- **テスト工数が増える**: 両モードで決定性テスト・property test を書く必要がある
+- **report.md に値が 2 つ出る**: レポート読者が「どちらを見ればよいか」迷う可能性があるため、`report.md` 冒頭にモードの位置付けを必ず書く
+
+### Superseded への備え
+
+- 将来、新しいモード（例: log-likelihood based）を追加する場合は ADR-0002 を Superseded とし、新 ADR を起こす
+- 既存の mode 名 `paper` / `research_extended` は v1.0 まで変更しない
+
+## References
+
+- レビュー指摘の逆参照:
+  - `docs/reviews/review-privacy.md` 指摘 1（原論文式との整合）
+  - `docs/reviews/review-python.md` 指摘 4（セル数正規化）
+  - `docs/reviews/review-python.md` 指摘 14（禁止ペナルティをハード制約に移す → 本 ADR とは別だが関連）
+- `docs/reviews/action-plan.md` §1.1、§2A 「§11.4」
+- `docs/spec/spec.md` §11.4、§15.1
+- 原論文: Murata, Harada, Masui (2017) 式(1), (3), §4
+- 関連 ADR: ADR-0001（内部表現、本モードの差分更新は ADR-0001 に従う）

--- a/docs/adr/0003-privacy-evaluation-layers.md
+++ b/docs/adr/0003-privacy-evaluation-layers.md
@@ -1,0 +1,91 @@
+# ADR-0003: 秘匿性評価は 3 層（proxy / CAP baseline / shadow-based MIA）
+
+- **Status**: Accepted
+- **Date**: 2026-04-23
+
+## Context
+
+`docs/spec/spec.md` 旧版 §13.3 は秘匿性評価として DCR / NNDR / ARD / レコード一致率 / 属性部分一致率 を初期実装に並べ、TAPAS / MIA / AIA を「拡張候補」に置いていた。この構成には 3 つの問題がある。
+
+1. **類似度ベース指標の既知バイアス**（`docs/reviews/review-privacy.md` 指摘 2）: Ganev & De Cristofaro (2024) "On the Inadequacy of Similarity-based Privacy Metrics" (arXiv:2312.03054) は、DCR / NNDR が MIA 成功率と単調関係にないことを実証している。DCR は **低頻度レコードを過剰保護**し、**頻出レコードの攻撃リスクを過小評価**する。スケール依存性（連続 vs 離散）もある。
+2. **属性推論ベースラインの欠落**（Priv 指摘 3）: 合成データ評価の事実上の標準である **Generalized CAP (Correct Attribution Probability)** / **TCAP** が spec に無い。DCR より CAP の方が「実個票と属性が一致する確率」を直接推定でき、頻出レコード攻撃にロバスト。
+3. **shadow model 前提の MIA を単体併置**（Priv 指摘 3）: TAPAS の MIA は shadow generator を前提とするが、spec は「shadow model なしで TAPAS を使う」と誤読できる記述だった。
+
+加えて、評価用の実個票の出所・倫理処理が旧版 spec には無かった（Priv 指摘 2 末尾、Priv S5/S6）。これは ADR-0003 のスコープ外だが、本 ADR と同時に `docs/assumptions.md` で取り扱う。
+
+## Decision
+
+秘匿性評価を性質の異なる **3 層** に分ける。`evaluate/privacy_metrics.py` の I/F もこの層に合わせる。
+
+### (a) 類似度 proxy（MVP、Phase 4）
+
+- **DCR** (Distance to Closest Record)
+- **NNDR** (Nearest Neighbor Distance Ratio)
+- **ARD** (Harada 2024 由来の平均レコード距離指標)
+- 距離は **Gower** を primary（連続は [0,1] 正規化、カテゴリはマッチ/非マッチ）
+- **本層は proxy に過ぎない旨を `report.md` に自動注記**し、単体で privacy claim を張らない
+
+### (b) 属性推論 baseline（**MVP 必須**、Phase 3.5 先行 → Phase 4 本実装）
+
+- **Generalized CAP** (Taub et al. 2018 ほか)
+- **TCAP** (Targeted CAP)
+- Per-family_type 分解も出力
+- **DCR/NNDR/ARD よりも先に実装する**（実装順序: rare_cell → CAP → DCR/NNDR/ARD → MIA）
+
+### (c) shadow-based MIA（Phase 5 stretch）
+
+- **TAPAS** (Houssiau et al. 2022)
+- **DOMIAS** (van Breugel et al. 2023)
+- **shadow generator を同一統計入力の異なる seed 群で再生成**する protocol を `docs/experiment_plan.md` に pre-register
+- 本層は stretch goal とし、欠けていても v0.2 は出荷できる
+
+### 将来の差分プライバシー (DP) 拡張への備え
+
+- `domain/protocols.py` に `Distribution` / `PrivacyMetric` Protocol を**空定義で先置き**する
+- `optimize/objective.py` は `target` を `Distribution` 型で受け取り、`.sample()` / `.mean()` を持つ抽象化に寄せる
+- これにより DP-ε 計算器を後付けしても spec が壊れない（Priv S7）
+
+### Rare cell 監視
+
+- `family_type × age` で cell size < 5 の割合、unique 率を `evaluate/rare_cell_metrics.py` で監視
+- §11.6 の soft constraint（rare cell 比率が閾値超過で trial を rejected とする）と連動
+
+## Consequences
+
+### 肯定的な結果
+
+- **研究としての正当性**: proxy / baseline / MIA の 3 層結果を併記することで、単一指標に依存しない主張が可能
+- **実装順序が合理的**: CAP を先に実装することで、Phase 3b の実験 1/2 段階でも属性推論リスクを測れる
+- **文献整合**: Ganev & De Cristofaro (2024) の指摘に spec 上で応答している
+- **将来拡張の余地**: DP・TAPAS/DOMIAS を後付けできる
+
+### 否定的な結果
+
+- **実装コストが増える**: CAP は Phase 3.5 で先出ししつつ、shadow seed 運用も Phase 5 で設計する必要がある
+- **評価用実個票が必要**: 3 層すべてが「real individual-level records」を前提とするため、`docs/assumptions.md` の semi-synthetic protocol（ACS PUMS / IPUMS 等）が成立しないと評価できない
+- **report 読者の負担増**: 3 層の値を読むガイドを `docs/spec/metrics.md` と `report.md` 冒頭に必ず置く
+
+### 評価実行のゲート
+
+- Phase 3.5 の Exit 条件: `synthpop-jp evaluate` が rare cell + CAP を出力できること
+- Phase 4 の Exit 条件: proxy 層と CAP が両方出ること
+- Phase 5 は stretch、出なくても v1.0 は出せる
+
+## References
+
+- レビュー指摘の逆参照:
+  - `docs/reviews/review-privacy.md` 指摘 2（類似度 proxy の既知バイアス）
+  - `docs/reviews/review-privacy.md` 指摘 3（CAP 欠落、shadow 前提の誤解）
+  - `docs/reviews/review-privacy.md` 指摘 4（rare cell と秘匿性の緊張）
+  - `docs/reviews/review-privacy.md` S7（DP 拡張への備え）
+- `docs/reviews/action-plan.md` §2A「§13.3 の 3 層再構成」
+- `docs/spec/spec.md` §13.3、§11.6
+- 参考文献:
+  - Ganev & De Cristofaro (2024) "On the Inadequacy of Similarity-based Privacy Metrics" arXiv:2312.03054
+  - Houssiau et al. (2022) "TAPAS"
+  - van Breugel et al. (2023) "DOMIAS" ICML
+  - Taub et al. (2018) "Differential Correct Attribution Probability"
+  - Platzer & Reutterer (2021) "Holdout-Based Empirical Assessment" Front. Big Data
+  - Stadler et al. (2022) "Synthetic Data – Anonymisation Groundhog Day" USENIX Security
+  - Harada et al. (2024) `docs/papers/harada_2024.pdf`
+- 関連 ADR: ADR-0001（内部表現）、ADR-0002（目的関数）

--- a/docs/adr/0004-naming-and-license.md
+++ b/docs/adr/0004-naming-and-license.md
@@ -1,0 +1,86 @@
+# ADR-0004: 命名 `synthpop-jp` とライセンス Apache-2.0
+
+- **Status**: Accepted（ユーザー承認: 2026-04-23）
+- **Date**: 2026-04-23
+
+## Context
+
+旧版では命名が三重にズレていた（`docs/reviews/review-oss.md` 指摘 1）。
+
+- リポジトリ名: `synth-pop-harada-2024`
+- `docs/spec/spec.md` 旧版 §9 のパッケージ名: `synthetic_population`
+- CLI エントリ: `python -m synthetic_population.cli ...`（30 文字超、Quickstart に不向き）
+- PyPI 公開時の名前: 未定義
+
+このズレを放置すると:
+
+- PyPI の一般語（`synthetic_population`）は類似 OSS（`synthpop` R パッケージ、`SDV`、`pop-synth`、`SynPop` 等）に埋もれ Googleable でない
+- リポジトリ名の "harada-2024" は Harada 2024 論文を想起させるが、旧 spec 本文は Murata 2017 中心で Harada への言及ゼロ → 読者が「どちらの論文の実装か」判断できない
+- 引用時に `synthetic_population` だけでは DOI や論文参照に耐えない
+
+ライセンス面では、旧 §20 に LICENSE が無く、依存ライブラリ（pandas / scipy / scikit-learn 等）のライセンス整合も未記載だった（OSS 指摘 2）。e-Stat 再配布規約への対応も書かれていなかった。
+
+## Decision
+
+### 命名（ユーザー承認済み 2026-04-23、動かさない）
+
+- **PyPI パッケージ名**: `synthpop-jp`
+- **import 名**: `synthpop_jp`（PEP 8 準拠、ハイフン不可のため）
+- **CLI エントリポイント**: `synthpop-jp`（`[project.scripts]` に登録、`uvx synthpop-jp ...` で起動可）
+- **リポジトリ名**: `synth-pop-harada-2024`（現状維持、研究期間中の実験リポ名として許容）
+- **spec §9 のディレクトリ**: `src/synthpop_jp/...`
+- **README 冒頭に必須の一文**: "A Python re-implementation of Murata et al. (2017) synthetic population generator, with usability/privacy evaluation following Harada et al. (2024)"
+
+### ライセンス（ユーザー承認済み 2026-04-23）
+
+- **Apache-2.0** を採用
+  - 研究ユーザー向けに**特許条項による保護**が重要
+  - 依存ライブラリ（pandas BSD-3、numpy BSD、scipy BSD、pydantic MIT、typer MIT、scikit-learn BSD）と互換
+  - GPL 系には依存しない（CI で license 互換チェック）
+- `LICENSE`（Apache-2.0 全文）と `NOTICE`（依存クレジット）をリポジトリルートに配置
+
+### データ取扱い方針
+
+- **`data/sample_case/` は完全合成ダミー**（`scripts/generate_sample_case.py` で seed 固定生成）
+- e-Stat 実データは**同梱しない**。取得スクリプト `scripts/fetch_estat.py` のみを同梱し、ユーザー環境でダウンロードさせる
+- 出典表記は `io/writers.py` が `report.md` に自動埋込（統計法 §44・e-Stat 利用規約対応）
+- 詳細は `DATASET.md` で管理
+
+### 引用 (Citation)
+
+- `CITATION.cff` に preferred-citation として **Murata 2017 と Harada 2024 を両方**記載
+- v0.1 公開時に **Zenodo 連携**で DOI を発行、v1.0 で論文 DOI と並記
+
+## Consequences
+
+### 肯定的な結果
+
+- **検索性**: `synthpop-jp` は PyPI 上で未使用（事前確認済）、"jp" suffix で日本の国勢調査特化を明示
+- **Quickstart UX**: `uvx synthpop-jp quickstart` で 30 秒 end-to-end
+- **引用耐性**: DOI + preferred-citation で研究利用者が正しく cite できる
+- **ライセンス互換**: Apache-2.0 により企業研究者も特許条項で保護される
+- **e-Stat 規約遵守**: 実データ非同梱 + 自動出典埋込で統計法 §44 の出典表示義務を満たす
+
+### 否定的な結果
+
+- **ユーザー混乱リスク**: リポジトリ名 `synth-pop-harada-2024` とパッケージ名 `synthpop-jp` が異なる
+  - 緩和策: README 冒頭とドキュメントサイトで**必ずこの関係を明示**する
+- **改名コスト**: 現時点では旧名 `synthetic_population` を使ったコードが無いため低コスト。Phase 1 着手前に確定したため手戻りなし
+- **Apache-2.0 の形式要件**: ファイルヘッダ推奨（強制ではない）、`NOTICE` の維持義務
+
+### SemVer と破壊的変更ポリシー
+
+- v0.x の間は破壊的変更を許容する旨を `CHANGELOG.md` に明示
+- 命名（`synthpop-jp` / `synthpop_jp` / `synthpop-jp` CLI）と LICENSE は v1.0 以降も変更しない（本 ADR を Superseded にしない限り）
+
+## References
+
+- レビュー指摘の逆参照:
+  - `docs/reviews/review-oss.md` 指摘 1（命名ズレ）
+  - `docs/reviews/review-oss.md` 指摘 2（LICENSE / e-Stat）
+  - `docs/reviews/review-oss.md` 指摘 3（Harada 2024 の位置付け）
+- `docs/reviews/action-plan.md` §1.3「命名の確定」、§2A「§6」
+- ユーザー承認: 2026-04-23（本 worktree への作業依頼時）
+- `docs/spec/spec.md` §6、§9、§17、§20
+- `docs/assumptions.md`（e-Stat 利用規約の取扱い）
+- 関連 ADR: なし（本 ADR と独立）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records (ADR)
+
+本ディレクトリは `synthpop-jp` の **構造的な設計決定** を記録する。一度決めたら蒸し返されがちな論点を、後から根拠付きで参照できるように凍結する。
+
+## 書式
+
+各 ADR は Michael Nygard 形式（Status / Context / Decision / Consequences）に従い、以下のセクションを持つ。
+
+1. **タイトル**: `NNNN-kebab-case-title`（例: `0001-internal-representation.md`）
+2. **Status**: `Proposed` | `Accepted` | `Superseded by NNNN` | `Deprecated`
+3. **Date**: `YYYY-MM-DD`
+4. **Context**: この決定が必要になった背景。レビュー指摘や性能要件など。
+5. **Decision**: 何を決めたか。具体的な選択肢と、選ばれた選択肢。
+6. **Consequences**: 何が楽になり、何が苦しくなるか。
+7. **References**: 出典（レビュー指摘の逆参照、論文、Issue、PR 等）。
+
+## 番号付け規約
+
+- ゼロ埋め 4 桁の連番（`0001`, `0002`, ...）
+- 欠番は作らない
+- ファイル名は `NNNN-kebab-case-title.md`
+
+## Superseded 運用
+
+- 既存 ADR を上書きしない
+- 代わりに新しい ADR（`NNNN+k`）を作り、古い ADR の **Status を `Superseded by NNNN+k` に更新**する
+- 新 ADR の **References に旧 ADR を明記**する
+- これにより「いつ・なぜ方針が変わったか」を時系列で追える
+
+## 現在の ADR 一覧
+
+| No. | Title | Status | Date |
+|---|---|---|---|
+| 0001 | [Internal Representation (NumPy parallel arrays + diff update)](0001-internal-representation.md) | Accepted | 2026-04-23 |
+| 0002 | [Objective Function Normalization (two modes)](0002-objective-normalization.md) | Accepted | 2026-04-23 |
+| 0003 | [Privacy Evaluation Layers (proxy / CAP / MIA)](0003-privacy-evaluation-layers.md) | Accepted | 2026-04-23 |
+| 0004 | [Naming and License (synthpop-jp / Apache-2.0)](0004-naming-and-license.md) | Accepted | 2026-04-23 |
+
+## 新しい ADR を書くとき
+
+1. 本 README に行を追加
+2. `docs/adr/NNNN-title.md` を作成（既存 ADR をテンプレにする）
+3. Status は作成時は `Proposed`、レビュー完了後 `Accepted`
+4. コード/仕様上で関連する位置から `ADR-NNNN` で逆参照する

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -1,0 +1,107 @@
+# Assumptions（評価用実個票・倫理・利用規約）
+
+**ステータス: 骨子（Phase 1 着手前に基本方針確定、Phase 3.5 で評価実行前に完全確定）**
+
+本ドキュメントは `synthpop-jp` が **秘匿性評価（§13.3）で必要となる評価用実個票の protocol と倫理要件** を記述する。`docs/spec/spec.md` §13.3 および §6 から本書に委譲されている。
+
+## 背景
+
+DCR / NNDR / ARD / CAP / MIA のどれも「評価用の実個票 (individual-level records)」を前提とする。ところが Murata 2017 はそもそも「サンプル個票を使わず公開集計表のみから生成する」手法である。つまり本実装は、**生成入力**としては公開集計表のみを使うが、**評価入力**としては別途実個票が必要になる、という非対称性がある。
+
+本書はこの非対称性を「何のデータを、どこから、どの手続きで得るか」で閉じる。
+
+## 1. 評価用 "real" 個票 protocol（semi-synthetic 設定）
+
+合成データ研究で標準的な **semi-synthetic 設定** を採用する:
+
+1. 実個票データセット（例: ACS PUMS / IPUMS / e-Stat 公開ミクロデータ）から集計表を計算
+2. 計算した集計表を `synthpop-jp` の入力として合成集団を生成
+3. **元の実個票を hold-out として** DCR / CAP / MIA の評価に使う
+
+これにより「生成器は実個票を一切見ていない」状態で評価が成立する。
+
+**Phase 3.5 で hold-out 分割手順と cell size 制限を確定。**
+
+## 2. 利用候補データセット
+
+### 2.1 ACS PUMS（米国 American Community Survey Public Use Microdata Sample）
+
+- 長所: 公開ミクロデータとして最も整備、研究利用前例多数
+- 短所: 米国データであり日本の家族類型と完全一致しない
+- ライセンス: Public Domain（USCB）
+- 取得スクリプト: `scripts/fetch_acs_pums.py`（Phase 3.5 で作成）
+
+### 2.2 IPUMS (International Public Use Microdata Series)
+
+- 長所: 多国横断、日本分も一部あり
+- 短所: 利用登録とデータ利用同意書が必要
+- ライセンス: IPUMS Terms of Use
+- 取得: 各研究者が個別申請
+
+### 2.3 e-Stat 公開ミクロデータ / オーダーメード集計
+
+- 長所: 日本の国勢調査と完全整合
+- 短所: **個票の取得は厳格に制限**され、通常の研究用途では「オーダーメード集計」または「匿名データ」を利用する形になる
+- ライセンス: 統計法 §33、§44、e-Stat 利用規約
+- **本実装の評価用途としては原則使わない**（代わりに公開集計表から semi-synthetic 設定を組む）
+
+**Phase 3.5 で最終選定。**
+
+## 3. Hold-out 手順と cell size 制限
+
+- 実個票から集計表を作成する際の **cell size ≥ 5** ルール（k-anonymity 下限）
+- hold-out は random split ではなく **stratified**（family_type × sex × age_group 層別）
+- hold-out 比率: 既定 20%
+
+**Phase 3.5 で確定。**
+
+## 4. IRB / data use agreement 要件
+
+- ACS PUMS は原則 IRB 不要（公開データ）
+- IPUMS は data use agreement 署名が必要
+- 所属機関の IRB 必要性は **研究開始前に確認**
+- 本書に「どのデータセット・どの版・誰が取得・取得日・IRB の有無」を記録
+
+**テンプレートは §6 に記載。Phase 3.5 で使用時に記入。**
+
+## 5. 統計法 §44・e-Stat 利用規約（出典表記義務）
+
+e-Stat 由来の集計表を入力に使った場合は次の義務が発生する:
+
+- **出典表示義務**（統計法 §44）
+- **加工の明示**（e-Stat 利用規約）
+- **商用再配布制限**（データによる、要個別確認）
+
+本実装の対応:
+
+- `io/writers.py` の `report.md` ジェネレータに **出典セクションを自動埋込**
+- `DATASET.md` に e-Stat データ取得スクリプト (`scripts/fetch_estat.py`) と出典テンプレを同梱
+- **`data/sample_case/` は完全合成ダミー** とし、e-Stat 実データは同梱しない（ADR-0004）
+
+## 6. 倫理記録テンプレート
+
+実験で特定の実個票データセットを使う際は、以下のメタデータを `docs/experiments/<date>-<slug>/metadata.yaml` に記録する:
+
+```yaml
+dataset:
+  name: "ACS PUMS 2022"
+  version: "2022 1-year"
+  source_url: "https://www.census.gov/programs-surveys/acs/microdata/documentation.html"
+acquisition:
+  acquired_by: "researcher_name"
+  acquired_at: "2026-04-23"
+  license: "Public Domain (USCB)"
+  irb_status: "not_required"
+  dua_signed: false
+hold_out:
+  split_method: "stratified"
+  split_ratio: 0.20
+  stratify_columns: ["family_type", "sex", "age_group"]
+  cell_size_floor: 5
+```
+
+**Phase 3.5 で実験記録時に使用。**
+
+## 7. 履歴
+
+- 2026-04-23: v0.0.1 骨子作成（Phase 0）

--- a/docs/experiment_plan.md
+++ b/docs/experiment_plan.md
@@ -1,0 +1,122 @@
+# Experiment Plan（実験事前登録）
+
+**ステータス: 骨子（Phase 3 着手前に完成させ、git tag でフリーズ）**
+
+本ドキュメントは `synthpop-jp` の §15 実験群の **事前登録（pre-registration）** 文書である。仮説・指標・統計検定・サンプルサイズ・停止条件を実験開始前に確定し、事後の指標選択バイアスを避けるために用いる。
+
+## 目的
+
+`docs/spec/spec.md` §15 の実験 1〜4 を、着手前に「何を測るか」で凍結する。実験走行後に指標を追加・差し替えしたくなった場合は、本書を更新せず **ADR を追加** して追記管理する（Superseded フィールドで旧版を明示）。
+
+## 凍結手順
+
+1. Phase 3 着手前に本書を最終化する
+2. `git tag experiment-plan-v1` を打つ
+3. `metrics.json` に本 tag の SHA を記録する
+4. 以降の変更は ADR + 新タグ (`experiment-plan-v2`) として管理
+
+## 実験 1（§15.1）: Murata 再現の最小比較
+
+### 仮説
+
+- H1a: `age-change` は `evals_per_agent` が小さい領域（例: 1000）で有利
+- H1b: `age-swap` は `evals_per_agent` が大きい領域（例: 16000）で有利
+- 原論文モード（§11.4.1）のみで実施
+
+### 指標
+
+- 主指標: 原論文式(1) の総 `f(A)`
+- 副指標: 21 統計別 L1 誤差（Table 13 形式）、計算時間
+
+### 統計検定
+
+- Wilcoxon signed-rank test（seed 対応あり）
+- Effect size: Cliff's δ
+
+### サンプルサイズ
+
+- seed n=10〜30（最終値は Phase 3 着手前に確定）
+- `evals_per_agent ∈ {1000, 2000, 4000, 8000, 16000}`
+
+### 停止条件
+
+- `best_score <= target_threshold` または `max_iters` 到達
+
+**Phase 3 着手前に埋める。**
+
+## 実験 2（§15.2）: hybrid 戦略
+
+### 仮説
+
+- H2: 初期 `age-change` 優勢 → 後半 `age-swap` 優勢の hybrid が、単独 age-change / age-swap より総合スコアで優れる
+
+### 指標
+
+- 主指標: 原論文式(1) の総 `f(A)` と 21 統計別 L1 の両方
+- 副指標: `p_change` / `p_swap` のスケジュール依存性
+
+### 統計検定
+
+- Welch's t test + Holm 補正
+
+### サンプルサイズ
+
+- seed n=10〜30
+
+**Phase 3 着手前に埋める。**
+
+## 実験 3（§15.3）: 改善戦略比較（rule_based vs pareto vs random_search）
+
+### 仮説
+
+- H3: pareto 戦略は rule_based に対し 3 目的（統計整合性・有用性・秘匿性）の total ranking で優れる
+- 副仮説 H3a: random_search は両者のベースライン下限として機能する
+
+### 指標
+
+- 主指標: Pareto フロント上の non-dominated solution 数
+- 副指標: 3 目的それぞれの best 値、ハイパーボリューム
+
+### 統計検定
+
+- Welch's t test + Holm 補正
+
+**Phase 3 着手前に埋める。**
+
+## 実験 4（§15.4）: 複数候補のばらつき
+
+### 仮説
+
+- H4: 同一 config で生成した複数候補の評価指標ばらつきは、seed n 増加で安定化する（SD 低下）
+
+### 指標
+
+- 主指標: 各評価指標の seed 間 SD
+- 副指標: best の安定性
+
+### 統計検定
+
+- 変動係数の bootstrap CI 比較
+
+**Phase 3 着手前に埋める。**
+
+## shadow seed 群の運用
+
+Phase 5 の shadow-based MIA 評価のため:
+
+- shadow generator は同一公開統計入力に対し異なる seed 群（既定 n=20）で再生成
+- shadow seed は main seed と独立な `SeedSequence.spawn` 枝から取得
+- TAPAS / DOMIAS はこの shadow group を使う
+
+**Phase 5 着手前に詳細確定。**
+
+## Pre-registration 凍結手順
+
+1. 本書の全セクションを埋める
+2. 共著者レビュー後、`git tag experiment-plan-v1` を打つ
+3. tag の SHA を `metrics.json` にも記録
+4. 以降の変更は ADR + 新タグ
+
+## 履歴
+
+- 2026-04-23: v0.0.1 骨子作成（Phase 0）

--- a/docs/spec/data_contract.md
+++ b/docs/spec/data_contract.md
@@ -1,0 +1,79 @@
+# Data Contract（入力 CSV のスキーマ契約）
+
+**ステータス: 骨子（Phase 1 で肉付け）**
+
+本ドキュメントは `synthpop-jp` が受け取る全 CSV ファイルのスキーマ契約を一元化する。`docs/spec/spec.md` §7 から本書に委譲されている。
+
+## 1. 対象範囲と責務
+
+**何をここで決めるか**: 入力 CSV の列名・型・単位・欠損規則・値域・相互整合制約、pydantic v2 バリデーションのエラー規約、SemVer による契約バージョン管理。
+
+**ここで決めないこと**: 評価指標の距離定義（`docs/spec/metrics.md`）、実験 protocol（`docs/experiment_plan.md`）、データ出所・倫理（`docs/assumptions.md`）。
+
+本書が「契約」として固まることで、ローダ実装（`io/loaders.py`）とダミー生成器（`scripts/generate_sample_case.py`）と e-Stat adapter（`data/templates/estat/`）が分岐しなくなる。
+
+## 2. ファイル別スキーマ
+
+Phase 1 で `spec.md` §7.1 の全 CSV を列・型・単位・欠損規則で再記述する。各ファイルについて次のテーブルを埋める。
+
+- ファイル名
+- 必須/任意
+- 列名 / dtype / 単位 / 値域 / null 可否 / 説明
+- pydantic v2 モデル名（`FamilyTypeCountRow` など）
+- サンプル（5 行）
+
+対象ファイル:
+
+- `family_type_counts.csv`
+- `children_count_dist.csv`
+- `demographic_by_age_sex.csv`
+- `age_diff_parent_child.csv`
+- `age_diff_couple.csv`
+- `demographic_by_family_type_role.csv`（任意）
+- `household_size_by_family_type.csv`（任意）
+
+**Phase 1 で埋める。**
+
+## 3. 半開区間文字列と diff_min/diff_max の規約
+
+- `diff_bin` は **半開区間の文字列** `"[-5,-3)"` 形式で表現する（左閉右開）
+- もしくは `diff_min:int, diff_max:int` の 2 列表現（左閉右開で `diff_min <= x < diff_max`）
+- 前者を採用した場合は `pandas.Interval` にパースする
+- ローダは両形式を受け付けて内部では後者に正規化する
+
+**Phase 1 で最終方針確定。**
+
+## 4. `couple_diff` の符号規則
+
+- **`couple_diff = husband_age - wife_age`** に統一する
+- 夫が年上なら正、妻が年上なら負
+- 入力 CSV 側が逆符号の場合はローダで反転して正規化する
+- `DATASET.md` に出典別の符号慣習を記録する
+
+## 5. `family_type` ↔ `family_type_group` マッピング
+
+- 9 種類の `family_type`（`spec.md` §8.1）から粗い `family_type_group`（例: `with_children` / `without_children` 等）へのマッピング
+- yaml で配布: `data/mappings/family_type_group.yaml`
+- `registry.register_family_type(name, template)` で外部拡張に開く
+
+**Phase 1 で yaml の初版を配布。**
+
+## 6. pydantic v2 `TypeAdapter` エラー規約
+
+- ローダは `TypeAdapter(list[FamilyTypeCountRow])` で行単位バリデーション
+- 失敗時は `rich.console.Console` で **行番号付きエラー** を整形出力
+- `errors()` の loc は `(row_index, field_name)` で返す
+- CLI の `synthpop-jp validate-config` は同じフォーマッタを使う
+
+**Phase 1 で実装、Phase 0 では規約のみ。**
+
+## 7. 変更履歴（SemVer）
+
+- 本契約は SemVer で版管理する
+- 破壊的変更（列名変更・必須列追加など）は **MAJOR**、新しい任意列の追加は **MINOR**、説明やエラーメッセージの改善は **PATCH**
+- 変更は本書末尾の「履歴」セクションに日付付きで追記
+- v0.x の間は破壊的変更を許容する旨を `CHANGELOG.md` と整合させる
+
+## 8. 履歴
+
+- 2026-04-23: v0.0.1 骨子作成（Phase 0）

--- a/docs/spec/experiment_report_format.md
+++ b/docs/spec/experiment_report_format.md
@@ -1,0 +1,111 @@
+# Experiment Report Format（比較レポートと metrics.json の仕様）
+
+**ステータス: 骨子（Phase 3b で肉付け）**
+
+本ドキュメントは `synthpop-jp compare` サブコマンドの入出力仕様、および全 run が共通で出力する `metrics.json` スキーマを固定する。`docs/spec/spec.md` §13〜§15 から本書に委譲されている。
+
+## 1. `synthpop-jp compare` の入力 config 形式
+
+`configs/compare_*.yaml` の形式を Phase 3b で確定する。想定する要素:
+
+- `base_config`: 基準となる `configs/base.yaml`
+- `variants`: 比較対象の上書きリスト（例: `transition: age_change` と `transition: age_swap`）
+- `seeds`: seed 群（n=10〜30）
+- `bootstrap_iterations`: 既定 2,000
+- `significance_test`: `welch_t` | `wilcoxon_signed_rank`
+- `multiple_comparison_correction`: `holm` | `none`
+
+**Phase 3b で確定。**
+
+## 2. Seed 群実行ポリシー
+
+- 各条件で seed n=10〜30 の多試行
+- seed は `SeedSequence.spawn(n)` で根 seed から決定論的に生成（`spec.md` §18.1）
+- 並列実行は `pytest-xdist` ではなく `joblib` / `concurrent.futures` を使う
+- 並列でも bitwise 再現を保つ（各 trial は独立 seed）
+
+**Phase 3b で実装。**
+
+## 3. Bootstrap CI 算出規約
+
+- 方法: **percentile bootstrap**
+- 反復回数: 既定 2,000
+- 信頼水準: 95%（両側）
+- `numpy.random.Generator.choice` を resample に使う（scipy ではなく）
+- CI が生の値とともに `metrics.json` に記録される
+
+## 4. 有意差判定
+
+- **独立群の主比較**: Welch's t test + Holm 補正
+- **対応群の比較**（同 seed で条件違い）: Wilcoxon signed-rank test
+- **Effect size**: Cliff's δ を必ず併記
+- 多重比較は Holm（Bonferroni より検出力が高い）
+
+## 5. 出力 `report.md` の固定セクション構造
+
+Phase 3b で次の順で生成する:
+
+1. Run メタデータ（git_sha、uv.lock hash、numpy_version、実行時刻）
+2. 入力 config の抜粋
+3. 統計整合性（21 統計ブレークダウン、Table 13 形式）
+4. Broad utility
+5. Narrow utility（TSTR / TRTS）
+6. Privacy 3 層（proxy / CAP / MIA）
+7. Rare cell 監視
+8. 検定結果（Welch's t / Wilcoxon / Holm 補正後 p 値 / Cliff's δ）
+9. **出典とライセンス注記**（`writers.py` が自動埋込、e-Stat 利用時は統計法 §44 出典表示）
+10. 再現手順（`uvx synthpop-jp compare --experiment ...`）
+
+**Phase 3b で `writers.py` に実装。**
+
+## 6. `metrics.json` スキーマ
+
+最小フィールド:
+
+```json
+{
+  "run_id": "string",
+  "git_sha": "string",
+  "uv_lock_hash": "string",
+  "numpy_version": "string",
+  "python_version": "string",
+  "seed": 42,
+  "timestamp_utc": "2026-04-23T12:00:00Z",
+  "config": { "...": "config.yaml の全内容を埋め込み" },
+  "objective": {
+    "mode": "paper | research_extended",
+    "best_score_paper": 123.4,
+    "best_score_research": 45.6
+  },
+  "aggregate_metrics": {
+    "per_statistic_l1": { "father_child_gap": 0.12, "...": "21 統計ブレークダウン" },
+    "pyramid_1yr_tv": 0.03,
+    "pyramid_5yr_tv": 0.02
+  },
+  "broad_utility": {
+    "univariate_l1": 0.01,
+    "correlation_frobenius_diff": 0.05
+  },
+  "narrow_utility": {
+    "task_a_tstr_macro_f1": 0.85,
+    "task_a_trts_macro_f1": 0.83,
+    "task_b_tstr_rmse": 1.2,
+    "task_c_tstr_macro_f1": 0.78
+  },
+  "privacy": {
+    "proxy": { "dcr_p05": 0.08, "nndr_p05": 0.45, "ard": 0.12 },
+    "cap": { "generalized": 0.31, "tcap": 0.28 },
+    "mia": { "tapas_auc": null, "domias_auc": null }
+  },
+  "rare_cell": {
+    "ratio_cell_lt_5": 0.04,
+    "unique_ratio": 0.01
+  }
+}
+```
+
+**JSON Schema を `schemas/metrics.schema.json` として Phase 3b でコミット。**
+
+## 7. 履歴
+
+- 2026-04-23: v0.0.1 骨子作成（Phase 0）

--- a/docs/spec/metrics.md
+++ b/docs/spec/metrics.md
@@ -1,0 +1,115 @@
+# Metrics（距離・評価指標の仕様）
+
+**ステータス: 骨子（Phase 3〜4 で肉付け）**
+
+本ドキュメントは `synthpop-jp` が報告する全評価指標の距離定義・算出式・アルゴリズムを一元化する。`docs/spec/spec.md` §13 から本書に委譲されている。
+
+## 1. 距離の基本方針
+
+- **Gower 距離を primary** にする（混合型データの標準的手法）
+- 連続変数（age 等）は [0, 1] に正規化してから距離を取る
+- カテゴリ変数（sex, role, family_type 等）はマッチ / 非マッチで 0 / 1
+- Euclidean は使わない（カテゴリ変数混在で不適切）
+- `domain/distance.py` に `gower(x, y, col_types)` を実装し、unit test を置く
+
+**Phase 4 冒頭で実装。**
+
+## 2. 統計整合性指標
+
+- **L1 (= 原論文式(1) の絶対誤差) を primary**
+- L2 / χ² を secondary
+- TV を参考指標とする
+- 人口ピラミッドは **1 歳刻みと 5 歳刻みの両方**を報告（原論文が両方使うため）
+- 21 統計の Table 13 形式ブレークダウンを `aggregate_metrics.py` で出力
+
+**Phase 3.5 で実装開始、Phase 3b で完成。**
+
+## 3. Broad utility 指標
+
+- 単変量分布差: L1 / TV
+- クロス集計差: 全属性ペア TV、Frobenius norm と max-abs の両方
+- **混合型相関行列** は `dython.associations` 準拠
+  - 連続 × 連続: Pearson
+  - カテゴリ × カテゴリ: Cramér's V
+  - 連続 × カテゴリ: Correlation Ratio
+  - 非対称関連（方向あり）: Theil's U
+- 相関差は Frobenius norm / max-abs の両方を出す
+
+**Phase 4a で実装。**
+
+## 4. Narrow utility 指標
+
+**固定 3 タスク**（Phase 0 で凍結、事後変更禁止）:
+
+- タスク A: family_type 分類（age, sex, 世帯内 role 分布 → family_type、**macro-F1**）
+- タスク B: 世帯人数回帰（family_type, 子ども人数 → household_size、**RMSE**）
+- タスク C: 役割予測（age, sex, family_type → role、**macro-F1**）
+
+評価:
+
+- **TSTR**（Train Synthetic, Test Real）
+- **TRTS**（Train Real, Test Synthetic）
+- 両方を seed 群 n=10〜30 で平均 ± SD + bootstrap CI
+
+データ分割・学習アルゴリズム・ハイパラは `docs/experiment_plan.md` に事前登録して凍結する。
+
+**Phase 4a で実装。**
+
+## 5. Privacy 指標 3 層
+
+### 5.1 (a) 類似度 proxy（MVP、Phase 4）
+
+距離定義:
+
+- **Gower 距離**（§1）を使う
+- 評価用 real 個票と生成合成集団の間で計算する
+
+指標:
+
+- **DCR** (Distance to Closest Record): 各 real レコードから最も近い合成レコードまでの Gower 距離。分布（min / 5 percentile / median）を報告
+- **NNDR** (Nearest Neighbor Distance Ratio): 最近傍距離 / 次近傍距離の比
+- **ARD** (Average Record Distance): Harada 2024 由来の平均レコード距離指標（Phase 4 で厳密定義を確定）
+
+**本層は proxy に過ぎない旨を `report.md` に明記**（Ganev & De Cristofaro 2024）。
+
+### 5.2 (b) 属性推論 baseline（MVP 必須、Phase 4 / Phase 3.5 先行）
+
+- **Generalized CAP** (Correct Attribution Probability、Taub et al. 2018)
+  - quasi-identifier `Q` と sensitive attribute `S` を定める
+  - 合成集団から推定される `P(S | Q=q)` と、real 個票の `S` の一致確率を評価
+- **TCAP** (Targeted CAP)
+- Per-family_type CAP 分解も出力
+
+アルゴリズムの詳細は Phase 3.5 で確定。
+
+### 5.3 (c) shadow-based MIA（Phase 5 stretch）
+
+- **TAPAS** (Houssiau et al. 2022): shadow generator を異なる seed で再生成して MIA 成功率を推定
+- **DOMIAS** (van Breugel et al. 2023)
+- shadow seed 群の運用は `docs/experiment_plan.md` に事前登録
+
+**Phase 5 で実装。**
+
+## 6. Rare cell 監視
+
+- `family_type × age` で cell size < 5 の **割合**
+- **unique 率**（1 人しかいない cell の割合）
+- 属性別分解（per family_type）
+- `evaluate/rare_cell_metrics.py` に実装
+
+**Phase 3.5 で実装。**
+
+## 7. 出典・参考文献
+
+- Gower (1971) "A general coefficient of similarity and some of its properties"
+- Ganev & De Cristofaro (2024) "On the Inadequacy of Similarity-based Privacy Metrics" arXiv:2312.03054
+- Houssiau et al. (2022) "TAPAS"
+- van Breugel et al. (2023) "DOMIAS" ICML
+- Taub et al. (2018) "Differential Correct Attribution Probability"
+- Harada et al. (2024)（`docs/papers/harada_2024.pdf`）
+
+**Phase 4 で完全な参考文献リスト化。**
+
+## 8. 履歴
+
+- 2026-04-23: v0.0.1 骨子作成（Phase 0）

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,12 +1,16 @@
 # Spec: Murata 2017 と「生成・評価・改善」型の合成人口データ実装
 
+本ドキュメントは `synthpop-jp` プロジェクトの中核仕様書である。実装詳細の一部は `docs/spec/data_contract.md` / `docs/spec/metrics.md` / `docs/spec/experiment_report_format.md` / `docs/experiment_plan.md` / `docs/assumptions.md` / `docs/adr/` に委譲する。
+
 ## 1. 背景
 
-本実装の目的は、公開統計から世帯・個人レベルの合成人口データを生成する Murata et al. (2017) の simulated annealing (SA) ベース手法を、Python で再現可能な形で実装し、その上に「生成→評価→改善」の反復ループを載せることで、実験可能な研究用プロトタイプを構築することである。
+本実装の目的は、公開統計（集計表）から世帯・個人レベルの合成人口データを生成する Murata et al. (2017) の simulated annealing (SA) ベース手法を、Python で再現可能な形で実装し、その上に「生成 → 評価 → 改善」の反復ループを載せることで、実験可能な研究用プロトタイプを構築することである。
 
-Murata 2017 は、サンプル個票を使わず、公開統計に整合する世帯構成・個人属性を SA で探索的に再構成する手法である。候補解遷移として `age-change` と `age-swap` を比較し、探索回数が少ないときは age-change が有利、十分な探索回数があるときは age-swap が有利であることを報告している。目的関数は統計表との差の総和であり、初期集団生成・候補解遷移・追加統計による評価の3点が改良点として示されている。
+Murata 2017 はサンプル個票を使わず、公開統計に整合する世帯構成・個人属性を SA で探索的に再構成する手法である。候補解遷移として `age-change` と `age-swap` を比較し、探索回数が少ないときは age-change が有利、十分な探索回数があるときは age-swap が有利であることを報告している。目的関数は統計表との差の総和であり、初期集団生成・候補解遷移・追加統計による評価の 3 点が改良点として示されている。
 
-一方、合成人口は公開集計表から数値計算を繰り返して差を最小化する探索的生成が有力であり、単発生成ではなく、複数データセットを生成・評価しながら利用する前提が適している。本 Spec では、Murata 2017 の再現をコア実装とし、その外側に「生成・評価・改善」ループを設ける。
+Harada et al. (2024)（仮想都市データに関する研究、`docs/papers/harada_2024.pdf`）は、合成人口データの**有用性と秘匿性をどのように評価するか**の基準を与える。とくに ARD（Average Record Distance 系の距離指標）のような評価軸は、本実装の `evaluate/privacy_metrics.py` の設計指針として取り込む。本実装は「生成手法は Murata 2017、評価軸は Harada 2024」を両輪として位置付ける。
+
+合成人口は公開集計表から数値計算を繰り返して差を最小化する探索的生成が有力であり、単発生成ではなく、複数データセットを生成・評価しながら利用する前提が適している。本 Spec では、Murata 2017 の再現をコア実装とし、その外側に「生成・評価・改善」ループを設ける。
 
 ## 2. 目的
 
@@ -21,7 +25,7 @@ Murata 2017 は、サンプル個票を使わず、公開統計に整合する�
 ### 2.2 副目的
 
 * 都道府県統計や仮想都市データに差し替えやすい構成にする。
-* 将来、TAPAS 等による MIA/AIA 評価を追加できるようにする。
+* 将来、shadow-based MIA（TAPAS / DOMIAS 等）による評価を追加できるようにする。
 * 生成された複数候補を保存し、比較レポートを出せるようにする。
 
 ## 3. 非目的
@@ -29,9 +33,9 @@ Murata 2017 は、サンプル個票を使わず、公開統計に整合する�
 以下は今回のスコープ外とする。
 
 * 日本の実統計表を完全収集して全国再現すること
-* 高速化の最適化（C++化、GPU化、分散実行）
+* 高速化の最適化（C++ 化、GPU 化、分散実行）
 * GUI の実装
-* 差分プライバシー保証付き生成器の実装
+* 差分プライバシー (DP) 保証付き生成器の実装（ただし将来拡張に備えた Protocol 抽象は用意する）
 * 画像・時系列・自由記述を含む非表形式データへの拡張
 * 法的判定の自動化
 
@@ -49,15 +53,15 @@ Murata 2017 は、サンプル個票を使わず、公開統計に整合する�
 ### 4.2 評価器
 
 * 統計整合性評価
-* 個票レベルの近傍類似度評価
-* 必要に応じて推定タスク性能評価
+* 有用性評価（broad / narrow）
+* 秘匿性評価（類似度 proxy / 属性推論 baseline / shadow-based MIA の 3 層）
 * 実験メタデータ保存
 
 ### 4.3 改善器
 
 * 遷移方式変更（age-change / age-swap / 混合）
 * 温度スケジュール変更
-* 目的関数重み変更
+* 目的関数重み変更（研究拡張モードのみ）
 * 初期解生成パラメータ変更
 * 停止条件の延長・短縮
 
@@ -65,105 +69,95 @@ Murata 2017 は、サンプル個票を使わず、公開統計に整合する�
 
 ### 5.1 Murata 2017 の実装要点
 
-Murata 2017 は、9種類の家族類型、子ども人数統計、人口ピラミッド、親子年齢差、夫婦年齢差などの公開統計を用い、SA により誤差を最小化する。元の9統計ベース目的関数 `f(A)` と、拡張後の21統計ベース目的関数 `f'(A)` が示されている。候補解遷移としては、
+Murata 2017 は、9 種類の家族類型、子ども人数統計、人口ピラミッド、親子年齢差、夫婦年齢差などの公開統計を用い、SA により誤差を最小化する。元の 9 統計ベース目的関数 `f(A)` と、拡張後の 21 統計ベース目的関数 `f'(A)` が示されている。候補解遷移としては、
 
-* `age-change`: 役割に応じた年齢分布に従い1人の年齢を変更
-* `age-swap`: 同一 family type・同一 sex の2人の年齢を交換
+* `age-change`: 役割に応じた年齢分布に従い 1 人の年齢を変更
+* `age-swap`: 同一 family type・同一 sex の 2 人の年齢を交換
 
-の2方式がある。`age-swap` は family type 別人口構成を保ちやすい。
+の 2 方式がある。`age-swap` は family type 別人口構成を保ちやすい。
 
 ### 5.2 生成・評価・改善の考え方
 
-本実装では「一度生成して終わり」ではなく、評価に基づく再生成を前提とする。
+本実装では「一度生成して終わり」ではなく、評価に基づく再生成を前提とする。1 回の SA では探しきれない局所解を、設定を変えた複数 trial の中から選ぶことを想定する。
 
 ### 5.3 評価観点
 
 * 統計整合性
 * 有用性（broad utility / narrow utility）
-* 秘匿性（近傍距離、レコード一致、必要に応じて MIA/AIA）
+* 秘匿性（proxy / baseline / MIA の 3 層。§13.3 参照）
+
+### 5.4 Murata 生成 / Harada 評価の役割分担
+
+本実装は 2 つの先行研究を明確に**役割分担**して使う。
+
+* **Murata 2017 は「生成側」の根拠**: SA ベースの SR 手法、21 統計への誤差最小化、age-change / age-swap 遷移の比較設計など、§10〜§12 の生成ロジックと §11 の目的関数はここに由来する。
+* **Harada 2024 は「評価側」の根拠**: 有用性と秘匿性の評価軸、特に §13.3 (a) 層に置く ARD のような距離ベース指標はここに由来する。§13 の評価指標体系はこちらを参照する。
+
+spec 本文中の各節には、由来する論文を脚注または「§13.3 (a) ARD (Harada 2024)」のように括弧書きで明示する。
 
 ## 6. システム要件
 
 ### 6.1 開発言語・環境
 
-* Python 3.11 以上
-* パッケージ管理: `uv`
+* **Python 3.11+**
+* パッケージ管理: `uv`、lockfile (`uv.lock`) をコミットし CI は `uv sync --frozen` で再現する
+* **PyPI パッケージ名: `synthpop-jp`**
+* **import 名: `synthpop_jp`**
+* **CLI エントリポイント: `synthpop-jp`**（`[project.scripts]` に登録）
+* **ライセンス: Apache-2.0**（研究ユーザー向けの特許条項保護を重視、ADR-0004 参照）
 * 実装形態: ライブラリ + CLI
 * OS: Linux / macOS を想定
 
 ### 6.2 想定ライブラリ
 
-* `pandas`
-* `numpy`
+* `numpy`（SA 内部表現の主、ADR-0001 参照）
+* `pandas`（I/O 層のみで使用）
 * `scipy`
-* `pydantic`
+* `pydantic` v2（I/O バリデーション、config ローダ）
+* `pydantic-settings`
 * `typer`
 * `matplotlib`
 * `pyyaml`
-* `rich`
+* `rich`（進捗・構造化ログの人間可読レンダリング、`tqdm` は使わない）
+* `structlog`（機械可読ログ）
 * `scikit-learn`
 
 ## 7. 入出力仕様
 
-### 7.1 入力
+本節は概要のみを示す。**全 CSV の列・型・単位・欠損規則・半開区間表現・`family_type_group` との対応などの詳細は [`docs/spec/data_contract.md`](data_contract.md) に委譲する**。
 
-#### 必須入力
+### 7.1 入力（概要）
 
-1. `family_type_counts.csv`
+必須入力:
 
-   * family_type
-   * household_count
+1. `family_type_counts.csv`（family type ごとの世帯数）
+2. `children_count_dist.csv`（family type group 別、子ども人数分布）
+3. `demographic_by_age_sex.csv`（年齢 × 性別の人口）
+4. `age_diff_parent_child.csv`（親子年齢差の分布）
+5. `age_diff_couple.csv`（夫婦年齢差の分布。符号規則 `couple_diff = husband_age - wife_age`）
 
-2. `children_count_dist.csv`
+任意入力:
 
-   * family_type_group
-   * n_children
-   * rate
-
-3. `demographic_by_age_sex.csv`
-
-   * sex
-   * age
-   * count
-
-4. `age_diff_parent_child.csv`
-
-   * relation_type
-   * diff_bin
-   * rate_or_count
-
-5. `age_diff_couple.csv`
-
-   * diff
-   * rate_or_count
-
-#### 任意入力
-
-6. `demographic_by_family_type_role.csv`
-
-   * family_type
-   * sex
-   * role
-   * age
-   * count
-
+6. `demographic_by_family_type_role.csv`（family type × role × sex × age）
 7. `household_size_by_family_type.csv`
+8. `config.yaml`（§18 参照）
 
-   * family_type
-   * household_size
-   * count
-
-8. `config.yaml`
+各 CSV の列名・型・欠損規則・半開区間文字列 `"[-5,-3)"` の規約は `data_contract.md` に一元化する。
 
 ### 7.2 出力
 
 1. `synthetic_households.csv`
 2. `synthetic_persons.csv`
-3. `metrics.json`
-4. `report.md`
+3. `metrics.json`（スキーマは `docs/spec/experiment_report_format.md`）
+4. `report.md`（出典・ライセンス注記を自動埋込）
 5. `artifacts/`
+   * `artifacts/checkpoint/` — SA の再開用スナップショット（`--resume` で使用、10k 反復ごと）
+   * `artifacts/trace/` — `trace.jsonl`（SA の反復ログ）
+   * `artifacts/figures/` — 人口ピラミッドなどの PNG
 
 ## 8. データモデル
+
+I/O 層の外部データモデル（pydantic v2）:
 
 ```text
 Household
@@ -180,6 +174,8 @@ Person
 - role: str
 - kinship_id: Optional[str]
 ```
+
+SA 内部表現は `PopulationArrays`（NumPy 並列配列、ADR-0001 参照）で、§9・§12 で詳述する。I/O とドメイン層は pydantic、SA 内部は並列配列、という二層構造を取る。
 
 ### 8.1 family_type の初期定義
 
@@ -205,38 +201,60 @@ Person
 
 ## 9. アーキテクチャ
 
+`synthpop_jp` パッケージのディレクトリ構成を以下に固定する（命名の根拠は ADR-0004 を参照）。
+
 ```text
 src/
-  synthetic_population/
-    config.py
-    io/
-      loaders.py
-      writers.py
+  synthpop_jp/
+    __init__.py
+    cli.py                    # typer アプリ。[project.scripts] の synthpop-jp が参照
+    config.py                 # pydantic-settings ベースの設定ローダ
+    registry.py               # family_type / transition / evaluator のレジストリ
     domain/
       household.py
       person.py
       statistics.py
+      protocols.py            # Transition / CoolingSchedule / Evaluator / PrivacyMetric / Distribution Protocol
+      distance.py             # Gower 距離など
+    io/
+      loaders.py              # pydantic v2 ベースの CSV ローダ
+      writers.py              # 出典・ライセンス注記を埋め込む report.md ジェネレータ
     init/
       household_sampler.py
       initial_population.py
     optimize/
-      objective.py
+      state.py                # PopulationArrays（NumPy 並列配列）
+      objective.py            # 差分更新版 ObjectiveState（propose/apply/revert）
       annealing.py
       transitions.py
       cooling.py
     evaluate/
-      aggregate_metrics.py
-      privacy_metrics.py
-      utility_metrics.py
+      aggregate_metrics.py    # 統計整合性
+      utility_metrics.py      # broad / narrow utility
+      privacy_metrics.py      # 3 層評価（proxy / CAP baseline / MIA skeleton）
+      attribute_inference.py  # Generalized CAP / TCAP
+      rare_cell_metrics.py    # family_type × age の cell size 監視
       downstream_tasks.py
     improve/
       tuner.py
-      strategy.py
+      strategy.py             # rule_based / pareto / random_search
     experiments/
       runner.py
       comparison.py
-    cli.py
+      pareto.py
 ```
+
+### 9.1 拡張ポイント（plugin）
+
+外部パッケージから評価器・遷移・family_type を注入できるよう、次の 2 層で拡張点を提供する（OSS 指摘 5）。
+
+* **内側（同一プロセス）**: `domain/protocols.py` の `Protocol`（`Transition`, `CoolingSchedule`, `Evaluator`, `PrivacyMetric`, `Distribution`）を実装し、`registry.py` の `register_family_type(name, template)` / `register_transition(name, fn)` / `register_evaluator(name, cls)` で登録する。
+* **外側（別パッケージ）**: `pyproject.toml` の `[project.entry-points]` で登録する。名前空間は以下を使う。
+  * `synthpop_jp.evaluators`
+  * `synthpop_jp.transitions`
+  * `synthpop_jp.family_types`
+
+CONTRIBUTING.md に「新 family_type を足す 10 行の例」「新評価器を足す 20 行の例」を載せる。
 
 ## 10. 生成ロジック仕様
 
@@ -247,11 +265,13 @@ src/
 3. children を持つ family type に子ども人数を割当
 4. role を household template から展開
 5. sex を role に応じて設定
-6. age を粗い人口ピラミッドまたは family type × role × sex 分布から初期割当
+6. age を family type × role × sex 分布から割当（原論文 §3 は 21 統計のうち F〜W を初期生成で誤差 0 化する手続きを提示しており、Phase 3a でこの「初期誤差 0 化」を実装する。粗い人口ピラミッドのみを使う簡易モードは Phase 1〜2 の MVP 用に残す）
 
 ### 10.2 初期集団生成の方針
 
 * 再現性のため乱数 seed を固定可能にする
+* 乱数源は `numpy.random.Generator` のみを使い、`random` / `scipy.stats.random_state` は使わない
+* `SeedSequence` による階層 spawning を §18 に明記（`init_rng`, `sa_rng`, `eval_rng`, trial 別 seed）
 * 制約違反がある場合は household 単位で再生成する
 * まずは小規模データで矛盾なく生成できることを優先する
 
@@ -259,7 +279,12 @@ src/
 
 ### 11.1 基本方針
 
-目的関数は「公開統計と生成結果の差の総和」を基本とする。
+目的関数は「公開統計と生成結果の差の総和」を基本とする。**本実装は 2 モードを併記する**（ADR-0002）。
+
+* **原論文準拠モード**: Murata 2017 の式(1) / 式(3) に忠実。`weight_s` は使わない。Murata 再現を主張する場面ではこちらのみ。
+* **研究拡張モード**: セル数正規化 + 統計間重み。実用チューニング向け。
+
+実験 1（§15.1）は**原論文準拠モードのみ**で実施する。両モードの値は評価レポートで併記する。
 
 ### 11.2 第一段階: minimal objective
 
@@ -271,20 +296,72 @@ src/
 
 ### 11.3 第二段階: extended objective
 
-family type 別 demographic pyramid まで拡張する。
+family type 別 demographic pyramid まで拡張し、Murata 2017 の 21 統計に対応させる。
 
-### 11.4 式の実装方針
+### 11.4 式（原論文準拠モード / 研究拡張モード）
+
+#### 11.4.1 原論文準拠モード（primary）
+
+Murata 2017 式(1)（9 統計ベース）:
 
 ```text
-objective = sum_s sum_j weight_s * abs(observed[s,j] - target[s,j])
+f(A) = Σ_s Σ_j | c_{sj}(A) - Round( r_{sj} · m_{sj}(A) ) |
 ```
 
-### 11.5 追加ペナルティ
+* `A`: 現在の合成集団
+* `s`: 統計のインデックス（family type 別や demographic 等）
+* `j`: その統計内のセル（age bin, diff bin, family type 等）
+* `c_{sj}(A)`: 合成集団から観測したセル `j` の個数
+* `r_{sj}`: 公開統計が示す**率**（例: family type 別の age 分布）
+* `m_{sj}(A)`: 合成集団側の**対応する分母**（例: その family type の人数）
+* `Round(r_{sj} · m_{sj}(A))`: 率 × 分母を丸めた**動的ターゲット**
 
-* 年齢が 0〜100 を外れた場合の禁止ペナルティ
-* role と年齢の矛盾ペナルティ
-* 親が子より若い場合の大ペナルティ
-* 夫婦の片方が未成年の場合の大ペナルティ
+「`Round(r_{sj} · m_{sj}(A))` は生成集団側の分母に依存する動的ターゲットである」点を明記する。target を静的定数として扱うと誤実装になる。
+
+Murata 2017 式(3)（21 統計ベース、実数値 `R_{sj}` を直接使う拡張版）:
+
+```text
+f'(A) = Σ_s Σ_j | c_{sj}(A) - R_{sj} |
+```
+
+* `R_{sj}`: 実数値の実統計（率ではなく集計人数）
+* `weight_s` は存在しない
+
+#### 11.4.2 研究拡張モード
+
+セル数正規化 + 統計間重み（本実装独自、原論文の拡張）:
+
+```text
+loss_s    = (1 / |cells_s|) * Σ_j | observed_rate[s, j] - target_rate[s, j] |
+objective = Σ_s weight_s * loss_s
+```
+
+* `observed_rate`: 合成集団のセル個数を人口総数で割った rate
+* `target_rate`: 公開統計側の rate
+* `weight_s`: §18 の `objective.weights` と対応。値域は **統計間の相対重要度** として解釈する
+* このモードは Phase 3 以降のチューニング実験でのみ使う
+
+### 11.5 ハード制約
+
+**目的関数への加算ペナルティではなく、遷移前に弾くハード制約**として §12.2 に移す（Py 指摘 14）。以下は SA の提案段階でリジェクトする。
+
+* 年齢が 0〜100 を外れる提案
+* role と年齢が矛盾する提案
+* 親が子より若くなる提案
+* 夫婦の片方が未成年になる提案
+
+ペナルティを目的関数に入れると温度チューニングに干渉するため、上記はハード制約として閉じ込める。
+
+### 11.6 目的関数最小化と秘匿性
+
+Murata 2017 の拡張 21 統計（family type 別人口ピラミッド）を強く最小化すると、低頻度 family type（例: "couple_and_a_parent" 1.48%, "couple_and_parents" 0.47%）の**集計から一意に決まる年齢構成**が生成され、評価用実個票がある場合は属性推論耐性が低下する（Priv 指摘 4）。
+
+本実装は次の対策を仕様として用意する。
+
+* **rare family_type × age cell の k-anonymity 下限**: 合成集団上で `family_type × age` の cell size が閾値 `k`（既定 5）を下回る割合をモニタし、`docs/spec/metrics.md` で定義する `rare_cell_metrics` に含める。`improve` でこの割合が閾値を超えた場合は trial を rejected としてマークする soft constraint オプションを設ける。
+* **エントロピー正則化オプション**: 目的関数に `-λ · H(生成分布)` を加算する研究拡張モード限定のオプション（`objective.entropy_regularization` / `objective.lambda`）。既定は off。
+
+§15 の実験では「evals_per_agent を増やすと error ↓ だが rare cell unique 率 ↑」のトレードオフ曲線を主張指標に含める。
 
 ## 12. SA 仕様
 
@@ -293,8 +370,10 @@ objective = sum_s sum_j weight_s * abs(observed[s,j] - target[s,j])
 * 初期温度 `T0`
 * 冷却率 `alpha`
 * 反復数 `max_iters`
-* 評価回数 / person 上限
+* 評価回数 / person 上限 `evals_per_agent`
 * 受理判定: Metropolis
+* **内部表現は NumPy 並列配列 (`PopulationArrays`)、目的関数は差分更新前提**（ADR-0001）。1 遷移ごとに影響ビン（age_bin, sex, family_type 等）のみ `+1 / -1` し、`abs` の総和を保持変数 `score` に差分反映する。`ObjectiveState` クラスが `propose / apply / revert` の 3 メソッド API で全遷移を扱う。
+* `--resume` のための checkpoint を 10k 反復ごとに `artifacts/checkpoint/*.parquet` に保存する
 
 ### 12.2 遷移方式
 
@@ -303,13 +382,15 @@ objective = sum_s sum_j weight_s * abs(observed[s,j] - target[s,j])
 * family type を選択
 * member を選択
 * 役割に応じた分布から新年齢をサンプル
-* 年齢を更新
+* §11.5 ハード制約を通過した提案のみを SA の Metropolis に渡す
+* 受理時は `ObjectiveState.apply`、却下時は `revert`
 
 #### B. age-swap
 
 * family type と sex を選択
-* 対応する2人を選択
+* 対応する 2 人を選択
 * 年齢を交換
+* §11.5 ハード制約を通過した提案のみを SA の Metropolis に渡す
 
 #### C. hybrid
 
@@ -323,51 +404,73 @@ objective = sum_s sum_j weight_s * abs(observed[s,j] - target[s,j])
 * `best_score <= target_threshold`
 * `patience` 期間改善なし
 
+Murata 2017 Fig.5 の再現用に `evals_per_agent ∈ {1000, 2000, 4000, 8000, 16000}` の 5 水準を §18 の比較 config に置く。
+
 ## 13. 評価仕様
+
+各指標の**距離定義・算出式の詳細は [`docs/spec/metrics.md`](metrics.md) に委譲する**。本節は方針と層構造のみを固定する。
 
 ### 13.1 統計整合性評価
 
-* 総目的関数値
-* 統計別誤差
-* 平均絶対誤差
-* 相対誤差
-* 人口ピラミッド差分
-* family type 別人数差分
+* **L1 (= 原論文式(1) の絶対誤差) を primary**、L2 / χ² を secondary、TV を参考指標とする（Priv 指摘 5）
+* 指標一覧:
+  * 総目的関数値（原論文モード / 研究拡張モードの両方）
+  * 統計別誤差（21 統計ブレークダウン、Table 13 形式）
+  * 平均絶対誤差 / 相対誤差
+  * 人口ピラミッド差分は **1 歳刻みと 5 歳刻みの両方を報告**
+  * family type 別人数差分
 
 ### 13.2 有用性評価
 
 #### Broad utility
 
-* 単変量分布差
-* クロス集計差
-* 相関差
-* Jensen-Shannon 距離または TV 距離
+* 単変量分布差（L1 / TV）
+* クロス集計差（全属性ペア TV、Frobenius norm / max-abs）
+* 混合型相関行列（`dython.associations` 準拠: Theil's U / Cramér's V / Correlation Ratio）
+* プライマリ指標は **TV**、参考として JS 距離
 
 #### Narrow utility
 
-ダミー目的変数を用意し、
+**固定 3 タスク**（Priv 指摘 7）を事前登録する。
 
-* 実データ学習 → 実データ評価
-* 合成データ学習 → 実データ評価
+* タスク A: family_type 分類（age, sex, 世帯内 role 分布 → family_type、macro-F1）
+* タスク B: 世帯人数回帰（family_type, 子ども人数 → household_size、RMSE）
+* タスク C: 役割予測（age, sex, family_type → role、macro-F1）
 
-の性能差を比較する。
+評価は TSTR（Train Synthetic, Test Real）と TRTS の両方を出す。タスク・指標・データ分割は `docs/experiment_plan.md` に事前登録して凍結する。
 
-### 13.3 秘匿性評価
+### 13.3 秘匿性評価（3 層）
 
-#### 初期実装
+秘匿性は性質の異なる 3 層に分けて報告する。Ganev & De Cristofaro (2024) "On the Inadequacy of Similarity-based Privacy Metrics" (arXiv:2312.03054) が示すとおり、類似度ベース指標単体では privacy claim の根拠として不十分である（Priv 指摘 2, 3）。
 
-* 最近傍距離 (DCR)
-* NNDR
-* レコード一致率
-* 属性部分一致率
-* ARD
+評価用 "real" 個票の出所・倫理処理は [`docs/assumptions.md`](../assumptions.md) を参照。距離定義（Gower 距離など）の具体は [`docs/spec/metrics.md`](metrics.md) に委譲する。
 
-#### 拡張候補
+#### (a) 類似度 proxy（MVP、Phase 4）
 
-* TAPAS による MIA
-* TAPAS による AIA
-* holdout distinguishing
-* shadow modelling
+* **DCR** (Distance to Closest Record)
+* **NNDR** (Nearest Neighbor Distance Ratio)
+* **ARD** (Harada 2024 由来の距離指標、`evaluate/privacy_metrics.py` のコアに置く)
+* 距離は **Gower** を primary とし、連続は [0,1] 正規化、カテゴリはマッチ/非マッチ
+* **本層は proxy に過ぎない旨を `report.md` に明記**し、単体で privacy claim を張らない
+
+#### (b) 属性推論 baseline（MVP 必須、Phase 4 / Phase 3.5 先行）
+
+* **Generalized CAP** (Correct Attribution Probability、Taub et al. 2018 ほか)
+* **TCAP**
+* DCR/NNDR/ARD より先に実装する（実装順序: rare_cell → CAP → DCR/NNDR/ARD → MIA）
+* 属性別分解（per-family_type CAP）も出力
+
+#### (c) shadow-based MIA（Phase 5 stretch）
+
+* **TAPAS** (Houssiau et al. 2022)
+* **DOMIAS** (van Breugel et al. 2023)
+* shadow generator を同じ統計入力の異なる seed 群で再生成する protocol を `docs/experiment_plan.md` に事前登録
+
+### 13.4 Rare cell 監視
+
+* `family_type × age` で cell size < 5 の割合
+* unique 率（1 人しかいない cell の割合）
+* §11.6 と連動
 
 ## 14. 生成・評価・改善ループ
 
@@ -377,9 +480,9 @@ objective = sum_s sum_j weight_s * abs(observed[s,j] - target[s,j])
 for trial in trials:
     generate initial population
     optimize with SA
-    evaluate utility/privacy/statistical fit
+    evaluate utility / privacy / statistical fit
     record metrics
-    update parameters
+    update parameters (strategy に応じて)
 select best configuration
 ```
 
@@ -387,90 +490,178 @@ select best configuration
 
 * transition type
 * cooling schedule
-* objective weights
+* objective weights（研究拡張モードのみ）
 * max iterations
 * household initialization heuristics
 
-### 14.3 改善ロジック（初版）
+### 14.3 改善戦略（baseline）: rule_based
+
+if-then ルールを baseline として維持する。
 
 * 親子年齢差誤差が大きい → `age-change` 比率を上げる
 * demographic 誤差が小さいが親族関係誤差が大きい → `age-swap` を増やす
-* 有用性が高いが近傍距離が小さすぎる → penalty または iteration 制限を調整
+* rare cell unique 率が高い → `evals_per_agent` を下げる
 * 収束が遅い → 温度減衰を緩める
 
-### 14.4 改善ロジック（将来）
+### 14.4 改善戦略（MVP）: pareto / random_search
+
+本研究の本質は「統計整合性 × 有用性 × 秘匿性」の 3 目的最適化である（Priv 指摘 9）。`improve.strategy` は以下 3 値を取る。
+
+* `rule_based`（baseline、§14.3）
+* `pareto`（MVP、全 trial を 3 次元スコア空間にプロットし non-dominated set を抽出、`outputs/*/pareto.png` を出力）
+* `random_search`（参照用）
+
+rule_based vs pareto の比較は §15.3 実験 3 の主対象とする。
+
+将来拡張（Phase 6 以降）:
 
 * Bayesian optimization
-* multi-objective optimization
 * bandit による遷移選択
 
 ## 15. 実験計画
 
+**§15 の実験は事前登録必須**（Priv 指摘 8）。仮説・指標・統計検定・サンプルサイズ・停止条件は [`docs/experiment_plan.md`](../experiment_plan.md) に記載し、**Phase 3 着手前に git tag でフリーズ**する。報告指標の後付け変更は ADR を追加して追記管理する。
+
 ### 15.1 実験 1: Murata 再現の最小比較
 
 * `age-change` と `age-swap` の傾向差を確認する
-* 同一 seed 群
+* **原論文準拠モード（§11.4.1）のみ**で実施する
+* 同一 seed 群（n = 10〜30）
 * 同一入力統計
-* evals_per_agent を複数水準で変更
+* `evals_per_agent ∈ {1000, 2000, 4000, 8000, 16000}` の 5 水準
+* 統計検定: **Wilcoxon signed-rank**（seed 対応あり）、effect size は **Cliff's δ**
 
 ### 15.2 実験 2: hybrid 戦略
 
 * 初期 `age-change`、後半 `age-swap` の混合が有効か確認する
+* Welch's t + Holm 補正
 
-### 15.3 実験 3: 生成・評価・改善ループの有効性
+### 15.3 実験 3: 改善戦略の比較（rule_based vs pareto）
 
 * 固定設定より改善ループのほうが総合評価が良いか確認する
+* rule_based / pareto / random_search の 3 戦略を直接比較
+* Welch's t + Holm 補正
 
-### 15.4 実験 4: 複数候補生成
+### 15.4 実験 4: 複数候補のばらつき
 
 * 単一合成人口ではなく複数データセット生成時のばらつきを確認する
+* shadow seed 群の運用は `docs/experiment_plan.md` に定義
+
+### 15.5 統計検定の既定
+
+* seed 群: n = 10〜30
+* 主指標: Welch's t（独立群）or Wilcoxon signed-rank（対応群）、多重比較は Holm 補正
+* 信頼区間: bootstrap CI（2,000 回、percentile 法）
+* `metrics.json` に `seed`, `git_sha`, `numpy_version`, `uv.lock hash` を必ず記録
 
 ## 16. 実装フェーズ
 
-### Phase 1: 骨組み
+### Phase 0: 基盤整備（新設）
 
-* プロジェクト初期化
-* 入力ローダ
-* ドメインモデル
-* ダミー入力一式
+* spec.md 改訂、ADR 0001〜0004、命名・LICENSE 確定
+* 契約ドキュメント骨子（data_contract / metrics / experiment_report_format / experiment_plan / assumptions）
+* pyproject.toml / uv.lock / ruff / pyright / pre-commit / CI skeleton
+* ディレクトリ骨格と `domain/protocols.py`（空定義で可）
+
+### Phase 1: I/O + 初期生成
+
+* pydantic v2 ローダ（全 CSV、行番号付きエラー）
+* `PopulationArrays` と domain ↔ 並列配列のコンバータ
+* `family_type_group` yaml マッピング
 * ランダム初期人口生成
+* `synthpop-jp quickstart` / `synthpop-jp validate-config`
 
-### Phase 2: SA 最小実装
+### Phase 2: SA MVP
 
-* 目的関数 minimal 版
-* age-change 実装
-* SA 実装
-* ログ出力
+* 目的関数 minimal 版（原論文準拠モード、差分更新）
+* age-change 遷移
+* SA runner、`trace.jsonl`、`rich.live` 進捗
+* `--resume` / checkpoint
+* pytest-benchmark、hypothesis property test
 
-### Phase 3: Murata 拡張
+### Phase 3a: Murata 拡張
 
-* age-swap 実装
-* family type 別分布対応
-* extended objective 実装
-* 比較実験 runner 実装
+* age-swap / hybrid
+* family type × role × sex 分布からの年齢サンプリング
+* extended objective（21 統計、原論文式(3)）
+* 初期生成の 21 統計誤差 0 化
 
-### Phase 4: 評価
+### Phase 3.5: 評価器骨格（Phase 3a と一部並列）
 
-* broad utility
-* 近傍ベース privacy proxy
-* レポート出力
+* `Evaluator` Protocol と `evaluate/` skeleton
+* 統計別 L1 誤差レポータ（Table 13 形式）
+* **CAP 先行実装**（DCR より先）
+* rare cell 監視メトリクス
+* `metrics.json` スキーマ + `report.md` テンプレート
+
+### Phase 3b: 比較 runner
+
+* `synthpop-jp compare`
+* seed 群 runner、Welch's t + Holm、bootstrap CI
+* 実験 1 / 2 を `paper_results/` に固定
+
+### Phase 4: 評価器本体（utility / privacy を並列）
+
+* broad utility: mixed-type 相関、全属性ペア TV、Frobenius 差
+* narrow utility: 固定 3 タスクの TSTR/TRTS
+* privacy: rare cell → CAP（既済）→ DCR/NNDR/ARD → MIA skeleton
+* `report.md` ジェネレータに出典・ライセンス注記を自動埋込
+* mkdocs サイト v0.2（日英併記）
 
 ### Phase 5: 改善ループ
 
-* rule-based tuner
-* 複数 trial 実行
-* best config 選択
+* `improve/strategy.py` の 3 戦略（rule_based / pareto / random_search）
+* multi-trial runner、best config 選択
+* Pareto 可視化
+* 実験 3 / 4
+* MIA 実装（TAPAS / DOMIAS、stretch）
+
+### Phase 6: v1.0 準備（新設）
+
+* `paper_results/` 固定と `Makefile` による再現
+* Zenodo 連携、DOI 発行、`CITATION.cff` 更新
+* 英語ドキュメント完備
+* SDV 比較 end-to-end ベンチ
+* v1.0 release & PyPI stable
 
 ## 17. CLI 仕様
 
+エントリポイントは `synthpop-jp`（`[project.scripts]` に登録）。`uvx` で一発起動可能にする。
+
 ```bash
-uv run python -m synthetic_population.cli generate --config configs/base.yaml
-uv run python -m synthetic_population.cli evaluate --run-dir outputs/run_001
-uv run python -m synthetic_population.cli improve --config configs/base.yaml --trials 10
-uv run python -m synthetic_population.cli compare --experiment configs/compare_age_change_swap.yaml
+# 30 秒 Quickstart（sample_case ダミーで end-to-end）
+uvx synthpop-jp quickstart
+
+# config バリデーションのみ
+synthpop-jp validate-config --config configs/base.yaml
+
+# 生成
+synthpop-jp generate --config configs/base.yaml
+synthpop-jp generate --config configs/base.yaml --resume outputs/run_001
+synthpop-jp generate --config configs/base.yaml --dry-run
+synthpop-jp generate --config configs/base.yaml --log-level DEBUG
+
+# 評価
+synthpop-jp evaluate --run-dir outputs/run_001
+
+# 改善
+synthpop-jp improve --config configs/base.yaml --trials 10
+
+# 比較
+synthpop-jp compare --experiment configs/compare_age_change_swap.yaml
 ```
 
+共通フラグ:
+
+* `--resume <run-dir>` … `artifacts/checkpoint/` から再開
+* `--dry-run` … 設定解決と I/O 準備のみで終了
+* `--log-level {DEBUG,INFO,WARNING,ERROR}` … stdout は `rich` 人間可読、`run.log` は JSON Lines
+
+`--config` 未指定時は同梱デフォルト config を使う。
+
 ## 18. 設定ファイル例
+
+config は pydantic v2 モデル（`config.py` の `GenerateConfig`, `AnnealingConfig`, `ObjectiveConfig`, `ImproveConfig`）で定義し、`extra="forbid"` で未定義キーを禁止する。`synthpop-jp validate-config` でチェックのみ走る。
 
 ```yaml
 seed: 42
@@ -478,28 +669,41 @@ input_dir: data/sample_case
 output_dir: outputs/run_001
 
 annealing:
-  transition: hybrid
+  transition: hybrid             # age_change | age_swap | hybrid
   initial_temperature: 10.0
-  cooling_rate: 0.9995
+  cooling_rate: 0.9995           # 0 < alpha < 1
   max_iters: 200000
   evals_per_agent: 1000
   p_change: 0.7
   p_swap: 0.3
 
 objective:
+  mode: paper                    # paper | research_extended
   use_extended_statistics: true
-  weights:
+  weights:                       # mode=research_extended でのみ有効
     father_child_gap: 1.0
     mother_child_gap: 1.0
     couple_gap: 1.0
     demographic: 0.5
     family_type_demographic: 1.5
+  entropy_regularization: false  # §11.6、mode=research_extended でのみ有効
+  lambda: 0.0
 
 improve:
   enabled: true
   trials: 10
-  strategy: rule_based
+  strategy: rule_based           # rule_based | pareto | random_search
 ```
+
+### 18.1 seed の階層 spawning
+
+```python
+root_ss = np.random.SeedSequence(config.seed)
+init_rng, sa_rng, eval_rng = root_ss.spawn(3)
+trial_seeds = root_ss.spawn(config.improve.trials)
+```
+
+`metrics.json` に `seed`, `numpy_version`, `git_sha`, `uv.lock` のハッシュを必ず記録する。
 
 ## 19. テスト仕様
 
@@ -508,60 +712,89 @@ improve:
 * family type から household template が正しく構築される
 * objective 計算が期待値通り
 * 遷移後も household size が不変
-* age-swap 後に対象2人の age が交換される
-* 禁止制約が正しく検出される
+* age-swap 後に対象 2 人の age が交換される
+* ハード制約（§11.5）が正しく検出される
 
 ### 19.2 結合テスト
 
 * generate CLI が正常終了する
-* SA 実行で best score が初期値以下になる
+* SA 実行で best score が初期値から閾値以下に収束する（例: 初期 score の 30% 以下）
 * evaluate CLI が metrics を出力する
 * improve CLI が複数 trial を完走する
 
-### 19.3 回帰テスト
+### 19.3 決定性テスト（回帰とは分離）
 
-* seed 固定時に主要メトリクスの大幅劣化がない
+* **同一 seed・同一 input → 同一 `best_score`（bitwise 一致）**
+* `uv.lock` 固定 + CI `uv sync --frozen`
+* 失敗時は `paper_results/` の `metrics.json` との差分を出す
+
+### 19.4 許容幅テスト
+
+* 依存更新時の揺らぎ対応として **`best_score ±1%`** の幅で判定（決定性テストとは分離）
+* utility 指標は `paper_results/` との相対差 5% 以内
+
+### 19.5 Property テスト（hypothesis）
+
+* 遷移後の household size 不変
+* age-swap 後に 2 人の age が厳密に交換される
+* 差分更新と全再計算の結果が一致する
 
 ## 20. 成果物
 
-* `src/` 実装コード
+* `src/synthpop_jp/` 実装コード
 * `tests/`
-* `data/sample_case/`
+* `data/sample_case/`（完全合成ダミー、e-Stat 実データは同梱しない）
 * `configs/`
 * `outputs/example_run/`
-* `README.md`
-* `docs/spec.md`
+* `paper_results/`（実験 1〜4 の固定出力、`Makefile` で再現）
+* **`LICENSE`**（Apache-2.0）
+* `NOTICE`（依存ライブラリのクレジット）
+* `README.md`（日本語 primary、英語セクション併記、30 秒 Quickstart、比較表）
+* **`CITATION.cff`**（Murata 2017 + Harada 2024 を preferred-citation、Zenodo DOI は v0.1 公開時）
+* **`CHANGELOG.md`**（Keep a Changelog 形式、SemVer、v0.x 中の破壊的変更は明示）
+* **`CODE_OF_CONDUCT.md`**（Contributor Covenant）
+* **`CONTRIBUTING.md`**（新 family_type / 評価器追加の 10〜20 行例、worktree 規約）
+* **`DATASET.md`**（e-Stat 利用規約、sample_case 由来、出典表示義務）
+* `pyproject.toml`, `uv.lock`
+* `Makefile`（`make quickstart`, `make paper`, `make docs`）
+* `docs/spec/spec.md`（本書）
+* `docs/spec/data_contract.md`
+* `docs/spec/metrics.md`
+* `docs/spec/experiment_report_format.md`
 * `docs/experiment_plan.md`
 * `docs/assumptions.md`
+* `docs/adr/0001-internal-representation.md` 〜 `0004-naming-and-license.md`
 
 ## 21. 実装上の注意
 
 1. まずは実統計ではなく、整合が取りやすい小規模ダミー統計で作る。
-2. 年齢・役割制約を曖昧にすると収束しにくくなるため、禁止制約を先に入れる。
+2. 年齢・役割の矛盾は目的関数ではなく **ハード制約** として遷移前に弾く（§11.5）。
 3. 目的関数を一度に増やしすぎず、minimal → extended の順で広げる。
-4. 評価を後回しにしない。
+4. 評価を後回しにしない。`Evaluator` Protocol は Phase 3.5 で評価器骨格を先出しする。
 5. 乱数 seed、設定ファイル、実験結果保存を初期から標準化する。
+6. SA 内部表現は **NumPy 並列配列 + 差分更新**で固定する（ADR-0001）。
+7. 将来の DP 拡張に備え、`Distribution` / `PrivacyMetric` Protocol は空で良いので §9 に置いておく（Priv S7）。
 
 ## 22. 判断基準
 
 * 小規模統計入力から矛盾の少ない合成人口を生成できる
 * `age-change` / `age-swap` / `hybrid` の比較ができる
-* 統計整合性・有用性・秘匿性 proxy を同時に出せる
-* 評価結果に応じて設定を更新するループが回る
-* 追加データや追加評価器を差し込みやすい構成になっている
+* 統計整合性・有用性・秘匿性（proxy / CAP / MIA の 3 層）を同時に出せる
+* 評価結果に応じて設定を更新するループ（rule_based / pareto / random_search）が回る
+* 追加データや追加評価器を `entry_points` / Protocol で差し込める
+* 同一 seed で bitwise 一致の再現性を確認できる
 
 ## 23. Claude Code への実装指示
 
-1. `docs/spec.md` を読み、前提・スコープを明文化する
-2. `docs/tasks/phase-01.md` から `phase-05.md` を作成する
-3. Phase 1〜2 を先に完了し、最小動作を確認する
-4. その後に Murata 2017 拡張部分を追加する
-5. 各 Phase ごとに、
-
+1. `docs/spec/spec.md`（本書）と `docs/adr/0001`〜`0004` を読み、前提・スコープを明文化する
+2. `docs/tasks/phase-NN/task-MMM.md` の設計に従い作業する
+3. Phase 0 を先に完了し、仕様・基盤・ADR を凍結する
+4. Phase 1〜2 で最小動作を確認する
+5. その後に Murata 2017 拡張部分（Phase 3a / 3.5 / 3b）を追加する
+6. 各 Phase ごとに、
    * 変更ファイル一覧
    * 実装内容
    * テスト結果
    * 残課題
      を `docs/reports/` に記録する
-6. 実装完了後、`outputs/example_run/` にサンプル結果を保存する
-
+7. 実装完了後、`outputs/example_run/` にサンプル結果を保存する


### PR DESCRIPTION
## 背景
3 視点レビュー（review-python / review-privacy / review-oss）で spec.md §11.4 の目的関数式が Murata 2017 式(1)(3) と乖離、§13.3 の秘匿性評価が DCR 中心で Ganev & De Cristofaro (2024) の proxy 限界を反映していないなどの重大指摘が出ていた。Phase 1 に入る前に仕様と根拠を同期させる必要があった。

## この変更で提供する価値
研究者・レビュアーが `docs/spec/spec.md` と `docs/spec/metrics.md` と `docs/adr/` の 3 箇所を辿るだけで、Murata 2017 再現仕様・秘匿性評価 3 層・設計判断の根拠を把握できる。

## 変更内容（論理単位）
- **spec.md 改訂**: §11.4 目的関数 2 モード併記、§13.3 秘匿性 3 層（proxy / CAP baseline MVP / MIA Phase5）再構成、§9 に Protocol + entry_points 追加、§11.5 ハード制約化、§16 Phase 0/3a/3.5/3b/6 追加、§17 synthpop-jp エントリ、§19 決定性/許容幅テスト分離
- **契約・仕様ドキュメントの骨子**: `docs/spec/data_contract.md`, `docs/spec/metrics.md`, `docs/spec/experiment_report_format.md`, `docs/experiment_plan.md`, `docs/assumptions.md`
- **ADR 5 本**: `docs/adr/README.md`（運用規約）+ 0001 内部表現 / 0002 目的関数正規化 / 0003 秘匿性 3 層 / 0004 命名・Apache-2.0（ユーザー承認 2026-04-23）

## 影響範囲
- 変更モジュール: `docs/` のみ（コード無改変）
- 他モジュールへの影響: #2（pyproject.toml）と #3（README）は本 PR 決定を参照する前提。ADR-0004 の命名と #2 / #3 が整合していることを確認
- 既存 API の互換性: N/A（コード未着手）

## テスト
- 追加テスト: なし（docs のみ）
- 手動確認: `grep -c synthetic_population docs/spec/spec.md` = 0、ADR 5 本が Status/Context/Decision/Consequences を持つ

## 実験 / 検証
- 実験: N/A
- 手動検証: spec.md 差分を 3 レビューの重大指摘と 1 対 1 でクロスチェック、相対リンクの整合

## 残課題
- [ ] 著者詳細（CITATION.cff に TODO 残り、#3 で対応）
- [ ] `docs/experiment_plan.md` の実験数値は Phase 3 着手前にユーザー操作で `git tag experiment-plan-v1` 凍結
- [ ] `docs/assumptions.md` の利用候補データセット最終確定は Phase 3.5 で

## レビュアーに特に見てほしい点
1. **§11.4 の 2 モード分離**: 原論文準拠モード（weight 無し）と研究拡張モード（rate 正規化 + weight）の記述が混同されていないか
2. **§13.3 の 3 層**: CAP を DCR より先に MVP 必須と位置付けた記述が研究として妥当か
3. **ADR-0003**: Ganev & De Cristofaro 2024 の引用根拠が正しいか

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)