### PR TITLE
[phase-1] SeedRegistry による決定的 seed 管理を実装する (#16)

### DIFF
--- a/src/synthpop_jp/rng.py
+++ b/src/synthpop_jp/rng.py
@@ -1,0 +1,167 @@
+"""乱数源の階層管理モジュール (SeedRegistry).
+
+## 目的
+
+実験の再現性（bitwise 一致）を保証するために、プロセス内で使う乱数発生器を
+**一箇所で管理** します。ファイルごとに `np.random.seed(42)` を呼ぶアンチパターンを
+防ぎ、同じ root seed を渡せば全工程で同一の乱数列が得られることを保証します。
+
+## 使い方
+
+```python
+from synthpop_jp.rng import SeedRegistry
+
+# root seed を固定してレジストリを作成
+reg = SeedRegistry(root=42)
+
+# ラベルで乱数源を取得
+rng_init = reg.rng("init")  # 初期人口生成用
+rng_sa = reg.rng("sa")  # SA 用
+rng_eval = reg.rng("eval")  # 評価用
+
+# rng_init / rng_sa / rng_eval はそれぞれ独立した乱数列を持つ
+counts = rng_init.multinomial(100, [0.3, 0.7])
+```
+
+## seed 運用ルール（詳細は docs/rules/seed-policy.md）
+
+1. **1 run につき 1 つの root seed** を決める。複数箇所で独立に seed を作らない。
+2. `SeedRegistry` 経由でのみ `np.random.Generator` を取得する。
+   直接 `np.random.default_rng()` / `np.random.seed()` は呼ばない。
+3. ラベルは処理の役割を表す名詞を使う（例: `"init"`, `"sa"`, `"eval"`, `"improve"`）。
+4. 同じ `(root, label)` の組みは常に同じ乱数列を返す。
+   ラベルの登録順序が変わっても seed は変わらない。
+5. 実験記録には root seed を必ず残す。`artifacts/<run_id>/seed.txt` に書く。
+
+## 内部実装の概要
+
+`np.random.SeedSequence` の階層 spawning と `hashlib.blake2b` を組み合わせます。
+
+- `SeedSequence(root)` を root 節点とします。
+- ラベル文字列を `hashlib.blake2b` でハッシュ化し、128 bit 整数に変換します。
+- この整数を `root_ss.spawn(1, entropy=hash_int)` の entropy として使い、
+  ラベルに一意な子 SeedSequence を取得します。
+- ハッシュ化により、ラベルの登録順序に依存しない決定的な seed を実現します。
+- `rng(label)` は毎回 `np.random.default_rng(child_ss)` で新しい Generator を
+  作って返します。同じラベルなら初期 state は常に同じです。
+
+## プラットフォーム差異への対応
+
+NumPy の `SeedSequence` はプラットフォーム（macOS / Linux）によらず
+同じ子 seed を生成します。endianness の影響を受けない整数型（int16 / int32）を
+dtype に使うことで、bitwise 一致が macOS と Linux の両方で成立します。
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+# ハッシュの切り出しバイト数。128 bit = 16 bytes を整数として使う。
+_HASH_BYTES = 16
+
+
+def _label_to_entropy(label: str) -> int:
+    """ラベル文字列を 128 bit 整数に変換する.
+
+    ``hashlib.blake2b`` を使い、衝突リスクを実用上無視できるレベルに抑えます。
+    同じラベルは常に同じ整数を返します。
+
+    Parameters
+    ----------
+    label : str
+        変換対象のラベル文字列。
+
+    Returns
+    -------
+    int
+        128 bit の非負整数。
+    """
+    digest = hashlib.blake2b(label.encode(), digest_size=_HASH_BYTES).digest()
+    return int.from_bytes(digest, byteorder="big")
+
+
+class SeedRegistry:
+    """階層 spawning による乱数源レジストリ.
+
+    同じ ``(root, label)`` の組みに対して常に同じ ``SeedSequence`` を返します。
+    ラベルのハッシュ値を entropy に使うため、登録順序に依存しない決定的な
+    seed 管理を実現します。
+
+    Parameters
+    ----------
+    root : int
+        根となる seed 値。実験の再現性を保証するために外部から注入します。
+
+    Examples
+    --------
+    >>> reg = SeedRegistry(root=42)
+    >>> gen = reg.rng("init")
+    >>> isinstance(gen, np.random.Generator)
+    True
+    """
+
+    def __init__(self, root: int) -> None:
+        self._root = root
+        self._root_ss = np.random.SeedSequence(root)
+        # ラベル → 子 SeedSequence のキャッシュ
+        self._cache: dict[str, np.random.SeedSequence] = {}
+
+    def spawn(self, label: str) -> np.random.SeedSequence:
+        """ラベルに対応する子 SeedSequence を返す.
+
+        同じ ``(root, label)`` の組みは常に同じ ``SeedSequence`` を返します。
+        ラベルの登録順序が変わっても結果は変わりません。
+
+        Parameters
+        ----------
+        label : str
+            乱数源を識別するラベル。役割を表す名詞を使う（例: ``"init"``, ``"sa"``）。
+
+        Returns
+        -------
+        np.random.SeedSequence
+            対応する子 SeedSequence。
+        """
+        if label not in self._cache:
+            # ラベルをハッシュ化して entropy に使い、順序非依存の子 seed を得る。
+            # root の entropy（int か Sequence[int]）と label_hash を組み合わせて
+            # 新たな SeedSequence を構築する。
+            label_hash = _label_to_entropy(label)
+            raw = self._root_ss.entropy
+            if isinstance(raw, int):
+                combined: int = raw ^ label_hash
+            else:
+                # Sequence[int] の場合は先頭要素のみ使う（実用上 int が大半）
+                first = int(raw[0]) if raw else 0
+                combined = first ^ label_hash
+            child_ss = np.random.SeedSequence(combined)
+            self._cache[label] = child_ss
+        return self._cache[label]
+
+    def rng(self, label: str) -> np.random.Generator:
+        """ラベルに対応する np.random.Generator を返す.
+
+        呼び出しのたびに **新しい** Generator オブジェクトを生成しますが、
+        内部の初期 state は同じ ``(root, label)`` なら常に同一です。
+        したがって、同じラベルで連続して呼び出しても、それぞれが
+        乱数列の先頭から独立して使えます。
+
+        Parameters
+        ----------
+        label : str
+            乱数源を識別するラベル。
+
+        Returns
+        -------
+        np.random.Generator
+            初期化済みの Generator。
+        """
+        child_ss = self.spawn(label)
+        return np.random.default_rng(child_ss)
+
+    def __repr__(self) -> str:
+        """デバッグ用の文字列表現."""
+        labels_repr = ", ".join(f'"{lb}"' for lb in self._cache)
+        return f"SeedRegistry(root={self._root}, labels=[{labels_repr}])"

--- a/tests/regression/test_approximate.py
+++ b/tests/regression/test_approximate.py
@@ -1,0 +1,50 @@
+"""許容幅テストのスケルトン（Phase 2 で実装予定）.
+
+決定性テスト（bitwise 一致）とは別に、SA の収束後スコアが
+初期スコアに対して一定割合（例: ±1%）以内に収まることを検証します。
+
+Phase 2 の SA 実装が完了したら、このファイルのスキップを解除して
+テスト本体を記述してください。
+
+Notes
+-----
+- 決定性テストとは分離して管理します（``test_determinism.py`` を参照）。
+- ``hypothesis`` の seed はここでは扱いません（テスト側の乱数は別系統）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip(reason="phase 2 で実装予定: SA MVP 完成後にスキップを解除する")
+class TestApproximateConvergence:
+    """SA 実行後のスコアが許容幅 (±1%) に収まることを検証する.
+
+    Phase 2 の Exit 条件:
+      - seed=42 で evals_per_agent=1000 を実行したとき、
+        best_score が初期スコアの 30% 以下になること。
+
+    参考: action-plan.md §3.4 Phase 2 Exit 条件
+    """
+
+    def test_best_score_below_threshold(self) -> None:
+        """SA 後の best_score が初期スコアの 30% 以下であることを確認する.
+
+        TODO (Phase 2): SA runner が実装されたら、以下の疑似コードを実装する::
+
+            from synthpop_jp.rng import SeedRegistry
+            from synthpop_jp.optimize.runner import run_sa
+
+            reg = SeedRegistry(root=42)
+            result = run_sa(reg=reg, evals_per_agent=1000, ...)
+            assert result.best_score <= result.initial_score * 0.30
+        """
+        raise NotImplementedError("Phase 2 で実装する")
+
+    def test_score_within_tolerance_across_seeds(self) -> None:
+        """複数の seed で best_score が ±1% 以内のばらつきであることを確認する.
+
+        TODO (Phase 2): 複数 seed でのスコアばらつきを許容幅テストで保護する。
+        """
+        raise NotImplementedError("Phase 2 で実装する")

--- a/tests/regression/test_determinism.py
+++ b/tests/regression/test_determinism.py
@@ -1,0 +1,185 @@
+"""決定性回帰テスト.
+
+同じ seed を渡すと bitwise 一致の出力が得られることを検証します。
+
+## テスト対象
+
+1. ``SeedRegistry`` の決定性（単体）
+2. ``scripts/generate_sample_case.py`` の bitwise 一致（sha256 比較）
+
+Issue #16 の成功条件「同 seed で bitwise 一致」を CI の regression guard として実装します。
+SA 決定性（Phase 2）や評価器決定性（Phase 3.5）はスコープ外のため、ここでは触りません。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from synthpop_jp.rng import SeedRegistry
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parents[4]
+_GENERATE_SCRIPT = _REPO_ROOT / "scripts" / "generate_sample_case.py"
+_SAMPLE_CASE_DIR = _REPO_ROOT / "data" / "sample_case"
+
+_SAMPLE_CASE_FILES = [
+    "family_type_counts.csv",
+    "children_count_dist.csv",
+    "demographic_by_age_sex.csv",
+    "age_diff_parent_child.csv",
+    "age_diff_couple.csv",
+    "demographic_by_family_type_role.csv",
+    "household_size_by_family_type.csv",
+]
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _sha256(path: Path) -> str:
+    """ファイルの SHA-256 ハッシュを文字列で返す."""
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _run_generate(output_dir: Path) -> None:
+    """generate_sample_case.py を output_dir に向けて実行する."""
+    result = subprocess.run(
+        [sys.executable, str(_GENERATE_SCRIPT), "--output-dir", str(output_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"generate_sample_case.py failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 補完: SeedRegistry の決定性（integration 寄りの確認）
+# ---------------------------------------------------------------------------
+
+
+class TestSeedRegistryDeterminism:
+    """SeedRegistry が issue #16 の成功条件を満たすことを確認する."""
+
+    def test_same_root_same_label_bitwise_equal_samples(self) -> None:
+        """同じ (root, label) で生成した乱数配列が bitwise 一致する."""
+        reg1 = SeedRegistry(root=42)
+        reg2 = SeedRegistry(root=42)
+
+        arr1 = reg1.rng("init").integers(0, 10000, size=1000)
+        arr2 = reg2.rng("init").integers(0, 10000, size=1000)
+
+        np.testing.assert_array_equal(arr1, arr2)
+
+    def test_init_sa_bitwise_different(self) -> None:
+        """'init' と 'sa' は同じ root でも異なる乱数列を生成する."""
+        reg = SeedRegistry(root=42)
+
+        arr_init = reg.rng("init").integers(0, 10000, size=1000)
+        arr_sa = reg.rng("sa").integers(0, 10000, size=1000)
+
+        assert not np.array_equal(arr_init, arr_sa), (
+            "'init' と 'sa' の乱数列が一致した（seed 分離が失敗している）"
+        )
+
+    def test_multinomial_bitwise_equal(self) -> None:
+        """multinomial のような用途でも bitwise 一致する（generate_sample_case の手本）."""
+        probs = np.array([0.15, 0.20, 0.30, 0.05, 0.08, 0.05, 0.05, 0.07, 0.05])
+
+        reg1 = SeedRegistry(root=42)
+        reg2 = SeedRegistry(root=42)
+
+        result1 = reg1.rng("init").multinomial(100, probs)
+        result2 = reg2.rng("init").multinomial(100, probs)
+
+        np.testing.assert_array_equal(result1, result2)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: generate_sample_case.py の bitwise 一致 regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestGenerateSampleCaseBitwiseEqual:
+    """``scripts/generate_sample_case.py`` を 2 回実行して SHA-256 一致を確認する.
+
+    Issue #12 で確立した「seed=42 で 2 回実行すると bitwise 一致」の挙動を
+    回帰テストとして保護します。
+
+    Notes
+    -----
+    スクリプトは ``data/sample_case/`` に直接書き込むため、実行前後でファイルが
+    存在することが前提です。テスト用一時ディレクトリに書き込む方式を採用しています。
+    """
+
+    def test_generate_twice_sha256_identical(self, tmp_path: Path) -> None:
+        """2 回生成した CSV の SHA-256 が全ファイルで一致する."""
+        run1_dir = tmp_path / "run1"
+        run2_dir = tmp_path / "run2"
+
+        _run_generate(run1_dir)
+        _run_generate(run2_dir)
+
+        for filename in _SAMPLE_CASE_FILES:
+            path1 = run1_dir / filename
+            path2 = run2_dir / filename
+
+            assert path1.exists(), f"run1 に {filename} が存在しない"
+            assert path2.exists(), f"run2 に {filename} が存在しない"
+
+            sha1 = _sha256(path1)
+            sha2 = _sha256(path2)
+
+            assert sha1 == sha2, (
+                f"{filename}: 2 回の生成結果が一致しない\n"
+                f"  run1 sha256: {sha1}\n"
+                f"  run2 sha256: {sha2}"
+            )
+
+    def test_generate_matches_committed_data(self) -> None:
+        """コミット済みの data/sample_case/ と新規生成の SHA-256 が一致する.
+
+        既存の data/sample_case/ が存在しない場合はスキップします。
+        """
+        if not _SAMPLE_CASE_DIR.exists():
+            pytest.skip("data/sample_case/ が存在しないためスキップ")
+
+        missing = [f for f in _SAMPLE_CASE_FILES if not (_SAMPLE_CASE_DIR / f).exists()]
+        if missing:
+            pytest.skip(f"data/sample_case/ に不足ファイルあり: {missing}")
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            fresh_dir = Path(td) / "fresh"
+            _run_generate(fresh_dir)
+
+            for filename in _SAMPLE_CASE_FILES:
+                committed = _SAMPLE_CASE_DIR / filename
+                fresh = fresh_dir / filename
+
+                sha_committed = _sha256(committed)
+                sha_fresh = _sha256(fresh)
+
+                assert sha_committed == sha_fresh, (
+                    f"{filename}: コミット済みデータと新規生成が一致しない\n"
+                    f"  committed sha256: {sha_committed}\n"
+                    f"  fresh    sha256:  {sha_fresh}\n"
+                    "  → numpy バージョンが変わったか、スクリプトが変更された可能性があります。"
+                )

--- a/tests/regression/test_determinism.py
+++ b/tests/regression/test_determinism.py
@@ -27,7 +27,22 @@ from synthpop_jp.rng import SeedRegistry
 # 定数
 # ---------------------------------------------------------------------------
 
-_REPO_ROOT = Path(__file__).parents[4]
+
+def _find_repo_root() -> Path:
+    """`pyproject.toml` を含む最近接の祖先ディレクトリを repo root とみなす.
+
+    worktree 利用時と CI チェックアウト時で階層数が異なるため、
+    ``Path(__file__).parents[N]`` の固定 index ではなく
+    マーカーファイルで探索する。
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError(f"pyproject.toml が {here} から辿れない階層に見つからない")
+
+
+_REPO_ROOT = _find_repo_root()
 _GENERATE_SCRIPT = _REPO_ROOT / "scripts" / "generate_sample_case.py"
 _SAMPLE_CASE_DIR = _REPO_ROOT / "data" / "sample_case"
 

--- a/tests/unit/test_rng.py
+++ b/tests/unit/test_rng.py
@@ -1,0 +1,191 @@
+"""Unit tests for SeedRegistry.
+
+TDD: tests are written before the implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthpop_jp.rng import SeedRegistry
+
+# ---------------------------------------------------------------------------
+# Cycle 1: 決定性 — 同 root + 同 label → 同 SeedSequence
+# ---------------------------------------------------------------------------
+
+
+class TestSeedDeterminism:
+    """同じ (root, label) は常に同じ SeedSequence を返す."""
+
+    def test_same_root_same_label_returns_same_seed(self) -> None:
+        """同じ root と label を渡すと毎回同じ SeedSequence を返す."""
+        reg1 = SeedRegistry(root=42)
+        reg2 = SeedRegistry(root=42)
+
+        seq1 = reg1.spawn("init")
+        seq2 = reg2.spawn("init")
+
+        # SeedSequence は直接比較できないため state を比較する
+        assert seq1.state == seq2.state
+
+    def test_same_registry_spawn_twice_returns_same_seed(self) -> None:
+        """同一レジストリで同じラベルを 2 回呼んでも同じ SeedSequence."""
+        reg = SeedRegistry(root=42)
+
+        seq1 = reg.spawn("init")
+        seq2 = reg.spawn("init")
+
+        assert seq1.state == seq2.state
+
+    def test_different_root_returns_different_seed(self) -> None:
+        """異なる root では異なる SeedSequence を返す."""
+        reg1 = SeedRegistry(root=42)
+        reg2 = SeedRegistry(root=99)
+
+        seq1 = reg1.spawn("init")
+        seq2 = reg2.spawn("init")
+
+        assert seq1.state != seq2.state
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: ユニーク性 — 異なる label → 異なる SeedSequence
+# ---------------------------------------------------------------------------
+
+
+class TestSeedUniqueness:
+    """異なるラベルは異なる SeedSequence を返す."""
+
+    def test_different_labels_return_different_seeds(self) -> None:
+        """同じ root でも label が違えば SeedSequence が異なる."""
+        reg = SeedRegistry(root=42)
+
+        seq_init = reg.spawn("init")
+        seq_sa = reg.spawn("sa")
+        seq_eval = reg.spawn("eval")
+
+        assert seq_init.state != seq_sa.state
+        assert seq_sa.state != seq_eval.state
+        assert seq_init.state != seq_eval.state
+
+    def test_spawn_order_independent(self) -> None:
+        """ラベルを登録する順序が変わっても、同 (root, label) の seed は変わらない."""
+        reg_forward = SeedRegistry(root=42)
+        _ = reg_forward.spawn("init")
+        _ = reg_forward.spawn("sa")
+        _ = reg_forward.spawn("eval")
+
+        reg_reverse = SeedRegistry(root=42)
+        _ = reg_reverse.spawn("eval")
+        _ = reg_reverse.spawn("sa")
+        seq_eval_reverse = reg_reverse.spawn("init")
+
+        # init の state は順序によらず同一であるべき
+        reg_ref = SeedRegistry(root=42)
+        seq_init_ref = reg_ref.spawn("init")
+
+        assert seq_eval_reverse.state == seq_init_ref.state
+
+    def test_many_labels_all_unique(self) -> None:
+        """複数のラベルをまとめて登録しても、すべて異なる SeedSequence になる."""
+        reg = SeedRegistry(root=42)
+        labels = ["init", "sa", "eval", "improve", "benchmark"]
+        sequences = [reg.spawn(label) for label in labels]
+
+        states = [seq.state for seq in sequences]
+        # すべて異なることを確認
+        assert len(states) == len(set(str(s) for s in states))
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: rng() — np.random.Generator を返し、同ラベルで同一初期状態
+# ---------------------------------------------------------------------------
+
+
+class TestSeedRegistryRng:
+    """rng(label) は同じ label に対して同じ初期状態の Generator を返す."""
+
+    def test_rng_returns_generator(self) -> None:
+        """`rng` の戻り値が np.random.Generator であることを確認."""
+        reg = SeedRegistry(root=42)
+        gen = reg.rng("init")
+        assert isinstance(gen, np.random.Generator)
+
+    def test_rng_same_label_same_initial_state(self) -> None:
+        """同じ label で rng() を 2 回呼ぶと同じ乱数列を生成する."""
+        reg1 = SeedRegistry(root=42)
+        reg2 = SeedRegistry(root=42)
+
+        gen1 = reg1.rng("init")
+        gen2 = reg2.rng("init")
+
+        # 乱数列が一致することで初期状態が同じであることを検証
+        samples1 = gen1.integers(0, 1000, size=10)
+        samples2 = gen2.integers(0, 1000, size=10)
+
+        np.testing.assert_array_equal(samples1, samples2)
+
+    def test_rng_different_labels_different_sequences(self) -> None:
+        """異なる label の rng() は異なる乱数列を生成する."""
+        reg = SeedRegistry(root=42)
+
+        gen_init = reg.rng("init")
+        gen_sa = reg.rng("sa")
+
+        samples_init = gen_init.integers(0, 1000, size=10)
+        samples_sa = gen_sa.integers(0, 1000, size=10)
+
+        # 確率的にほぼ必ず異なる（同一の確率は 1/1000^10 以下）
+        assert not np.array_equal(samples_init, samples_sa)
+
+    def test_rng_each_call_returns_fresh_generator(self) -> None:
+        """同一レジストリで同じ label を 2 回呼ぶと、それぞれ新しい Generator を返す."""
+        reg = SeedRegistry(root=42)
+
+        gen_a = reg.rng("init")
+        # 1 回目の Generator から数値を消費する
+        _ = gen_a.integers(0, 100, size=5)
+
+        # 2 回目の呼び出しは初期状態から始まる新しい Generator
+        gen_b = reg.rng("init")
+        first_from_b = gen_b.integers(0, 100, size=5)
+
+        # gen_a と gen_b の最初の 5 個は同じはず（初期状態が等しい）
+        gen_c = reg.rng("init")
+        first_from_c = gen_c.integers(0, 100, size=5)
+
+        np.testing.assert_array_equal(first_from_b, first_from_c)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 追加: Cycle 2 の spawn_order_independent テストの補足
+# ---------------------------------------------------------------------------
+
+
+class TestSeedRegistryIndexStability:
+    """ラベルの登録順序と index 安定性の詳細確認."""
+
+    def test_first_label_index_stable_regardless_of_later_additions(self) -> None:
+        """最初に登録したラベルの seed は、後から別ラベルが追加されても変わらない."""
+        reg_a = SeedRegistry(root=42)
+        seq_init_only = reg_a.spawn("init")
+
+        reg_b = SeedRegistry(root=42)
+        seq_init_then_sa = reg_b.spawn("init")
+        _seq_sa = reg_b.spawn("sa")
+
+        # init の seed は sa の追加後も変わらない
+        assert seq_init_only.state == seq_init_then_sa.state
+
+    def test_repr_contains_root(self) -> None:
+        """`repr` に root 値が含まれる（デバッグ容易性の確認）."""
+        reg = SeedRegistry(root=42)
+        assert "42" in repr(reg)
+
+    @pytest.mark.parametrize("root", [0, 1, 42, 12345, 2**31 - 1])
+    def test_various_roots_produce_deterministic_seeds(self, root: int) -> None:
+        """さまざまな root 値で決定性が保たれる."""
+        reg1 = SeedRegistry(root=root)
+        reg2 = SeedRegistry(root=root)
+        assert reg1.spawn("init").state == reg2.spawn("init").state


### PR DESCRIPTION
## 概要

Issue #16 の実装です。`SeedRegistry`（`np.random.SeedSequence` 階層 spawning + `hashlib.blake2b`）を追加し、「同じ root seed を渡すと bitwise 一致の乱数列が得られる」ことを TDD で保証します。

## 変更内容

- `src/synthpop_jp/rng.py`（新規）: `SeedRegistry` クラス + `_label_to_entropy` ヘルパー
- `tests/unit/test_rng.py`（新規）: 決定性・ユニーク性・Generator 再現性の単体テスト（17 ケース）
- `tests/regression/test_determinism.py`（新規）: `SeedRegistry` の integration テスト + `generate_sample_case.py` の sha256 bitwise 一致 regression guard（5 ケース）
- `tests/regression/test_approximate.py`（新規）: Phase 2 向け許容幅テストの skeleton（`@pytest.mark.skip` で先置き）

## 設計のポイント

- `blake2b(label)` でラベルを 128 bit 整数化し `root ^ label_hash` を entropy に使う → ラベルの登録順序に依存しない決定的 seed
- 返り値は `np.random.Generator`（`default_rng` 経由）。呼ぶたびに新しいオブジェクトだが初期 state は同じ
- `SeedSequence` は macOS / Linux でプラットフォーム差異なし（endianness 独立）

## テスト結果

```
74 passed, 2 skipped in 1.15s
ruff check: passed
ruff format: passed
pyright: 0 errors, 1 warning (pandas stub 欠け、既存)
```

## 非スコープ（今 PR では触らない）

- SA 決定性テスト（Phase 2）
- 評価器決定性テスト（Phase 3.5）
- 初期人口生成（Issue #14）への `SeedRegistry` 注入

Closes #16