### PR TITLE
[#22] Phase 0-1 の知見を skill・rule に反映し次 Phase の事故を減らす

### DIFF
--- a/.claude/skills/2_issue_impl.md
+++ b/.claude/skills/2_issue_impl.md
@@ -60,10 +60,17 @@ description: 段階 1 で固めた計画に基づいて TDD で実装を進め�
 ## 完了条件
 
 - [ ] 計画で挙げたテスト観点のうち、必須項目がすべてテストとして存在する
-- [ ] すべてのテストが通る（`pytest` / `uv run pytest` が green）
+- [ ] CI と同一の以下 4 コマンドを **すべて引数なし** で走らせて green（詳細: [`docs/rules/ci-parity.md`](../../docs/rules/ci-parity.md)）
+  ```bash
+  uv run ruff check .
+  uv run ruff format --check .
+  uv run pyright
+  uv run pytest
+  ```
+  - `uv run pyright src/` のような部分検査で済ませるのは **不可**（tests 側の型エラーを見落とす。PR #17 / #18 の再発防止）
 - [ ] 実験を行った場合、seed と設定が再現可能な形で保存されている
 - [ ] 実験結果は Markdown レポート化されている（HTML 化は段階 3 以降でも可）
-- [ ] コミットが意味単位で小さく分かれている
+- [ ] 各 TDD サイクルが **`test:` コミットと `feat:` コミットに分離** されている（詳細は下の「コミット単位」節）
 
 ## 注意点
 
@@ -81,6 +88,31 @@ description: 段階 1 で固めた計画に基づいて TDD で実装を進め�
 | 最小実装 | `feat: add delta.apply for SA iteration` | `WIP SA` |
 | 整理 | `refactor: move Pop dtype into types module` | `misc cleanup` |
 | 設定変更 | `chore: pin numpy>=2.0 in pyproject` | `update deps` |
+
+### 1 TDD サイクル = 最低 2 コミット
+
+**test コミットと feat コミットを同一コミットにまとめない**。
+Phase 1 の Issue #13 実装時、1 コミットに test と src が混入して「Red の段階で実行したら本当に落ちたのか」が後追いできなくなる事案があった。
+
+正しい粒度:
+
+```
+test: add property test for PopulationArrays roundtrip (refs #13)
+feat: implement PopulationArrays.from_households (refs #13)
+```
+
+誤った粒度:
+
+```
+feat: implement PopulationArrays.from_households with tests (refs #13)   # NG: test+feat 混在
+```
+
+`refactor:` コミットは同一サイクル内で必要なときだけ追加する。テストを変えない整理のみ `refactor:` を名乗る。
+
+### コミット前に必須の検査
+
+各コミット前に `uv run pyright`（引数なし、src+tests 両方）を少なくとも 1 度走らせる。
+`uv run pyright src/` で済ませると、tests 側で Literal 外の値を渡すテストや pytest.approx の型不明が見逃される（PR #17 で実際に発生）。
 
 ## GitHub Issue に追記すべきこと（実装中）
 

--- a/.claude/skills/4_create_pr.md
+++ b/.claude/skills/4_create_pr.md
@@ -54,19 +54,27 @@ description: 自己レビュー済みの変更を `develop` 向けの PR にす�
    - レビュアーに特に見てほしい点
 5. **Draft → Ready に切り替える**
    - CI（テスト・lint・型チェック）が全部通ってから Ready にする
+   - **Draft PR は自動で Ready にならない**。明示的に `gh pr ready <番号>` を叩く
    - Ready 切り替えと同時に、レビュアーを指名する
 6. **レビューコメントへの対応ループ**
    - 指摘を受けたら feature ブランチに commit する（force push は基本しない）
    - コメントに返信する際、対応コミット SHA を添える
    - 追加実装があれば段階 2 / 3 に戻り、再度自己レビューしてから Ready 更新
-7. **merge 後の後片付け**
-   - merge 完了後、ローカルの worktree を削除
-     ```bash
-     cd <repo_root>
-     git worktree remove gitworktree/feature-<issue番号>-<keyword>
-     git branch -d feature/<issue番号>-<keyword>
-     ```
-   - 対応 Issue を close（PR 本文に `Closes #<番号>` を書いていれば自動 close される）
+7. **squash merge**
+   ```bash
+   gh pr merge <番号> --squash --delete-branch
+   ```
+   - `--squash` は本リポジトリの既定（`docs/rules/branch-strategy.md` §5 参照）
+   - `--delete-branch` はリモートの feature ブランチを消す。ローカル worktree が使用中の場合は **ローカル削除のみ失敗** してリモートは消える（想定内）
+8. **merge 後の後片付け**（詳細: [`docs/rules/git-worktree.md`](../../docs/rules/git-worktree.md) §3.5）
+   ```bash
+   cd <repo_root>
+   git worktree remove gitworktree/feature-<issue番号>-<keyword>
+   git branch -D feature/<issue番号>-<keyword>   # ローカルが残っていれば
+   git checkout develop
+   git pull --ff-only
+   ```
+   - 対応 Issue は PR 本文の `Closes #<番号>` で自動 close
    - HTML レポートの公開場所（もしあれば）にデプロイするコマンドを実行
 
 ## 出力物
@@ -79,9 +87,10 @@ description: 自己レビュー済みの変更を `develop` 向けの PR にす�
 
 - [ ] PR タイトルが `[#<issue番号>] <価値を示す短い動詞句>` 形式
 - [ ] PR 本文のテンプレ欄がすべて埋まっている
-- [ ] CI がすべて green
+- [ ] CI がすべて green（手元で 4 コマンドが通り、GitHub Actions でも通った）
 - [ ] 実験がある場合 HTML レポートへのリンクが本文にある
 - [ ] Issue と PR が相互にリンクされている（`Closes #<番号>`）
+- [ ] Draft → Ready → squash merge → worktree 片付け、までが完了している
 
 ## 注意点
 

--- a/.claude/skills/multi_agent_orchestration.md
+++ b/.claude/skills/multi_agent_orchestration.md
@@ -1,0 +1,204 @@
+---
+name: multi_agent_orchestration
+description: 複数 Issue を並列に進めるために、Claude Code の親セッションがサブエージェント（Task tool / Agent tool）を呼び分けるときの運用を定める。プロンプト雛形と依存関係の受け渡しを含む。
+---
+
+# SKILL: multi_agent_orchestration — サブエージェント並列実行の運用
+
+## 目的
+
+Phase が進むにつれて 1 Phase 内で 3〜6 Issue を並列に回す必要が出てくる。単に並列に `Agent` tool を呼ぶだけでは、
+
+- サブエージェントが先行 PR の API を把握できず、develop の古い HEAD を参照する
+- `1_issue_plan` / `3_review_and_refactor` の Issue コメント投稿を省略する
+- worktree を自前で作ってルールに合わない場所に置く
+
+といった事故が起きる。本 skill は、**親セッションがサブエージェントに渡すプロンプトに必ず入れるべき要素** をまとめる。
+
+## 使う場面
+
+- 1 Phase で 3 本以上の Issue を並列・直列に回すとき
+- 既存 PR の API に依存する新 Issue のサブエージェントを起動するとき
+- 長時間かかる実装をバックグラウンド agent に任せるとき
+
+## 親セッションの責務
+
+サブエージェントを起動する前に、以下 5 点を **親セッション側で済ませる**:
+
+1. **Issue を value_driven テンプレで起票** する（`.claude/skills/0_issue_create.md` に従う）。サブエージェントは起票しない
+2. **worktree を作成** する（`develop` 起点、命名規則は `docs/rules/git-worktree.md`）
+3. **worktree で `uv sync --frozen` と baseline 検査**（pytest / pyright）を走らせて green を確認
+4. **依存 PR の merged commit hash と使える API を整理** する
+5. サブエージェントに渡すプロンプトに以下を**絶対パスで**含める
+
+## サブエージェントプロンプトに含める必須要素
+
+### A. 固定情報ブロック
+
+```
+- リポジトリ: <絶対パス>
+- **作業ディレクトリ（必ずこの worktree 内で作業する）**: <絶対パス>
+- ブランチ: feature/<N>-<keyword>（origin/develop 起点、worktree 作成済、uv sync 済、<baseline テスト数> passed / pyright 0 errors を確認済）
+- base branch: develop
+- Issue: https://github.com/<owner>/<repo>/issues/<N>
+- Issue 本文（スコープ / 成功条件 / 非スコープ）は `gh issue view <N>` で読める。すべてそこに書かれている前提を守る。
+```
+
+### B. 依存する先行 PR の成果
+
+```
+## 前置き: 依存する先行 PR の成果（すべて develop に merged 済）
+
+### Issue #<A> merged (commit <hash>)
+- `<使えるモジュールパス>`: 提供 API の 1 文説明
+- ...
+
+### Issue #<B> merged (commit <hash>)
+- ...
+```
+
+サブエージェントは `git log` から依存を推定する代わりに、**この節をそのまま信じて実装する**。
+親セッションは直前の `git log develop --oneline -N` で hash を確認する。
+
+### C. 守るべき rule の明示列挙
+
+最低でも以下を列挙する:
+
+```
+- `CLAUDE.md` と `docs/rules/{tdd,issue-driven-development,branch-strategy,git-worktree,ci-parity,documentation-style}.md` に従う。
+- skill 運用:
+  - `.claude/skills/1_issue_plan.md` → plan を **Issue #<N> のコメント**として投稿。docs/plans に別ファイルは作らない。
+  - `.claude/skills/2_issue_impl.md` → TDD で Red → Green → Refactor、test と feat は別 commit。
+  - `.claude/skills/3_review_and_refactor.md` → 自己レビューサマリを Issue #<N> にコメントで投稿。
+  - `.claude/skills/4_create_pr.md` → develop 向け Draft PR を作成、本文末尾に `Closes #<N>`。
+- **TDD 厳守**。新振る舞いには先に落ちるテスト。
+- commit は Claude Opus 4.7 の Co-Authored-By trailer を含めて署名（HEREDOC）。
+- hooks skip 禁止（--no-verify）。
+- **CI と同じ順で手元検査**: `uv run ruff check .` → `uv run ruff format --check .` → `uv run pyright`（src+tests）→ `uv run pytest`。詳細は `docs/rules/ci-parity.md`。
+- 非スコープ（Issue 明記）には手を出さない。
+```
+
+### D. 想定規模と分割判断基準
+
+```
+## 想定規模
+
+<N>〜<M> 行の実装 + <X>〜<Y> 行のテスト。これより膨らむなら非スコープに逃がす判断をして plan comment を更新する。
+```
+
+「想定規模」は親セッションが Issue 本文とコードベースの読みから立てる見積り。
+**実装中に規模が倍を超えそうなら、サブエージェントは plan comment を更新し、親セッションに報告する**。
+
+### E. 戻り値フォーマット
+
+```
+## 戻り値
+
+以下を含む完了レポートを 300 語以内で返す:
+- PR URL
+- 追加・変更ファイル（合計数と主要な行）
+- 合計コミット数、テスト数
+- 未解決の論点 / レビュー依頼事項
+- CI（もし手元で走らせたもの）の結果
+```
+
+短い固定フォーマットで戻すことで、親セッションのコンテキストが膨れない。
+
+## 並列起動の判断
+
+### 並列可能な条件
+
+- 2 つ以上の Issue が **直接の依存を持たない**（一方の PR が merged にならなくても他方が始められる）
+- 変更ファイルに明確な重複がない（`src/` の同一ファイルを 2 エージェントが同時に触るのは避ける）
+- 親セッションが **両方の monitor を並行して回せる**（Monitor tool）
+
+### 直列にすべき条件
+
+- Issue B の plan / impl で Issue A の API を前提にしている
+- 同一モジュール（`cli.py`, `config.py` など）を両方が変更する可能性がある
+
+### 例: Phase 1 の実行順序
+
+```
+Issue #12 (data contract)                          # 先行、他 4 つの土台
+  └─ merge
+     ├─ Issue #13 (PopulationArrays)  ┐            # #12 に依存、両者は独立
+     └─ Issue #16 (SeedRegistry)      ┘ 並列可
+        └─ いずれか merge
+           └─ Issue #14 (initial population)       # #13 と #16 両方を利用
+              └─ merge
+                 └─ Issue #15 (quickstart CLI)     # #14 を利用
+```
+
+## 親セッションの監視ループ
+
+サブエージェントを `run_in_background: true` で起動したら:
+
+1. 完了通知（task-notification）を待つ。**polling や output file の tail はしない**
+2. 進捗確認が必要なら **worktree の `git log origin/develop..HEAD` と `git diff --stat`** で代替する
+3. 完了したら:
+   - worktree 内で手元 CI 4 コマンドを走らせる
+   - GitHub CI 結果を `gh pr checks <N>` で確認（`Monitor` tool で失敗時に通知を受ける）
+   - 失敗していれば原因を最小修正して push、再度 CI を待つ
+   - 緑になったら `gh pr ready <N>` → `gh pr merge <N> --squash --delete-branch`
+   - worktree を片付ける（`docs/rules/git-worktree.md` §3.5）
+
+## 完了条件
+
+- [ ] サブエージェントに A〜E の必須要素を含むプロンプトを渡した
+- [ ] 依存 PR の merged commit hash を `git log` で確認してからプロンプトに記載した
+- [ ] 並列起動した場合、各 Agent の作業ディレクトリが別 worktree になっている
+- [ ] 完了通知を待つ間、親セッションは他 Issue の準備か user への進捗報告に専念
+- [ ] サブエージェントが残した plan / review コメントを Issue 上で確認した
+
+## 注意点
+
+- **プロンプトから短縮語を減らす**。「plan を投稿」ではなく「`gh issue comment <N> --body ...` で plan を Issue コメントとして投稿」と具体的に書く
+- **pyright の引数なし実行を明示的に要求**。「pyright が通ること」ではなく「`uv run pyright`（引数なし）が 0 errors」と書かないと、サブエージェントは `pyright src/` で済ませる
+- **サブエージェントに Agent を再帰起動させない**。階層が深くなると管理不能になる。本 skill は親セッション 1 階層のみを想定
+- **失敗の責任は親セッションにある**。CI 失敗はサブエージェントのプロンプト不足か親セッションの監視不足のどちらかとして振り返る
+
+## プロンプト雛形（コピー用）
+
+```markdown
+あなたは synthpop-jp プロジェクトの <ロール> として、GitHub Issue #<N>「<タイトル>」を 5 段階フローで実装する。
+
+## 固定情報
+
+- リポジトリ: <絶対パス>
+- **作業ディレクトリ**: <絶対パス>/gitworktree/feature-<N>-<keyword>
+- ブランチ: feature/<N>-<keyword>（origin/develop 起点、worktree 作成済、uv sync 済、<X> passed / pyright 0 errors 確認済）
+- base branch: develop
+- Issue: https://github.com/<owner>/<repo>/issues/<N>
+
+## 前置き: 依存する先行 PR の成果（すべて develop に merged 済）
+
+<依存先 PR の列挙。使える API とモジュールパス>
+
+## 守るべき rule
+
+<上記 C. ルール列挙をそのまま>
+
+## 実装範囲
+
+<Issue のスコープ節を再掲>
+
+## 手順
+
+1. `gh issue view <N>` で Issue を読み直す
+2. 依存 spec / ADR を読む
+3. Issue にコメントで plan 投稿（`1_issue_plan.md` 準拠）
+4. TDD サイクルで順次実装（test → feat を別 commit）
+5. 全検査緑（ruff / ruff format --check / pyright / pytest、`docs/rules/ci-parity.md`）
+6. 自己レビューコメントを Issue に投稿（成功条件チェック表）
+7. `git push -u origin feature/<N>-<keyword>` → `gh pr create --draft --base develop`、本文に `Closes #<N>`
+8. 完了報告（上記 E のフォーマット）
+
+## 作業ディレクトリ
+
+すべて worktree 内。`cd <絶対パス>/gitworktree/feature-<N>-<keyword> && <command>` か `git -C <worktree>`。develop/main で直接編集禁止。他 worktree に触らない。
+
+## 想定規模
+
+<N>〜<M> 行の実装 + <X>〜<Y> 行のテスト。
+```

--- a/docs/rules/ci-parity.md
+++ b/docs/rules/ci-parity.md
@@ -1,0 +1,79 @@
+# CI parity 運用ルール
+
+本リポジトリでは **push 前の手元検査が CI と同一になる** ことを守ります。
+「ローカルでは通ったのに CI で落ちる」は可能な限りゼロに近づけます。
+
+---
+
+## 1. なぜ CI parity か
+
+Phase 1 実装で、サブエージェントが `uv run pyright src/` のように **部分検査** で済ませて push し、
+CI の `uv run pyright`（引数なし、src+tests 両方を検査）で落ちる事故が PR #17・#18 で連続発生しました。
+CI は `.github/workflows/ci.yml` の定義に従い、tests も検査対象に含みます。
+部分検査で「0 errors」と言っても、CI で落ちれば意味がありません。
+
+そのため本リポジトリでは、**push 前に以下 4 コマンドを必ず走らせる** ことを運用ルールとします。
+
+---
+
+## 2. push 前に走らせる 4 コマンド
+
+以下の順で実行します。順番は CI と合わせています。
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+```
+
+いずれかが赤なら push しません。
+
+### 各コマンドの意味
+
+| コマンド | 目的 | CI 側 |
+|---|---|---|
+| `uv run ruff check .` | lint（未使用 import、行長など） | `Ruff check` ステップと同一 |
+| `uv run ruff format --check .` | フォーマット統一確認 | `Ruff format --check` ステップと同一 |
+| `uv run pyright` | 型検査（strict、src+tests 両方） | `Pyright (strict)` ステップと同一 |
+| `uv run pytest` | 全テスト | `Pytest (coverage)` ステップと同一 |
+
+> **重要**: `uv run pyright src/` や `uv run pytest tests/unit/` のように対象を絞って済ませるのは NG です。
+> CI は対象を絞らないため、差分が出ます。
+
+---
+
+## 3. よくある落とし穴
+
+### 3.1 pyright strict は tests にも適用される
+
+`pyrightconfig.json` の `include` は `["src", "tests"]` です。
+tests 側で意図的に不正な Literal 値を渡すときは、型注釈を通さない書き方にします（`docs/rules/tdd.md` §9 参照）。
+
+### 3.2 テストから repo root を参照するときのパス解決
+
+`Path(__file__).parents[N]` は worktree 利用時と CI チェックアウト時で階層数が異なり、固定 index では壊れます。
+`pyproject.toml` を含む最近接の祖先を repo root とみなす探索方式に統一します（`docs/rules/tdd.md` §10 参照）。
+
+### 3.3 `uv run` を省略しない
+
+`ruff check .` / `pytest` を `uv` の外で走らせると、システムの古いバージョンが使われて結果が食い違うことがあります。
+**常に `uv run` を前置** してください。
+
+---
+
+## 4. チェックリスト
+
+- [ ] push 前に 4 コマンドを全部走らせた
+- [ ] `uv run pyright`（引数なし）で src+tests 両方に 0 errors
+- [ ] 「部分検査で済ませた」が無い
+- [ ] 失敗した場合は push しない、原因を潰してから再検査
+
+---
+
+## 5. 関連ドキュメント
+
+- `.github/workflows/ci.yml`（CI の実行コマンドの一次情報）
+- `pyrightconfig.json`（pyright の検査対象）
+- `.claude/skills/2_issue_impl.md` 完了条件
+- `docs/rules/tdd.md` §9, §10（テスト書き方の具体）

--- a/docs/rules/git-worktree.md
+++ b/docs/rules/git-worktree.md
@@ -81,6 +81,49 @@ git worktree prune
 
 ---
 
+## 3.5. PR merge 時の定型フロー
+
+PR がマージされたら、以下を **この順番で** 実行します（`.claude/skills/4_create_pr.md` §7-8 と整合）。
+
+```bash
+# 1. PR を Ready に切り替え（Draft で作成した場合）
+gh pr ready <PR 番号>
+
+# 2. squash merge + リモート feature ブランチ削除
+gh pr merge <PR 番号> --squash --delete-branch
+#    → ローカル worktree が使用中の feature ブランチはローカル削除が失敗するが、
+#      リモート側は消える。続けて worktree を片付ける。
+
+# 3. worktree とローカルブランチを削除
+cd <repo_root>
+git worktree remove gitworktree/feature-<issue番号>-<keyword>
+git branch -D feature/<issue番号>-<keyword>
+#    → ローカル未 merge 警告が出るが、リモートが squash merge 済なので -D で強制削除してよい
+
+# 4. develop を最新化
+git checkout develop
+git pull --ff-only
+```
+
+### よくある失敗
+
+| 失敗 | 回避策 |
+|---|---|
+| `gh pr merge --delete-branch` が「worktree で使用中」で落ちる | 先に Ready → merge、リモート側だけ消す。ローカル worktree は手順 3 で改めて削除 |
+| `cd gitworktree/...` したまま `git worktree remove` して cwd が消失 | 削除前に `cd <repo_root>` で抜ける。`pwd` で確認する習慣 |
+| Draft PR を `gh pr merge` で実行するとエラー | 先に `gh pr ready` を叩く（Draft は自動で Ready にならない） |
+| 片付け忘れた worktree が溜まる | `git worktree list` で定期的に確認。PR merged の worktree は即削除 |
+
+### 並列 PR merge の順序
+
+並列で複数 PR が緑になったときは、以下の順で 1 つずつ merge:
+
+1. 依存関係が少ない PR から merge（他 PR の base が古くなる波及を最小化）
+2. 1 つ merge したら次の PR で `gh pr view <N> --json mergeable` を確認（`MERGEABLE / CLEAN` なら進む、`CONFLICTING` なら rebase 必要）
+3. 基本的に CI 再ランは **1 回だけ** 許容、それで赤なら手元で原因調査
+
+---
+
 ## 4. 複数 Issue を並行で扱うときの注意
 
 - 実験出力は **worktree 内の `experiments/` に置き、ブランチごとに分離** する。他ブランチの実験結果を参照したい場合は該当 worktree に移動するか、HTML レポートを見る

--- a/docs/rules/tdd.md
+++ b/docs/rules/tdd.md
@@ -128,3 +128,75 @@ Issue 完了前に以下を満たしていること:
 - [ ] 過去のバグ修正があれば回帰テストが追加されている
 - [ ] 全テストが green
 - [ ] カバレッジの抜けに意図があり、説明できる
+
+---
+
+## 9. pydantic ValidationError を引き出すテストの書き方
+
+pydantic v2 のモデルは `Literal[...]` などで引数型を絞っていることが多い。
+**不正な値を意図的に渡して `ValidationError` を引き出すテスト**では、直接呼び出しだと pyright strict が止めます。
+
+### アンチパターン（pyright 落ちる）
+
+```python
+def test_invalid_sex_rejected(self) -> None:
+    with pytest.raises(ValidationError):
+        DemographicByAgeSexRow(age=30, sex="X", count=100)  # "X" は Literal["M","F"] にない
+```
+
+`reportArgumentType` で pyright が落ちます（PR #17 で実際に発生）。
+
+### 正しいパターン
+
+```python
+def test_invalid_sex_rejected(self) -> None:
+    with pytest.raises(ValidationError):
+        DemographicByAgeSexRow.model_validate({"age": 30, "sex": "X", "count": 100})
+```
+
+`model_validate(dict)` 経由にすることで、pydantic 側のランタイムバリデーションを正規ルートで引き出せます。
+これはローダが CSV の 1 行を処理するパスと同じため、テストの意図にも忠実です。
+
+### 参考
+
+- 現行実装例: `tests/io/test_loaders.py` の `TestDemographicByAgeSexRowSchema`
+- 関連: PR #17 で pyright strict 対応として model_validate に統一
+
+---
+
+## 10. テストから repo root を参照する時のパス解決
+
+回帰テストなどで `scripts/` や `data/` を参照したくなったとき、`Path(__file__).parents[N]` の **固定 index は使わない**。
+
+### アンチパターン（worktree の有無で壊れる）
+
+```python
+_REPO_ROOT = Path(__file__).parents[4]   # worktree だと 4、CI の checkout だと 3
+```
+
+worktree 下では `gitworktree/feature-xxx/tests/regression/test_foo.py` なので `parents[4]` が repo root。
+一方 CI の checkout では `<repo>/tests/regression/test_foo.py` なので `parents[3]` が repo root。
+固定 index にすると片方で絶対に壊れます（PR #18 で実際に発生）。
+
+### 正しいパターン
+
+```python
+def _find_repo_root() -> Path:
+    """pyproject.toml を含む最近接の祖先を repo root とみなす."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError(f"pyproject.toml が {here} から辿れない階層に見つからない")
+
+
+_REPO_ROOT = _find_repo_root()
+_GENERATE_SCRIPT = _REPO_ROOT / "scripts" / "generate_sample_case.py"
+```
+
+マーカーファイル（`pyproject.toml`）を探索するので、worktree の階層数に依存しません。
+
+### 参考
+
+- 現行実装例: `tests/regression/test_determinism.py` の `_find_repo_root`
+- 関連: PR #18 で CI 専用の失敗として修正


### PR DESCRIPTION
## 背景

Phase 0-1 で 5 PR（#17, #18, #19, #20, #21）を完走する中で、**オーケストレーションとサブ Agent 運用で同種の確認漏れ・失敗が繰り返し発生**した。主なもの:
- PR #17 / #18: Agent が `uv run pyright src/` で部分検査して済ませ、CI で tests 側の型エラーが失敗
- PR #18: テストから `Path(__file__).parents[4]` で repo root を参照 → worktree の有無で階層数が変わり CI 落ち
- Issue #13: test + feat が同一コミットに混入し、Red/Green 分離が不可視に
- 毎 PR で `gh pr ready` / `git worktree remove` / `git branch -D` / `git pull --ff-only` のフローを手元で思い出していた

Closes #22

## この変更で提供する価値

後続の Phase 2 以降でサブ Agent / contributor が作業するとき、**Phase 0-1 で踏んだ失敗を踏まずに済む**。Agent prompt の雛形と rule の相乗効果で、CI 失敗起点の追加サイクルを減らす。

## 変更内容

- `docs/rules/ci-parity.md` **新規**: push 前の検査 4 コマンド（`ruff check .` → `ruff format --check .` → `pyright`（引数なし）→ `pytest`）を一次情報として集約
- `.claude/skills/multi_agent_orchestration.md` **新規**: サブエージェントに渡すプロンプトの必須要素 A〜E、並列/直列判断基準、Phase 1 実行順序の実例、プロンプト雛形
- `.claude/skills/2_issue_impl.md` **改訂**: 完了条件を CI 4 コマンドで明示、部分検査禁止、1 TDD サイクル = test + feat 最低 2 コミットを粒度表に追加
- `.claude/skills/4_create_pr.md` **改訂**: 手順 5-8 を整理し Draft → Ready → squash → cleanup の全体像を明記、`gh pr ready` の明示要求
- `docs/rules/tdd.md` **改訂**: §9 pydantic `model_validate(dict)` パターン、§10 `pyproject.toml` 探索方式で repo_root を解決するパターンを追加
- `docs/rules/git-worktree.md` **改訂**: §3.5「PR merge 時の定型フロー」を新設、並列 PR merge の順序ルールを追記

各改訂は Phase 0-1 の具体 PR / Issue ID を根拠として引用し、将来「なぜこのルールがあるのか」を 1 クリックで辿れるようにした。

## 影響範囲

- 変更モジュール: `docs/rules/`, `.claude/skills/` のみ（Markdown）
- 他モジュールへの影響: なし（コードには 1 行も触っていない）
- 既存 API の互換性: 影響なし
- 依存関係の変化: なし

## テスト

- 追加テスト: なし（Markdown のみの変更）
- 変更テスト: なし
- 手動確認: `docs/rules/ci-parity.md` に書いた 4 コマンドが develop HEAD で手元実行可能

<details>
<summary>手元 CI 結果（抜粋）</summary>

```
uv run ruff check .
  → All checks passed!

uv run ruff format --check .
  → 66 files already formatted

uv run pyright
  → 0 errors, 1 warning (pandas stub, reportMissingTypeStubs=warning)

uv run pytest
  → 191 passed, 2 skipped in 7.77s
```
</details>

## 実験 / 検証

該当なし（ドキュメントのみの変更）

## 残課題

- [ ] CLAUDE.md §6 参照先インデックスに `ci-parity.md` と `multi_agent_orchestration.md` を追加（本 PR で軽量追加するか別 Issue にするかレビュアー判断を仰ぐ）
- [ ] Phase 2 で実際にサブ Agent を回したあと、`2_issue_impl_agent_prompt.md` を独立ファイル化する必要があれば別 Issue で切り出す

## レビュアーに特に見てほしい点

1. **既存 rule / skill の書式との整合**: 章立て、表の使い方、「なぜ X か」節の構成を踏襲したつもりだが、逸脱がないか
2. **コミット粒度（6 分割）の妥当性**: カテゴリごとに 1 コミットで分けた。まとめる方が読みやすいか、更に細かくする方がよいか
3. **Phase 0-1 の具体引用**: `PR #17 で実際に発生` のような引用が冗長すぎないか、読みやすいか

## 自己点検（PR 作成者が確認）

- [x] `origin/develop` を取り込み済みで、コンフリクトなし（#24 merged 後も無衝突を確認）
- [x] すべてのテスト・検査が green（手元 4 コマンド全緑）
- [x] 実験を伴わないため HTML レポートなし
- [x] Issue #22 の成功条件を達成（1 項目は「非独立ファイル化」として判断変更、Issue コメントに記録）
- [x] 非技術者にも伝わるよう、具体 PR / Issue ID を引用し抽象語だけにしない
- [x] `Closes #22` で Issue にリンク

🤖 Generated with [Claude Code](https://claude.com/claude-code)