### PR TITLE
[phase-2] #29 age-change 遷移: AgeChangeTransition の実装

### DIFF
--- a/src/synthpop_jp/optimize/state.py
+++ b/src/synthpop_jp/optimize/state.py
@@ -108,6 +108,21 @@ class PopulationArrays:
         """配列が保持する person 数を返す."""
         return int(self.age.shape[0])
 
+    @property
+    def role_reg(self) -> RoleRegistry:
+        """役割 ↔ 整数 ID の Registry を返す."""
+        return self._role_reg
+
+    @property
+    def family_reg(self) -> FamilyTypeRegistry:
+        """家族類型 ↔ 整数 ID の Registry を返す."""
+        return self._family_reg
+
+    @property
+    def sex_reg(self) -> SexRegistry:
+        """性別 ↔ 整数 ID の Registry を返す."""
+        return self._sex_reg
+
     @classmethod
     def empty(
         cls,

--- a/src/synthpop_jp/optimize/transitions.py
+++ b/src/synthpop_jp/optimize/transitions.py
@@ -1,5 +1,421 @@
-"""Transition operators (age-change / age-swap / hybrid、Phase 2-3a で実装)."""
+"""Transition operators (age-change, Phase 2).
+
+age-swap / hybrid は Phase 3a で実装する。
+
+このモジュールは SA（シミュレーテッドアニーリング）の候補解生成を担う。
+``AgeChangeTransition.propose()`` を呼ぶと、ハード制約を満たす
+``(person_idx, new_age)`` が返される。
+
+ハード制約一覧
+--------------
+- 年齢は 0 以上 100 以下
+- husband / wife / father / mother は 18 歳以上
+- father / mother / parent（義親）は同世帯の child の最高齢 + 14 歳以上
+- child は同世帯の father / mother / parent の最若年 - 14 歳以下
+
+制約違反時は内部で retry（最大 MAX_RETRY 回）し、超過したら TransitionError を raise する。
+"""
 
 from __future__ import annotations
 
-# TODO: Phase 2 で age-change、Phase 3a で age-swap / hybrid を実装する。
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from synthpop_jp.io.schemas import DemographicByAgeSexRow, DemographicByFamilyTypeRoleRow
+    from synthpop_jp.optimize.state import PopulationArrays
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+#: age の有効範囲 [AGE_MIN, AGE_MAX]
+AGE_MIN: int = 0
+AGE_MAX: int = 100
+
+#: 成人年齢（husband / wife / father / mother / single が満たすべき最低年齢）
+ADULT_AGE_MIN: int = 18
+
+#: parent（義親役割）が child の最高齢より何歳以上年上でなければならないか
+PARENT_CHILD_AGE_GAP: int = 14
+
+#: parent 系役割の最低年齢（分布フィルタに使用）
+PARENT_ROLE_AGE_MIN: int = 40
+
+#: child 系役割の最高年齢（分布フィルタに使用）
+CHILD_ROLE_AGE_MAX: int = 25
+
+#: propose() の 1 回あたりの最大 retry 数
+MAX_RETRY: int = 10
+
+#: 役割別の sex フィルタ（None なら両方）
+_ROLE_SEX_FILTER: dict[str, str | None] = {
+    "husband": "M",
+    "wife": "F",
+    "father": "M",
+    "mother": "F",
+    "child": None,
+    "parent": None,
+    "single": None,
+}
+
+#: 役割別の最低年齢フィルタ
+_ROLE_AGE_MIN: dict[str, int] = {
+    "husband": ADULT_AGE_MIN,
+    "wife": ADULT_AGE_MIN,
+    "father": ADULT_AGE_MIN,
+    "mother": ADULT_AGE_MIN,
+    "child": AGE_MIN,
+    "parent": PARENT_ROLE_AGE_MIN,
+    "single": ADULT_AGE_MIN,
+}
+
+#: 役割別の最高年齢フィルタ
+_ROLE_AGE_MAX: dict[str, int] = {
+    "husband": AGE_MAX,
+    "wife": AGE_MAX,
+    "father": AGE_MAX,
+    "mother": AGE_MAX,
+    "child": CHILD_ROLE_AGE_MAX,
+    "parent": AGE_MAX,
+    "single": AGE_MAX,
+}
+
+# ---------------------------------------------------------------------------
+# 例外
+# ---------------------------------------------------------------------------
+
+
+class TransitionError(Exception):
+    """ハード制約を満たす新年齢が retry 上限内に見つからなかった.
+
+    ``AgeChangeTransition.propose()`` が ``MAX_RETRY`` 回試行しても
+    有効な new_age を見つけられないときに raise される。
+    """
+
+
+# ---------------------------------------------------------------------------
+# 役割別年齢分布の構築
+# ---------------------------------------------------------------------------
+
+
+def build_role_age_dist(
+    demo_by_age_sex: list[DemographicByAgeSexRow],
+    demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None,
+) -> dict[str, np.ndarray]:
+    """役割別の年齢確率分布（shape=(101,)）を構築して返す.
+
+    Parameters
+    ----------
+    demo_by_age_sex : list[DemographicByAgeSexRow]
+        ``demographic_by_age_sex.csv`` の行リスト。フォールバック用。
+    demo_ft_role : list[DemographicByFamilyTypeRoleRow] | None
+        ``demographic_by_family_type_role.csv`` の行リスト。
+        None または空リストのときはフォールバックを使う。
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        key: role 名、value: shape=(101,) の正規化確率配列（index = age）。
+
+    Notes
+    -----
+    ``demo_ft_role`` が提供されている場合、対象 role に対するデータが 1 行以上
+    存在すれば、``demo_ft_role`` を優先して分布を構築する。
+    データが存在しない role は ``demo_by_age_sex`` にフォールバックする。
+    """
+    roles = list(_ROLE_SEX_FILTER.keys())
+
+    # demo_ft_role を role ごとに集計（age → count）
+    ft_role_by_role: dict[str, dict[int, int]] = {}
+    if demo_ft_role:
+        for row in demo_ft_role:
+            if row.role in roles:
+                age_counts = ft_role_by_role.setdefault(row.role, {})
+                age_counts[row.age] = age_counts.get(row.age, 0) + row.count
+
+    # demo_by_age_sex を age → {sex → count} に整理
+    # shape=(101, 2): axis0=age, axis1=sex (M=0, F=1)
+    demo_arr = np.zeros((AGE_MAX + 1, 2), dtype=np.float64)
+    for row in demo_by_age_sex:
+        if AGE_MIN <= row.age <= AGE_MAX:
+            sex_idx = 0 if row.sex == "M" else 1
+            demo_arr[row.age, sex_idx] += row.count
+
+    result: dict[str, np.ndarray] = {}
+
+    for role in roles:
+        prob = np.zeros(AGE_MAX + 1, dtype=np.float64)
+
+        if role in ft_role_by_role:
+            # ft_role データで構築
+            for age, count in ft_role_by_role[role].items():
+                if AGE_MIN <= age <= AGE_MAX:
+                    prob[age] = float(count)
+        else:
+            # demo_by_age_sex でフォールバック
+            sex_filter = _ROLE_SEX_FILTER[role]
+            if sex_filter == "M":
+                prob_raw = demo_arr[:, 0].copy()
+            elif sex_filter == "F":
+                prob_raw = demo_arr[:, 1].copy()
+            else:
+                # 両方合計
+                prob_raw = demo_arr[:, 0] + demo_arr[:, 1]
+            prob = prob_raw.copy()
+
+        # role 固有の age フィルタを適用（ハード制約の static 部分）
+        age_min = _ROLE_AGE_MIN[role]
+        age_max = _ROLE_AGE_MAX[role]
+        if age_min > 0:
+            prob[:age_min] = 0.0
+        if age_max < AGE_MAX:
+            prob[age_max + 1 :] = 0.0
+
+        # 正規化
+        total = prob.sum()
+        if total > 0:
+            prob /= total
+        else:
+            # フォールバック: 有効範囲内の一様分布
+            valid_range = age_max - age_min + 1
+            if valid_range > 0:
+                prob[age_min : age_max + 1] = 1.0 / valid_range
+
+        result[role] = prob
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# AgeChangeTransition
+# ---------------------------------------------------------------------------
+
+
+class AgeChangeTransition:
+    """役割別年齢分布から新年齢を抽選する age-change 遷移.
+
+    SA runner が ``propose()`` を繰り返し呼ぶことで候補解を生成する。
+    ``propose()`` はハード制約を満たす ``(person_idx, new_age)`` を返す。
+
+    Parameters
+    ----------
+    arrays : PopulationArrays
+        SA の状態配列。propose() は副作用なし（配列を変更しない）。
+    demo_by_age_sex : list[DemographicByAgeSexRow]
+        人口ピラミッド（sex / age 別 count）。役割別分布のフォールバック用。
+    rng : np.random.Generator
+        ``SeedRegistry.rng("sa_transition")`` で注入する乱数源。
+    demo_ft_role : list[DemographicByFamilyTypeRoleRow] | None
+        役割別詳細分布（任意）。あれば demo_by_age_sex より優先する。
+    """
+
+    def __init__(
+        self,
+        arrays: PopulationArrays,
+        demo_by_age_sex: list[DemographicByAgeSexRow],
+        rng: np.random.Generator,
+        demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
+    ) -> None:
+        self._arrays = arrays
+        self._rng = rng
+
+        # 役割別年齢確率配列を事前構築
+        self._role_dist: dict[str, np.ndarray] = build_role_age_dist(demo_by_age_sex, demo_ft_role)
+
+        # role id → role name のマッピングを用意
+        role_reg = arrays.role_reg
+        self._role_id_to_name: dict[int, str] = {}
+        for role_name in _ROLE_SEX_FILTER:
+            try:
+                rid = role_reg.id_of(role_name)
+                self._role_id_to_name[rid] = role_name
+            except KeyError:
+                pass
+
+        # age 配列の候補リスト（age 0-100）
+        self._age_choices = np.arange(AGE_MAX + 1, dtype=np.int64)
+
+        # ハード制約の動的部分をプリコンピュート
+        # household_id ごとに:
+        #   - child の max_age（parent/father/mother 用: new_age >= child_max + 14）
+        #   - parent 系の min_age（child 用: new_age <= parent_min - 14）
+        self._precompute_household_constraints()
+
+    def _precompute_household_constraints(self) -> None:
+        """世帯内の親子制約を事前に計算する.
+
+        各 person のハード制約（親子関係由来の dynamic 部分）を
+        person_idx → (age_min, age_max) の形で
+        self._dynamic_age_min / self._dynamic_age_max に格納する。
+
+        静的制約（role 固有の最低/最高年齢）は role_dist の構築時点で処理済みのため、
+        ここでは親子関係の dynamic な制約のみを扱う。
+        """
+        arrays = self._arrays
+        n = arrays.n_persons
+        role_reg = arrays.role_reg
+
+        # person ごとの dynamic 制約（-1 は制約なしを意味する）
+        # dynamic_age_min[i]: new_age の下限（ハード制約由来）
+        # dynamic_age_max[i]: new_age の上限（ハード制約由来）
+        self._dynamic_age_min = np.full(n, -1, dtype=np.int64)
+        self._dynamic_age_max = np.full(n, -1, dtype=np.int64)
+
+        if n == 0:
+            return
+
+        # 役割 ID を取得（KeyError は無視）
+        def get_role_id(name: str) -> int | None:
+            try:
+                return role_reg.id_of(name)
+            except KeyError:
+                return None
+
+        father_id = get_role_id("father")
+        mother_id = get_role_id("mother")
+        parent_id = get_role_id("parent")
+        child_id = get_role_id("child")
+
+        parent_role_ids = {rid for rid in [father_id, mother_id, parent_id] if rid is not None}
+        child_role_id = child_id
+
+        if not parent_role_ids and child_role_id is None:
+            return
+
+        # 世帯ごとに child max_age と parent系 min_age を計算
+        hh_ids = arrays.household_id
+        roles = arrays.role
+        ages = arrays.age
+
+        # ユニークな世帯 ID
+        unique_hh_ids = np.unique(hh_ids)
+
+        for hh_id in unique_hh_ids:
+            mask = hh_ids == hh_id
+            hh_roles = roles[mask]
+            hh_ages = ages[mask].astype(np.int64)
+            hh_indices = np.where(mask)[0]
+
+            # child の max_age を計算
+            child_max_age = -1
+            if child_role_id is not None:
+                child_mask = hh_roles == child_role_id
+                if child_mask.any():
+                    child_max_age = int(hh_ages[child_mask].max())
+
+            # parent 系の min_age を計算
+            parent_min_age = -1
+            if parent_role_ids:
+                parent_mask = np.zeros(len(hh_roles), dtype=bool)
+                for pid in parent_role_ids:
+                    parent_mask |= hh_roles == pid
+                if parent_mask.any():
+                    parent_min_age = int(hh_ages[parent_mask].min())
+
+            # 各 person に動的制約を設定
+            for local_i, global_i in enumerate(hh_indices):
+                role_id = int(hh_roles[local_i])
+                if role_id in parent_role_ids and child_max_age >= 0:
+                    # father/mother/parent は child の max_age + 14 以上
+                    self._dynamic_age_min[global_i] = child_max_age + PARENT_CHILD_AGE_GAP
+                elif child_role_id is not None and role_id == child_role_id and parent_min_age >= 0:
+                    # child は parent 系の min_age - 14 以下
+                    self._dynamic_age_max[global_i] = parent_min_age - PARENT_CHILD_AGE_GAP
+
+    def _sample_age_for_role(self, role_name: str) -> int:
+        """役割別確率分布から age を 1 つサンプリングして返す.
+
+        Parameters
+        ----------
+        role_name : str
+            サンプリング対象の役割名。
+
+        Returns
+        -------
+        int
+            サンプリングされた age（0-100）。
+        """
+        dist = self._role_dist.get(role_name)
+        if dist is None:
+            # 未知の役割: 全範囲一様
+            return int(self._rng.integers(AGE_MIN, AGE_MAX + 1))
+        return int(self._rng.choice(self._age_choices, p=dist))
+
+    def _check_hard_constraints(self, person_idx: int, new_age: int, role_name: str) -> bool:
+        """new_age がハード制約を満たすか検証する.
+
+        Parameters
+        ----------
+        person_idx : int
+            対象 person のインデックス。
+        new_age : int
+            検証する新年齢。
+        role_name : str
+            対象 person の役割名。
+
+        Returns
+        -------
+        bool
+            True ならハード制約を満たす（有効な new_age）。
+        """
+        # 静的制約: role 固有の最低/最高年齢
+        static_min = _ROLE_AGE_MIN.get(role_name, AGE_MIN)
+        static_max = _ROLE_AGE_MAX.get(role_name, AGE_MAX)
+        if new_age < static_min or new_age > static_max:
+            return False
+
+        # グローバル制約: 0-100
+        if new_age < AGE_MIN or new_age > AGE_MAX:
+            return False
+
+        # 動的制約: 親子関係
+        dyn_min = int(self._dynamic_age_min[person_idx])
+        dyn_max = int(self._dynamic_age_max[person_idx])
+
+        if dyn_min >= 0 and new_age < dyn_min:
+            return False
+        return not (dyn_max >= 0 and new_age > dyn_max)
+
+    def propose(self) -> tuple[int, int]:
+        """1 人を選んで新年齢を提案する（副作用なし）.
+
+        1/N の一様分布でランダムに person を選び、その役割に対応する
+        年齢確率分布から new_age を抽選する。ハード制約を満たさない場合は
+        最大 MAX_RETRY 回 retry する。
+
+        Returns
+        -------
+        tuple[int, int]
+            ``(person_idx, new_age)`` のタプル。
+            ``person_idx`` は PopulationArrays のインデックス（0-based）。
+            ``new_age`` は ハード制約を満たす新年齢（0-100）。
+
+        Raises
+        ------
+        TransitionError
+            MAX_RETRY 回 retry してもハード制約を満たす new_age が見つからない場合。
+        """
+        arrays = self._arrays
+        n = arrays.n_persons
+
+        # 1/N 一様分布で person を選択
+        person_idx = int(self._rng.integers(0, n))
+
+        # 役割名を取得
+        role_id = int(arrays.role[person_idx])
+        role_name = self._role_id_to_name.get(role_id, "")
+
+        # ハード制約を満たすまで retry
+        for _ in range(MAX_RETRY):
+            new_age = self._sample_age_for_role(role_name)
+            if self._check_hard_constraints(person_idx, new_age, role_name):
+                return (person_idx, new_age)
+
+        msg = (
+            f"propose() が {MAX_RETRY} 回の retry 後もハード制約を満たす"
+            f" new_age を見つけられませんでした"
+            f"（person_idx={person_idx}, role={role_name!r}）"
+        )
+        raise TransitionError(msg)

--- a/tests/optimize/test_transitions.py
+++ b/tests/optimize/test_transitions.py
@@ -1,0 +1,698 @@
+"""Tests for AgeChangeTransition — TDD cycles 1-8.
+
+TDD Cycle 1: 役割別年齢分布の事前構築（正規化して合計 1.0）
+TDD Cycle 2: propose() の単純ケース（role=single、制約なし）
+TDD Cycle 3: husband/wife の age>=18 ハード制約
+TDD Cycle 4: 親子関係のハード制約（father/mother/parent が child+14 以上）
+TDD Cycle 5: retry と TransitionError（制約違反が必ず起きるシナリオ）
+TDD Cycle 6: 決定性（同 seed で propose() 列が bitwise 一致）
+TDD Cycle 7: 抽選の統計性（KS 検定、サンプル 10000）
+TDD Cycle 8: 性能 skeleton（1000 世帯で propose() 1 回が 10μs 以内）
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.io.schemas import DemographicByAgeSexRow, DemographicByFamilyTypeRoleRow
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.optimize.transitions import (
+    AgeChangeTransition,
+    TransitionError,
+    build_role_age_dist,
+)
+from synthpop_jp.rng import SeedRegistry
+
+# ---------------------------------------------------------------------------
+# ヘルパー: テスト用 Registry / PopulationArrays の生成
+# ---------------------------------------------------------------------------
+
+ALL_ROLES = ["husband", "wife", "father", "mother", "child", "parent", "single"]
+ALL_FAMILY_TYPES = [
+    "couple",
+    "couple_and_children",
+    "single",
+    "lone_parent_and_children",
+    "couple_and_a_parent",
+]
+
+
+def make_registries() -> tuple[FamilyTypeRegistry, RoleRegistry, SexRegistry]:
+    """テスト用の登録済み Registry を返す."""
+    family_reg = FamilyTypeRegistry()
+    for ft in ALL_FAMILY_TYPES:
+        family_reg.register(ft)
+    role_reg = RoleRegistry()
+    for r in ALL_ROLES:
+        role_reg.register(r)
+    sex_reg = SexRegistry()
+    return family_reg, role_reg, sex_reg
+
+
+def make_demo_by_age_sex(
+    *, uniform_count: int = 100
+) -> list[DemographicByAgeSexRow]:
+    """age=0-100, sex=M/F の均一分布を返す."""
+    rows: list[DemographicByAgeSexRow] = []
+    for age in range(101):
+        rows.append(DemographicByAgeSexRow(age=age, sex="M", count=uniform_count))
+        rows.append(DemographicByAgeSexRow(age=age, sex="F", count=uniform_count))
+    return rows
+
+
+def make_arrays_single_household(
+    *,
+    family_type: str = "couple_and_children",
+    members: list[tuple[str, str, int]],
+    household_id: int = 1,
+) -> PopulationArrays:
+    """指定メンバー構成の 1 世帯から PopulationArrays を生成するヘルパー.
+
+    Parameters
+    ----------
+    members : list[tuple[str, str, int]]
+        (role, sex, age) のタプルリスト。
+    """
+    family_reg, role_reg, sex_reg = make_registries()
+    persons = [
+        Person(household_id=household_id, role=role, sex=sex, age=age)  # type: ignore[arg-type]
+        for role, sex, age in members
+    ]
+    hh = Household(household_id=household_id, family_type=family_type, members=persons)
+    return PopulationArrays.from_households([hh], family_reg, role_reg, sex_reg)
+
+
+def make_multi_household_arrays(
+    households: list[tuple[str, list[tuple[str, str, int]]]],
+) -> PopulationArrays:
+    """複数世帯から PopulationArrays を生成するヘルパー.
+
+    Parameters
+    ----------
+    households : list[tuple[str, list[tuple[str, str, int]]]]
+        (family_type, [(role, sex, age), ...]) のリスト。
+    """
+    family_reg, role_reg, sex_reg = make_registries()
+    hh_list: list[Household] = []
+    for hh_id, (family_type, members) in enumerate(households, start=1):
+        persons = [
+            Person(household_id=hh_id, role=role, sex=sex, age=age)  # type: ignore[arg-type]
+            for role, sex, age in members
+        ]
+        hh_list.append(
+            Household(household_id=hh_id, family_type=family_type, members=persons)
+        )
+    return PopulationArrays.from_households(hh_list, family_reg, role_reg, sex_reg)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1: 役割別年齢分布の事前構築
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRoleAgeDist:
+    """build_role_age_dist の単体テスト."""
+
+    def test_distribution_sums_to_one_husband(self) -> None:
+        """husband の分布（sex=M, age>=18）の合計が 1.0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        assert "husband" in dist
+        total = float(np.sum(dist["husband"]))
+        assert abs(total - 1.0) < 1e-9
+
+    def test_distribution_sums_to_one_child(self) -> None:
+        """child の分布（age<=25）の合計が 1.0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        assert "child" in dist
+        total = float(np.sum(dist["child"]))
+        assert abs(total - 1.0) < 1e-9
+
+    def test_husband_dist_has_zero_prob_under_18(self) -> None:
+        """husband の分布は age<18 の確率が 0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        husband_dist = dist["husband"]
+        assert float(np.sum(husband_dist[:18])) == 0.0
+
+    def test_wife_dist_has_zero_prob_under_18(self) -> None:
+        """wife の分布は age<18 の確率が 0（sex=F, age>=18 のみ）."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        wife_dist = dist["wife"]
+        assert float(np.sum(wife_dist[:18])) == 0.0
+
+    def test_child_dist_has_zero_prob_over_25(self) -> None:
+        """child の分布は age>25 の確率が 0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        child_dist = dist["child"]
+        assert float(np.sum(child_dist[26:])) == 0.0
+
+    def test_parent_dist_has_zero_prob_under_40(self) -> None:
+        """parent の分布は age<40 の確率が 0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        parent_dist = dist["parent"]
+        assert float(np.sum(parent_dist[:40])) == 0.0
+
+    def test_single_dist_has_zero_prob_under_18(self) -> None:
+        """single の分布は age<18 の確率が 0."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        single_dist = dist["single"]
+        assert float(np.sum(single_dist[:18])) == 0.0
+
+    def test_dist_shape_is_101(self) -> None:
+        """分布の shape は (101,)（age 0-100）."""
+        demo = make_demo_by_age_sex()
+        dist = build_role_age_dist(demo, demo_ft_role=None)
+        for role in ["husband", "wife", "child", "parent", "single"]:
+            assert dist[role].shape == (101,), f"role={role} の shape が違う"
+
+    def test_ft_role_data_overrides_fallback_for_husband(self) -> None:
+        """demographic_by_family_type_role がある場合、husband 分布がそちらを優先する."""
+        demo = make_demo_by_age_sex()
+        # husband の ft_role データ: age=30 のみに集中
+        ft_role_rows = [
+            DemographicByFamilyTypeRoleRow(
+                family_type="couple", role="husband", sex="M", age=30, count=100
+            )
+        ]
+        dist = build_role_age_dist(demo, demo_ft_role=ft_role_rows)
+        husband_dist = dist["husband"]
+        # age=30 の確率が 1.0
+        assert abs(float(husband_dist[30]) - 1.0) < 1e-9
+        # その他の age は 0
+        assert float(np.sum(husband_dist[:30])) == 0.0
+        assert float(np.sum(husband_dist[31:])) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: propose() の単純ケース（role=single、制約なし）
+# ---------------------------------------------------------------------------
+
+
+class TestProposeBasic:
+    """propose() の基本動作テスト."""
+
+    def test_propose_returns_tuple_of_two_ints(self) -> None:
+        """propose() が (int, int) のタプルを返す."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="single",
+            members=[("single", "M", 30)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        result = transition.propose()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        person_idx, new_age = result
+        assert isinstance(person_idx, int)
+        assert isinstance(new_age, int)
+
+    def test_propose_person_idx_in_valid_range(self) -> None:
+        """person_idx が 0 以上 n_persons 未満の範囲内."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="single",
+            members=[("single", "M", 30), ("single", "F", 25)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        for _ in range(50):
+            person_idx, _ = transition.propose()
+            assert 0 <= person_idx < arrays.n_persons
+
+    def test_propose_new_age_in_valid_range(self) -> None:
+        """new_age が 0 以上 100 以下の範囲内."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="single",
+            members=[("single", "M", 30)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        for _ in range(50):
+            _, new_age = transition.propose()
+            assert 0 <= new_age <= 100
+
+    def test_propose_does_not_modify_arrays(self) -> None:
+        """propose() を呼んでも arrays.age が変更されない（副作用なし）."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="single",
+            members=[("single", "M", 30)],
+        )
+        original_age = int(arrays.age[0])
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        transition.propose()
+        assert int(arrays.age[0]) == original_age
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: husband/wife の age>=18 ハード制約
+# ---------------------------------------------------------------------------
+
+
+class TestHardConstraintAge18:
+    """husband/wife の age>=18 ハード制約テスト."""
+
+    def test_husband_new_age_always_ge_18(self) -> None:
+        """husband の propose() で new_age が常に 18 以上（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="couple",
+            members=[("husband", "M", 40), ("wife", "F", 38)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        husband_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("husband")
+            )[0][0]
+        )
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == husband_idx:
+                assert new_age >= 18, f"husband の new_age={new_age} が 18 未満"
+
+    def test_wife_new_age_always_ge_18(self) -> None:
+        """wife の propose() で new_age が常に 18 以上（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="couple",
+            members=[("husband", "M", 40), ("wife", "F", 38)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        wife_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("wife")
+            )[0][0]
+        )
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == wife_idx:
+                assert new_age >= 18, f"wife の new_age={new_age} が 18 未満"
+
+    def test_father_new_age_always_ge_18(self) -> None:
+        """father の propose() で new_age が常に 18 以上（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 45),
+                ("mother", "F", 43),
+                ("child", "M", 15),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        father_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("father")
+            )[0][0]
+        )
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == father_idx:
+                assert new_age >= 18, f"father の new_age={new_age} が 18 未満"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: 親子関係のハード制約
+# ---------------------------------------------------------------------------
+
+
+class TestHardConstraintParentChild:
+    """親子関係のハード制約テスト."""
+
+    def test_father_new_age_ge_child_max_age_plus_14(self) -> None:
+        """father の new_age が同世帯 child の max_age + 14 以上（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        child_age = 20
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 50),
+                ("mother", "F", 48),
+                ("child", "F", child_age),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        father_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("father")
+            )[0][0]
+        )
+        min_father_age = child_age + 14
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == father_idx:
+                assert new_age >= min_father_age, (
+                    f"father の new_age={new_age} が child({child_age})+14={min_father_age} 未満"
+                )
+
+    def test_mother_new_age_ge_child_max_age_plus_14(self) -> None:
+        """mother の new_age が同世帯 child の max_age + 14 以上（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        child_age = 20
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 50),
+                ("mother", "F", 48),
+                ("child", "M", child_age),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        mother_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("mother")
+            )[0][0]
+        )
+        min_mother_age = child_age + 14
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == mother_idx:
+                assert new_age >= min_mother_age, (
+                    f"mother の new_age={new_age} が child({child_age})+14={min_mother_age} 未満"
+                )
+
+    def test_child_new_age_le_parent_min_age_minus_14(self) -> None:
+        """child の new_age が同世帯 father/mother の min_age - 14 以下（100 回試行）."""
+        demo = make_demo_by_age_sex()
+        father_age = 45
+        mother_age = 43
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", father_age),
+                ("mother", "F", mother_age),
+                ("child", "M", 15),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        child_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("child")
+            )[0][0]
+        )
+        max_child_age = min(father_age, mother_age) - 14
+        for _ in range(100):
+            person_idx, new_age = transition.propose()
+            if person_idx == child_idx:
+                assert new_age <= max_child_age, (
+                    f"child の new_age={new_age} が parent_min({min(father_age, mother_age)})"
+                    f"-14={max_child_age} 超"
+                )
+
+    def test_parent_role_new_age_ge_child_max_age_plus_14(self) -> None:
+        """parent（role='parent'）の new_age が同世帯 child の max_age + 14 以上."""
+        demo = make_demo_by_age_sex()
+        child_age = 20
+        arrays = make_arrays_single_household(
+            family_type="couple_and_a_parent",
+            members=[
+                ("husband", "M", 45),
+                ("wife", "F", 43),
+                ("parent", "M", 70),
+                ("child", "F", child_age),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        parent_idx = int(
+            np.where(
+                arrays.role == arrays._role_reg.id_of("parent")
+            )[0][0]
+        )
+        min_parent_age = child_age + 14
+        hits = 0
+        for _ in range(200):
+            person_idx, new_age = transition.propose()
+            if person_idx == parent_idx:
+                hits += 1
+                assert new_age >= min_parent_age, (
+                    f"parent の new_age={new_age} が child({child_age})+14={min_parent_age} 未満"
+                )
+        # parent が一度も選ばれなかったら警告
+        assert hits > 0, "parent が 200 回試行で一度も選ばれなかった"
+
+    def test_no_parent_child_constraint_without_children(self) -> None:
+        """同世帯に child がいない場合、father でも親子制約が適用されない（エラーなし）."""
+        demo = make_demo_by_age_sex()
+        # couple_and_children でも child がいないケース（単純な夫婦世帯として）
+        arrays = make_arrays_single_household(
+            family_type="couple",
+            members=[("husband", "M", 40), ("wife", "F", 38)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        # エラーが出ないこと
+        for _ in range(10):
+            transition.propose()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5: retry と TransitionError
+# ---------------------------------------------------------------------------
+
+
+class TestRetryAndTransitionError:
+    """retry と TransitionError の例外テスト."""
+
+    def test_transition_error_raised_when_no_valid_age(self) -> None:
+        """全 age が制約違反になるシナリオで TransitionError が raise される.
+
+        child が age=25 で同世帯の father/mother の age が 25 + 14 = 39 のとき、
+        father の分布は age>=18 だが、age>=39 を満たす range は 39-100 でほとんど満たせる。
+        ここでは故意に child=25 かつ father の分布を age<=30 に限定して conflict を起こす。
+        """
+        # child_age=25 なので father は 39 以上が必要
+        # father の ft_role データを age=20 のみにして制約（>=39）を必ず違反させる
+        demo = make_demo_by_age_sex()
+        ft_role_rows = [
+            DemographicByFamilyTypeRoleRow(
+                family_type="couple_and_children",
+                role="father",
+                sex="M",
+                age=20,
+                count=100,
+            )
+        ]
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 50),
+                ("mother", "F", 48),
+                ("child", "F", 25),
+            ],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(
+            arrays=arrays,
+            demo_by_age_sex=demo,
+            demo_ft_role=ft_role_rows,
+            rng=rng,
+        )
+        # father だけを対象に propose を強制的に実行するため、
+        # 単人配列で試みる（father のみの世帯）
+        father_only_arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 50),
+                ("child", "F", 25),
+            ],
+        )
+        rng2 = SeedRegistry(root=42).rng("sa_transition")
+        transition2 = AgeChangeTransition(
+            arrays=father_only_arrays,
+            demo_by_age_sex=demo,
+            demo_ft_role=ft_role_rows,
+            rng=rng2,
+        )
+        with pytest.raises(TransitionError):
+            # 最大 10 回 retry するので 20 回試行すれば必ず発生
+            for _ in range(20):
+                transition2.propose()
+
+    def test_transition_error_is_raised(self) -> None:
+        """TransitionError が Exception のサブクラスであること."""
+        assert issubclass(TransitionError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6: 決定性
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """決定性テスト: 同じ seed で propose() 100 回が bitwise 一致."""
+
+    def test_propose_sequence_is_deterministic(self) -> None:
+        """SeedRegistry(root=42) で propose() 100 回の列が 2 回とも同一."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 45),
+                ("mother", "F", 43),
+                ("child", "M", 15),
+            ],
+        )
+
+        def run_sequence() -> list[tuple[int, int]]:
+            rng = SeedRegistry(root=42).rng("sa_transition")
+            transition = AgeChangeTransition(
+                arrays=arrays, demo_by_age_sex=demo, rng=rng
+            )
+            return [transition.propose() for _ in range(100)]
+
+        seq1 = run_sequence()
+        seq2 = run_sequence()
+        assert seq1 == seq2, "同 seed でも propose() 列が一致しない"
+
+    def test_different_seeds_produce_different_sequences(self) -> None:
+        """異なる seed では propose() 列が（高確率で）異なる."""
+        demo = make_demo_by_age_sex()
+        arrays = make_arrays_single_household(
+            family_type="couple_and_children",
+            members=[
+                ("father", "M", 45),
+                ("mother", "F", 43),
+                ("child", "M", 15),
+            ],
+        )
+        rng1 = SeedRegistry(root=42).rng("sa_transition")
+        rng2 = SeedRegistry(root=99).rng("sa_transition")
+        t1 = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng1)
+        t2 = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng2)
+        seq1 = [t1.propose() for _ in range(20)]
+        seq2 = [t2.propose() for _ in range(20)]
+        # 20 回のうち全て一致する確率は無視できるほど低い
+        assert seq1 != seq2, "異なる seed で propose() 列が完全一致した（異常）"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7: 抽選の統計性（KS 検定）
+# ---------------------------------------------------------------------------
+
+
+class TestStatisticalDistribution:
+    """KS 検定で抽選の統計性を検証."""
+
+    def test_single_age_distribution_follows_input(self) -> None:
+        """role=single の new_age 分布が入力の人口ピラミッドに従う（KS 検定、p>0.05）.
+
+        入力: age=18-100 の均一分布（single は age>=18 のフィルタ後）。
+        期待: KS 検定で p > 0.05（分布が一致することを棄却できない）。
+        """
+        from scipy.stats import ks_1samp  # type: ignore[import-untyped]
+
+        demo = make_demo_by_age_sex(uniform_count=100)
+        arrays = make_arrays_single_household(
+            family_type="single",
+            members=[("single", "M", 30)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+
+        # 10000 回サンプリング
+        n_samples = 10000
+        sampled_ages = [transition.propose()[1] for _ in range(n_samples)]
+
+        # single は age=18-100 の均一分布（83 段階）
+        # KS 検定: 離散一様分布 U(18, 100) との比較
+        def uniform_cdf(x: float) -> float:
+            """U(18, 100) の CDF."""
+            if x < 18:
+                return 0.0
+            if x >= 100:
+                return 1.0
+            return (x - 18 + 1) / (100 - 18 + 1)
+
+        result = ks_1samp(sampled_ages, uniform_cdf)
+        assert result.pvalue > 0.01, (
+            f"KS 検定 p={result.pvalue:.4f} < 0.01: single の年齢分布が期待と乖離"
+        )
+
+    def test_husband_age_distribution_only_ge_18(self) -> None:
+        """husband の new_age が age>=18 の範囲のみから来ることを 1000 回で確認."""
+        demo = make_demo_by_age_sex(uniform_count=100)
+        arrays = make_arrays_single_household(
+            family_type="couple",
+            members=[("husband", "M", 40), ("wife", "F", 38)],
+        )
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+        husband_idx = int(
+            np.where(arrays.role == arrays._role_reg.id_of("husband"))[0][0]
+        )
+        violations = 0
+        trials = 0
+        for _ in range(1000):
+            person_idx, new_age = transition.propose()
+            if person_idx == husband_idx:
+                trials += 1
+                if new_age < 18:
+                    violations += 1
+        assert violations == 0, f"husband の age<18 が {violations}/{trials} 回発生"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8: 性能 skeleton（pytest-benchmark を使わず時刻計測）
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceSkeleton:
+    """性能テスト skeleton: 1000 世帯で propose() 1 回が 10μs 以内."""
+
+    def test_propose_performance_1000_households(self) -> None:
+        """1000 世帯（約 3000 人）で propose() 1 回が 10 マイクロ秒以内."""
+        import time
+
+        demo = make_demo_by_age_sex()
+        # 1000 世帯: couple_and_children（父・母・子 各 1 人）
+        households = [
+            (
+                "couple_and_children",
+                [
+                    ("father", "M", 45),
+                    ("mother", "F", 43),
+                    ("child", "M", 15),
+                ],
+            )
+            for _ in range(1000)
+        ]
+        arrays = make_multi_household_arrays(households)
+        rng = SeedRegistry(root=42).rng("sa_transition")
+        transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
+
+        # ウォームアップ
+        transition.propose()
+
+        # 計測
+        n_trials = 100
+        start = time.perf_counter()
+        for _ in range(n_trials):
+            transition.propose()
+        elapsed = time.perf_counter() - start
+
+        avg_us = (elapsed / n_trials) * 1e6
+        # 10μs 以内が目標（CI 環境のばらつきを考慮して 100μs でチェック）
+        # #33 で本格計測を行う
+        assert avg_us < 100.0, (
+            f"propose() の平均時間 {avg_us:.1f}μs が 100μs を超えた（skeleton チェック）"
+        )

--- a/tests/optimize/test_transitions.py
+++ b/tests/optimize/test_transitions.py
@@ -53,9 +53,7 @@ def make_registries() -> tuple[FamilyTypeRegistry, RoleRegistry, SexRegistry]:
     return family_reg, role_reg, sex_reg
 
 
-def make_demo_by_age_sex(
-    *, uniform_count: int = 100
-) -> list[DemographicByAgeSexRow]:
+def make_demo_by_age_sex(*, uniform_count: int = 100) -> list[DemographicByAgeSexRow]:
     """age=0-100, sex=M/F の均一分布を返す."""
     rows: list[DemographicByAgeSexRow] = []
     for age in range(101):
@@ -103,9 +101,7 @@ def make_multi_household_arrays(
             Person(household_id=hh_id, role=role, sex=sex, age=age)  # type: ignore[arg-type]
             for role, sex, age in members
         ]
-        hh_list.append(
-            Household(household_id=hh_id, family_type=family_type, members=persons)
-        )
+        hh_list.append(Household(household_id=hh_id, family_type=family_type, members=persons))
     return PopulationArrays.from_households(hh_list, family_reg, role_reg, sex_reg)
 
 
@@ -274,11 +270,7 @@ class TestHardConstraintAge18:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        husband_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("husband")
-            )[0][0]
-        )
+        husband_idx = int(np.where(arrays.role == arrays.role_reg.id_of("husband"))[0][0])
         for _ in range(100):
             person_idx, new_age = transition.propose()
             if person_idx == husband_idx:
@@ -293,11 +285,7 @@ class TestHardConstraintAge18:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        wife_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("wife")
-            )[0][0]
-        )
+        wife_idx = int(np.where(arrays.role == arrays.role_reg.id_of("wife"))[0][0])
         for _ in range(100):
             person_idx, new_age = transition.propose()
             if person_idx == wife_idx:
@@ -316,11 +304,7 @@ class TestHardConstraintAge18:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        father_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("father")
-            )[0][0]
-        )
+        father_idx = int(np.where(arrays.role == arrays.role_reg.id_of("father"))[0][0])
         for _ in range(100):
             person_idx, new_age = transition.propose()
             if person_idx == father_idx:
@@ -349,11 +333,7 @@ class TestHardConstraintParentChild:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        father_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("father")
-            )[0][0]
-        )
+        father_idx = int(np.where(arrays.role == arrays.role_reg.id_of("father"))[0][0])
         min_father_age = child_age + 14
         for _ in range(100):
             person_idx, new_age = transition.propose()
@@ -376,11 +356,7 @@ class TestHardConstraintParentChild:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        mother_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("mother")
-            )[0][0]
-        )
+        mother_idx = int(np.where(arrays.role == arrays.role_reg.id_of("mother"))[0][0])
         min_mother_age = child_age + 14
         for _ in range(100):
             person_idx, new_age = transition.propose()
@@ -404,11 +380,7 @@ class TestHardConstraintParentChild:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        child_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("child")
-            )[0][0]
-        )
+        child_idx = int(np.where(arrays.role == arrays.role_reg.id_of("child"))[0][0])
         max_child_age = min(father_age, mother_age) - 14
         for _ in range(100):
             person_idx, new_age = transition.propose()
@@ -433,11 +405,7 @@ class TestHardConstraintParentChild:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        parent_idx = int(
-            np.where(
-                arrays.role == arrays._role_reg.id_of("parent")
-            )[0][0]
-        )
+        parent_idx = int(np.where(arrays.role == arrays.role_reg.id_of("parent"))[0][0])
         min_parent_age = child_age + 14
         hits = 0
         for _ in range(200):
@@ -492,21 +460,6 @@ class TestRetryAndTransitionError:
                 count=100,
             )
         ]
-        arrays = make_arrays_single_household(
-            family_type="couple_and_children",
-            members=[
-                ("father", "M", 50),
-                ("mother", "F", 48),
-                ("child", "F", 25),
-            ],
-        )
-        rng = SeedRegistry(root=42).rng("sa_transition")
-        transition = AgeChangeTransition(
-            arrays=arrays,
-            demo_by_age_sex=demo,
-            demo_ft_role=ft_role_rows,
-            rng=rng,
-        )
         # father だけを対象に propose を強制的に実行するため、
         # 単人配列で試みる（father のみの世帯）
         father_only_arrays = make_arrays_single_household(
@@ -523,10 +476,14 @@ class TestRetryAndTransitionError:
             demo_ft_role=ft_role_rows,
             rng=rng2,
         )
-        with pytest.raises(TransitionError):
+
+        def _exhaust_retries() -> None:
             # 最大 10 回 retry するので 20 回試行すれば必ず発生
             for _ in range(20):
                 transition2.propose()
+
+        with pytest.raises(TransitionError):
+            _exhaust_retries()
 
     def test_transition_error_is_raised(self) -> None:
         """TransitionError が Exception のサブクラスであること."""
@@ -555,9 +512,7 @@ class TestDeterminism:
 
         def run_sequence() -> list[tuple[int, int]]:
             rng = SeedRegistry(root=42).rng("sa_transition")
-            transition = AgeChangeTransition(
-                arrays=arrays, demo_by_age_sex=demo, rng=rng
-            )
+            transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
             return [transition.propose() for _ in range(100)]
 
         seq1 = run_sequence()
@@ -615,18 +570,16 @@ class TestStatisticalDistribution:
 
         # single は age=18-100 の均一分布（83 段階）
         # KS 検定: 離散一様分布 U(18, 100) との比較
-        def uniform_cdf(x: float) -> float:
-            """U(18, 100) の CDF."""
-            if x < 18:
-                return 0.0
-            if x >= 100:
-                return 1.0
-            return (x - 18 + 1) / (100 - 18 + 1)
+        def uniform_cdf(x: np.ndarray) -> np.ndarray:  # type: ignore[type-arg]
+            """U(18, 100) の CDF（vectorized）."""
+            x_arr = np.asarray(x, dtype=float)
+            mid = (x_arr - 18 + 1) / (100 - 18 + 1)
+            result_arr = np.where(x_arr < 18, 0.0, np.where(x_arr >= 100, 1.0, mid))
+            return result_arr
 
-        result = ks_1samp(sampled_ages, uniform_cdf)
-        assert result.pvalue > 0.01, (
-            f"KS 検定 p={result.pvalue:.4f} < 0.01: single の年齢分布が期待と乖離"
-        )
+        ks_result = ks_1samp(sampled_ages, uniform_cdf)
+        pvalue = float(ks_result.pvalue)  # type: ignore[union-attr]
+        assert pvalue > 0.01, f"KS 検定 p={pvalue:.4f} < 0.01: single の年齢分布が期待と乖離"
 
     def test_husband_age_distribution_only_ge_18(self) -> None:
         """husband の new_age が age>=18 の範囲のみから来ることを 1000 回で確認."""
@@ -637,9 +590,7 @@ class TestStatisticalDistribution:
         )
         rng = SeedRegistry(root=42).rng("sa_transition")
         transition = AgeChangeTransition(arrays=arrays, demo_by_age_sex=demo, rng=rng)
-        husband_idx = int(
-            np.where(arrays.role == arrays._role_reg.id_of("husband"))[0][0]
-        )
+        husband_idx = int(np.where(arrays.role == arrays.role_reg.id_of("husband"))[0][0])
         violations = 0
         trials = 0
         for _ in range(1000):


### PR DESCRIPTION
## 概要

Issue #29「SA 実装者が役割別年齢分布から 1 人の新年齢を抽選できる age-change 遷移」を実装した。

SA runner が `transition.propose()` を呼ぶと `(person_idx, new_age)` の候補が返る。
ハード制約違反は遷移内で弾かれ、返された候補は必ず有効解である。

Closes #29

## 変更内容

### 新規実装: `src/synthpop_jp/optimize/transitions.py`

- `build_role_age_dist(demo_by_age_sex, demo_ft_role)` — 役割別年齢確率配列（shape=101）を事前構築
  - `demo_ft_role` があれば優先、なければ `demo_by_age_sex` でフォールバック
  - role 固有の age フィルタ（husband/wife ≥ 18、child ≤ 25、parent ≥ 40）を適用
- `AgeChangeTransition(arrays, demo_by_age_sex, rng, demo_ft_role=None)`
  - `propose() -> tuple[int, int]`: 1/N 一様で person 選択 → 役割分布から新年齢抽選
  - ハード制約（age 0-100、成人 18 以上、親子 14 歳差）を検証、違反時は最大 10 回 retry
  - 親子制約は `__init__` 時に世帯別プリコンピュート（O(1) lookup）
  - retry 上限超過で `TransitionError` を raise
- `TransitionError(Exception)` — 制約満足失敗の専用例外

### 既存修正: `src/synthpop_jp/optimize/state.py`

- `PopulationArrays` に `role_reg` / `family_reg` / `sex_reg` の public property を追加
  - pyright `reportPrivateUsage` を解消するため

### テスト調整: `tests/optimize/test_transitions.py`

- `arrays._role_reg` → `arrays.role_reg`（public property 経由）
- `uniform_cdf` を vectorized numpy 関数に修正（`ks_1samp` が ndarray を渡すため）
- `pvalue` を `float()` キャストして pyright 型エラーを解消

## コミット列

1. `test(#29): add TDD cycles 1-8 for AgeChangeTransition (698 lines)` — Red 状態を規定点として保存
2. `feat(#29): implement AgeChangeTransition with build_role_age_dist and hard constraints` — Green
3. `test(#29): adjust test API to use public role_reg property and fix CDF vectorization` — API 調整（仕様は変えない）

## CI parity

- `uv run ruff check .` → 0 errors
- `uv run ruff format --check .` → 全フォーマット済み
- `uv run pyright` → 0 errors, 1 warning（pandas stub、既存）
- `uv run pytest` → 219 passed, 2 skipped（skip は Phase 2 完了まで意図的）

## テスト観点

| TDD Cycle | 検証内容 | 結果 |
|-----------|----------|------|
| 1 | 役割別分布の正規化・shape・フィルタ適用 | 9 テスト通過 |
| 2 | propose() の返り値・副作用なし | 4 テスト通過 |
| 3 | husband/wife/father の age≥18 制約 | 3 テスト通過 |
| 4 | 親子 14 歳差制約（father/mother/parent/child） | 5 テスト通過 |
| 5 | TransitionError の発生 | 2 テスト通過 |
| 6 | 同 seed で propose() 列が bitwise 一致 | 2 テスト通過 |
| 7 | KS 検定で分布の統計性を確認 | 2 テスト通過 |
| 8 | 1000 世帯で propose() が 100μs 以内 | 1 テスト通過 |

## 非スコープ

- age-swap / hybrid 遷移（Phase 3a）
- SA Metropolis ループ（#30）
- ObjectiveState との結合（#27）

🤖 Generated with [Claude Code](https://claude.com/claude-code)