### PR TITLE
[#23] リリース担当者が Phase 1 の変更点を CHANGELOG から追えるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+Phase 1 完了（2026-04-24）。合成人口生成の I/O・初期生成パイプラインと決定性担保が揃い、`synthpop-jp quickstart` コマンド 1 つで synthetic_households.csv と synthetic_persons.csv を生成できるようになった。これにより Phase 2（SA MVP）の土台が整った。
+
 ### Added
 - Apache-2.0 LICENSE と NOTICE を追加
 - CITATION.cff、CODE_OF_CONDUCT.md、CONTRIBUTING.md、DATASET.md を追加
 - README.md（日本語 primary）と README.en.md（英語骨子）を追加
 - Murata 2017 / Harada 2024 の位置付けを README 冒頭に明記
+- Phase 1: 研究者が壊れた CSV を渡すと行番号付きで検証エラーが出る pydantic v2 ローダ ([#17](https://github.com/gghatano/synth-pop-harada-2024/pull/17), [Issue #12](https://github.com/gghatano/synth-pop-harada-2024/issues/12))
+- Phase 1: SeedRegistry による階層 spawning と bitwise 一致の決定性 regression テスト ([#18](https://github.com/gghatano/synth-pop-harada-2024/pull/18), [Issue #16](https://github.com/gghatano/synth-pop-harada-2024/issues/16))
+- Phase 1: SA 実装者が並列配列とドメインモデルを迷わず往復できる PopulationArrays + Registry + Household/Person ドメインモデル ([#19](https://github.com/gghatano/synth-pop-harada-2024/pull/19), [Issue #13](https://github.com/gghatano/synth-pop-harada-2024/issues/13))
+- Phase 1: 9 family_type から統計に一致する初期人口をランダム生成する generate_initial_population ([#20](https://github.com/gghatano/synth-pop-harada-2024/pull/20), [Issue #14](https://github.com/gghatano/synth-pop-harada-2024/issues/14))
+- Phase 1: `synthpop-jp quickstart` / `validate-config` CLI で 10 秒以内（実測約 1.1 秒）に synthetic_households.csv と synthetic_persons.csv を得られる ([#21](https://github.com/gghatano/synth-pop-harada-2024/pull/21), [Issue #15](https://github.com/gghatano/synth-pop-harada-2024/issues/15))
 
 ### Changed
 - (なし)


### PR DESCRIPTION
## 背景

`CHANGELOG.md` の `[Unreleased]` 節は Phase 0 分のみ記録されており、Phase 1 で develop に入った 5 PR（#17, #18, #19, #20, #21）の変更点が未記録だった。v0.1.0 alpha リリース時に CHANGELOG を参照するリリース担当者が困らないよう、Phase 1 分を遡及追記する。

Closes #23

## この変更で提供する価値

リリース担当者が `CHANGELOG.md` の `[Unreleased]` 節を読むだけで、Phase 1 で何が利用可能になったかを 30 秒で把握できる。

## 変更内容

- `[Unreleased]` の `### Added` 直前に Phase 1 完了サマリ段落（2026-04-24 付）を挿入
- Phase 1 の 5 PR 分のエントリを利用者視点の表現で追記（各 PR 番号・Issue 番号リンク付き）
  - #17 / Issue #12: pydantic v2 ローダ（行番号付き検証エラー）
  - #18 / Issue #16: SeedRegistry + 決定性 regression テスト
  - #19 / Issue #13: PopulationArrays + Registry + ドメインモデル
  - #20 / Issue #14: generate_initial_population（9 family_type）
  - #21 / Issue #15: `synthpop-jp quickstart` / `validate-config` CLI（実測約 1.1 秒）

## 影響範囲

- 変更モジュール: `CHANGELOG.md` のみ
- 他モジュールへの影響: なし
- 既存 API の互換性: なし
- 依存関係の変化: なし

## テスト

- 追加テスト: 0 件（Markdown 変更のみ。TDD 対象外）
- 変更テスト: 0 件
- カバレッジ: 維持（191 passed, 2 skipped）
- 手動確認: あり（`cat CHANGELOG.md` で目視確認、全 5 エントリとリンクを確認）

<details>
<summary>実行コマンドと結果（抜粋）</summary>

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
66 files already formatted

$ uv run pyright
0 errors, 1 warning, 0 informations

$ uv run pytest
191 passed, 2 skipped in 2.39s

$ time uv run synthpop-jp quickstart
（省略）
uv run synthpop-jp quickstart  1.11s user 0.42s system 22% cpu 6.682 total
```

</details>

## 実験 / 検証

該当なし（ドキュメント変更のみ）

## 残課題

- [ ] PR マージ時に CHANGELOG を更新する運用ルールの明文化（別 Issue で対応予定）

## レビュアーに特に見てほしい点

- 各エントリの利用者視点の表現が適切か（技術者でない関係者にも伝わるか）
- quickstart 実測値「約 1.1 秒」の記載が誠実かつ正確か

## 自己点検（PR 作成者が確認）

- [x] `origin/develop` を取り込み済みで、コンフリクトなし
- [x] すべてのテストが green
- [x] 実験を伴わない変更（Markdown のみ）
- [x] Issue の成功条件を満たしていると自信を持って言える
- [x] 非技術者に 1 段落で説明できる
- [x] 関連 Issue を `Closes #23` でリンクした