### PR TITLE
docs: CLAUDE.md §6 索引に ci-parity と multi-agent orchestration を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Claude Code は、これらを満たさない状態で作業を終えないこ�
 | TDD の進め方 | [`docs/rules/tdd.md`](docs/rules/tdd.md) |
 | worktree の使い方 | [`docs/rules/git-worktree.md`](docs/rules/git-worktree.md) |
 | ブランチ戦略 | [`docs/rules/branch-strategy.md`](docs/rules/branch-strategy.md) |
+| CI parity（push 前 4 コマンド） | [`docs/rules/ci-parity.md`](docs/rules/ci-parity.md) |
 | 実験管理 | [`docs/rules/experiment-management.md`](docs/rules/experiment-management.md) |
 | HTML レポート運用 | [`docs/rules/html-reporting.md`](docs/rules/html-reporting.md) |
 | 文章スタイル | [`docs/rules/documentation-style.md`](docs/rules/documentation-style.md) |
@@ -118,3 +119,4 @@ Claude Code は、これらを満たさない状態で作業を終えないこ�
 | 実験レポート雛形 | [`docs/templates/experiment_report.md`](docs/templates/experiment_report.md) |
 | レビューサマリ雛形 | [`docs/templates/review_summary.md`](docs/templates/review_summary.md) |
 | 標準フロー skill | [`.claude/skills/`](.claude/skills/) |
+| マルチエージェント運用 | [`.claude/skills/multi_agent_orchestration.md`](.claude/skills/multi_agent_orchestration.md) |


### PR DESCRIPTION
## 概要

CLAUDE.md §6「参照先インデックス」の表に 2 行を追加し、PR #25 で新規配置したドキュメントへのリンクを整備した。

- `docs/rules/ci-parity.md`（push 前 4 コマンド検査ルール）
- `.claude/skills/multi_agent_orchestration.md`（サブエージェント並列実行の雛形と必須要素）

## 変更内容

- `CLAUDE.md` §6 表に 2 行追加のみ
  - CI parity: ブランチ戦略と実験管理の間（プロセス順序に沿った配置）
  - マルチエージェント運用: 標準フロー skill の直後（skill 系リソースの末尾）

## テスト計画

- [x] `grep -c 'ci-parity\|multi_agent_orchestration' CLAUDE.md` が 2
- [x] markdown 表構文の目視確認
- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 191 passed, 2 skipped

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)