### PR TITLE
feat(#27): ObjectiveState 差分更新 — 5 統計の O(1) スコア更新

### DIFF
--- a/src/synthpop_jp/optimize/objective.py
+++ b/src/synthpop_jp/optimize/objective.py
@@ -1,5 +1,1251 @@
-"""Differential objective function (Phase 2 で実装)."""
+"""差分更新版目的関数 — ObjectiveState (Issue #27).
+
+SA（シミュレーテッドアニーリング）の 1 ステップで 1 人の age が変わるとき、
+5 統計のヒストグラムを O(1) で差分更新し、目的スコアを維持するクラスを提供する。
+
+5 統計（spec §11.2）
+----------------------
+- stats[0]: father-child 年齢差 (parent_age - child_age, role=father)
+- stats[1]: mother-child 年齢差 (parent_age - child_age, role=mother)
+- stats[2]: couple 年齢差 (husband_age - wife_age)
+- stats[3]: male demographic pyramid (sex=M)
+- stats[4]: female demographic pyramid (sex=F)
+
+目的関数（原論文式(1) primary）
+---------------------------------
+    f(A) = Σ_s Σ_j |observed[s,j] - target[s,j]|
+
+weight は全部 1.0（研究拡張モード / ペナルティは非スコープ）。
+
+差分更新
+---------
+- ``propose_change(person_idx, new_age) -> float``: 副作用なし、スコア差分のみ返す
+- ``apply_change(person_idx, new_age) -> None``: 内部状態を実更新
+"""
 
 from __future__ import annotations
 
-# TODO: Phase 2 で差分更新版 ObjectiveState を実装する（review-python 指摘1）。
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from synthpop_jp.io.schemas import (
+    AgeDiffCoupleRow,
+    AgeDiffParentChildRow,
+    DemographicByAgeSexRow,
+)
+
+if TYPE_CHECKING:
+    from synthpop_jp.optimize.state import PopulationArrays
+
+
+# ---------------------------------------------------------------------------
+# StatTable: 1 統計分の observed / target ヒストグラム
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StatTable:
+    """1 統計分の observed/target ヒストグラム.
+
+    Attributes
+    ----------
+    observed : np.ndarray
+        観測値ヒストグラム（int64, shape=(n_bins,)）。
+        合成人口から計算した各 bin のカウント。
+    target : np.ndarray
+        目標値ヒストグラム（int64, shape=(n_bins,)）。
+        入力 CSV から得た各 bin のカウント。
+    bin_edges : np.ndarray
+        ビン境界（float64, shape=(n_bins+1,)）。
+        半開区間 [bin_edges[i], bin_edges[i+1]) で各 bin を定義する。
+    """
+
+    observed: np.ndarray
+    target: np.ndarray
+    bin_edges: np.ndarray
+
+    def l1_score(self) -> float:
+        """この統計の L1 スコア（Σ|observed - target|）を返す."""
+        return float(np.abs(self.observed.astype(np.int64) - self.target.astype(np.int64)).sum())
+
+    def bin_index(self, value: float) -> int:
+        """Value が属する bin の index を返す.
+
+        範囲外の場合は -1（bin_edges より小さい）または n_bins（大きい）を返す。
+        numpy.searchsorted の挙動に準じる。
+
+        Parameters
+        ----------
+        value : float
+            ビンに割り当てる値。
+
+        Returns
+        -------
+        int
+            0-indexed の bin index。範囲外なら -1 または len(observed)。
+        """
+        idx = int(np.searchsorted(self.bin_edges[1:], value, side="right"))
+        return idx
+
+
+# ---------------------------------------------------------------------------
+# ビン index 計算ユーティリティ
+# ---------------------------------------------------------------------------
+
+
+def _bin_index(bin_edges: np.ndarray, value: float) -> int:
+    """Value が属する bin の index を numpy.histogram と一致する方法で返す.
+
+    np.histogram は最後のビンだけ右端を閉じた区間 [left, right] として扱う。
+    これを再現するために、value == bin_edges[-1] の場合は最後のビンに含める。
+
+    Parameters
+    ----------
+    bin_edges : np.ndarray
+        ビン境界配列（長さ n_bins+1）。
+    value : float
+        ビンに割り当てる値。
+
+    Returns
+    -------
+    int
+        0-indexed の bin index。
+        範囲外（value < bin_edges[0] または value > bin_edges[-1]）なら
+        ``-1`` または ``n_bins`` を返す。
+    """
+    n_bins = len(bin_edges) - 1
+    idx = int(np.searchsorted(bin_edges[1:], value, side="right"))
+    # np.histogram の最後ビンは右端閉: [bin_edges[-2], bin_edges[-1]] を含む
+    if idx == n_bins and value == bin_edges[-1]:
+        idx = n_bins - 1
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# ヒストグラム構築ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _build_diff_bins(rows: list[AgeDiffParentChildRow] | list[AgeDiffCoupleRow]) -> np.ndarray:
+    """Diff rows から bin_edges 配列を構築する.
+
+    Parameters
+    ----------
+    rows : list[AgeDiffParentChildRow] | list[AgeDiffCoupleRow]
+        ソート済みの bin 定義行。
+
+    Returns
+    -------
+    np.ndarray
+        shape=(n_bins+1,) の bin 境界配列。
+    """
+    if not rows:
+        return np.array([0.0, 1.0], dtype=np.float64)
+    edges = [float(rows[0].diff_min)]
+    for row in rows:
+        edges.append(float(row.diff_max))
+    return np.array(edges, dtype=np.float64)
+
+
+def _build_age_bins(rows: list[DemographicByAgeSexRow]) -> np.ndarray:
+    """demographic_by_age_sex rows から age bin_edges を構築する.
+
+    各行の age 値が bin の下端。次の値までが 1 bin。
+    最後の bin の上端は最大 age + 1 step とする。
+
+    Parameters
+    ----------
+    rows : list[DemographicByAgeSexRow]
+        同じ sex でフィルタした行（ソート済みを想定）。
+
+    Returns
+    -------
+    np.ndarray
+        shape=(n_bins+1,) の bin 境界配列。
+    """
+    ages = sorted({row.age for row in rows})
+    if not ages:
+        return np.array([0.0, 1.0], dtype=np.float64)
+    if len(ages) == 1:
+        return np.array([float(ages[0]), float(ages[0] + 5)], dtype=np.float64)
+    # bin 幅を最初の差分から推定（通常 5 歳刻み）
+    step = ages[1] - ages[0]
+    edges = [float(a) for a in ages] + [float(ages[-1] + step)]
+    return np.array(edges, dtype=np.float64)
+
+
+def _build_parent_child_stat(
+    rows: list[AgeDiffParentChildRow],
+    role_name: str,
+    arrays: PopulationArrays,
+) -> StatTable:
+    """親子年齢差統計を構築する.
+
+    Parameters
+    ----------
+    rows : list[AgeDiffParentChildRow]
+        age_diff_parent_child.csv から読んだ全行。
+    role_name : str
+        ``"father"`` または ``"mother"``。
+    arrays : PopulationArrays
+        初期人口配列。
+
+    Returns
+    -------
+    StatTable
+        observed と target が初期化された統計テーブル。
+    """
+    role_rows = sorted(
+        [r for r in rows if r.role == role_name],
+        key=lambda r: r.diff_min,
+    )
+    bin_edges = _build_diff_bins(role_rows)
+    n_bins = len(bin_edges) - 1
+
+    # target: CSV の count
+    target = np.zeros(n_bins, dtype=np.int64)
+    for i, row in enumerate(role_rows):
+        target[i] = row.count
+
+    # observed: 合成人口から計算
+    observed = _compute_parent_child_observed(arrays, role_name, bin_edges, n_bins)
+
+    return StatTable(observed=observed, target=target, bin_edges=bin_edges)
+
+
+def _compute_parent_child_observed(
+    arrays: PopulationArrays,
+    role_name: str,
+    bin_edges: np.ndarray,
+    n_bins: int,
+) -> np.ndarray:
+    """親子年齢差の observed ヒストグラムを計算する.
+
+    Parameters
+    ----------
+    arrays : PopulationArrays
+        人口配列。
+    role_name : str
+        ``"father"`` または ``"mother"``。
+    bin_edges : np.ndarray
+        ビン境界。
+    n_bins : int
+        ビン数。
+
+    Returns
+    -------
+    np.ndarray
+        shape=(n_bins,) の observed カウント配列（int64）。
+    """
+    observed = np.zeros(n_bins, dtype=np.int64)
+
+    try:
+        parent_role_id = arrays.role_reg.id_of(role_name)
+    except KeyError:
+        return observed
+
+    try:
+        child_role_id = arrays.role_reg.id_of("child")
+    except KeyError:
+        return observed
+
+    parent_mask = arrays.role == parent_role_id
+    if not np.any(parent_mask):
+        return observed
+
+    parent_indices = np.where(parent_mask)[0]
+
+    # 世帯ごとに親と子の組み合わせを計算
+    # child_role_id を持つ世帯員を household_id でグループ化
+    child_mask = arrays.role == child_role_id
+    if not np.any(child_mask):
+        return observed
+
+    child_indices = np.where(child_mask)[0]
+
+    # household_id → child_ages のマッピング
+    hid_to_child_ages: dict[int, list[int]] = {}
+    for ci in child_indices:
+        hid = int(arrays.household_id[ci])
+        if hid not in hid_to_child_ages:
+            hid_to_child_ages[hid] = []
+        hid_to_child_ages[hid].append(int(arrays.age[ci]))
+
+    # 親ごとに差分を計算してビンに追加
+    for pi in parent_indices:
+        hid = int(arrays.household_id[pi])
+        parent_age = int(arrays.age[pi])
+        child_ages = hid_to_child_ages.get(hid, [])
+        for child_age in child_ages:
+            diff = float(parent_age - child_age)
+            bin_idx = _bin_index(bin_edges, diff)
+            if 0 <= bin_idx < n_bins:
+                observed[bin_idx] += 1
+
+    return observed
+
+
+def _build_couple_stat(
+    rows: list[AgeDiffCoupleRow],
+    arrays: PopulationArrays,
+) -> StatTable:
+    """夫婦年齢差統計を構築する.
+
+    couple_diff = husband_age - wife_age
+
+    Parameters
+    ----------
+    rows : list[AgeDiffCoupleRow]
+        age_diff_couple.csv から読んだ全行。
+    arrays : PopulationArrays
+        初期人口配列。
+
+    Returns
+    -------
+    StatTable
+        observed と target が初期化された統計テーブル。
+    """
+    sorted_rows = sorted(rows, key=lambda r: r.diff_min)
+    bin_edges = _build_diff_bins(sorted_rows)
+    n_bins = len(bin_edges) - 1
+
+    # target: CSV の count
+    target = np.zeros(n_bins, dtype=np.int64)
+    for i, row in enumerate(sorted_rows):
+        target[i] = row.count
+
+    observed = _compute_couple_observed(arrays, bin_edges, n_bins)
+
+    return StatTable(observed=observed, target=target, bin_edges=bin_edges)
+
+
+def _compute_couple_observed(
+    arrays: PopulationArrays,
+    bin_edges: np.ndarray,
+    n_bins: int,
+) -> np.ndarray:
+    """夫婦年齢差の observed ヒストグラムを計算する.
+
+    Parameters
+    ----------
+    arrays : PopulationArrays
+        人口配列。
+    bin_edges : np.ndarray
+        ビン境界。
+    n_bins : int
+        ビン数。
+
+    Returns
+    -------
+    np.ndarray
+        shape=(n_bins,) の observed カウント配列（int64）。
+    """
+    observed = np.zeros(n_bins, dtype=np.int64)
+
+    try:
+        husband_role_id = arrays.role_reg.id_of("husband")
+        wife_role_id = arrays.role_reg.id_of("wife")
+    except KeyError:
+        return observed
+
+    husband_mask = arrays.role == husband_role_id
+    if not np.any(husband_mask):
+        return observed
+
+    husband_indices = np.where(husband_mask)[0]
+
+    # household_id → wife_age のマッピング
+    wife_mask = arrays.role == wife_role_id
+    wife_indices = np.where(wife_mask)[0]
+    hid_to_wife_age: dict[int, int] = {}
+    for wi in wife_indices:
+        hid = int(arrays.household_id[wi])
+        hid_to_wife_age[hid] = int(arrays.age[wi])
+
+    # 夫ごとに差分を計算してビンに追加
+    for hi in husband_indices:
+        hid = int(arrays.household_id[hi])
+        if hid not in hid_to_wife_age:
+            continue
+        husband_age = int(arrays.age[hi])
+        wife_age = hid_to_wife_age[hid]
+        diff = float(husband_age - wife_age)
+        bin_idx = _bin_index(bin_edges, diff)
+        if 0 <= bin_idx < n_bins:
+            observed[bin_idx] += 1
+
+    return observed
+
+
+def _build_pyramid_stat(
+    rows: list[DemographicByAgeSexRow],
+    sex_label: str,
+    arrays: PopulationArrays,
+) -> StatTable:
+    """性別別人口ピラミッド統計を構築する.
+
+    Parameters
+    ----------
+    rows : list[DemographicByAgeSexRow]
+        demographic_by_age_sex.csv から読んだ全行。
+    sex_label : str
+        ``"M"`` または ``"F"``。
+    arrays : PopulationArrays
+        初期人口配列。
+
+    Returns
+    -------
+    StatTable
+        observed と target が初期化された統計テーブル。
+    """
+    sex_rows = sorted([r for r in rows if r.sex == sex_label], key=lambda r: r.age)
+    bin_edges = _build_age_bins(sex_rows)
+    n_bins = len(bin_edges) - 1
+
+    # target: CSV の count（bin_edges に対応する順序で）
+    target = np.zeros(n_bins, dtype=np.int64)
+    age_to_idx = {int(bin_edges[i]): i for i in range(n_bins)}
+    for row in sex_rows:
+        idx = age_to_idx.get(row.age)
+        if idx is not None and 0 <= idx < n_bins:
+            target[idx] = row.count
+
+    # observed: 合成人口の sex 別年齢ヒストグラム
+    sex_id = arrays.sex_reg.id_of(sex_label)
+    observed = _compute_pyramid_observed(arrays, sex_id, bin_edges, n_bins)
+
+    return StatTable(observed=observed, target=target, bin_edges=bin_edges)
+
+
+def _compute_pyramid_observed(
+    arrays: PopulationArrays,
+    sex_id: int,
+    bin_edges: np.ndarray,
+    n_bins: int,
+) -> np.ndarray:
+    """性別別人口ピラミッドの observed ヒストグラムを計算する.
+
+    Parameters
+    ----------
+    arrays : PopulationArrays
+        人口配列。
+    sex_id : int
+        性別 ID（0=M, 1=F）。
+    bin_edges : np.ndarray
+        ビン境界（年齢）。
+    n_bins : int
+        ビン数。
+
+    Returns
+    -------
+    np.ndarray
+        shape=(n_bins,) の observed カウント配列（int64）。
+    """
+    sex_mask = arrays.sex == sex_id
+    ages = arrays.age[sex_mask].astype(np.int64)
+    observed, _ = np.histogram(ages, bins=bin_edges)
+    return observed.astype(np.int64)
+
+
+# ---------------------------------------------------------------------------
+# build_objective_stats: 5 統計の構築
+# ---------------------------------------------------------------------------
+
+
+def build_objective_stats(
+    arrays: PopulationArrays,
+    age_diff_parent_child: list[AgeDiffParentChildRow],
+    age_diff_couple: list[AgeDiffCoupleRow],
+    demographic_by_age_sex: list[DemographicByAgeSexRow],
+) -> list[StatTable]:
+    """5 統計を構築して StatTable のリストを返す.
+
+    返り値のインデックス:
+    - 0: father-child 年齢差
+    - 1: mother-child 年齢差
+    - 2: couple 年齢差（husband - wife）
+    - 3: male demographic pyramid
+    - 4: female demographic pyramid
+
+    Parameters
+    ----------
+    arrays : PopulationArrays
+        初期人口配列。
+    age_diff_parent_child : list[AgeDiffParentChildRow]
+        age_diff_parent_child.csv から読んだ全行。
+    age_diff_couple : list[AgeDiffCoupleRow]
+        age_diff_couple.csv から読んだ全行。
+    demographic_by_age_sex : list[DemographicByAgeSexRow]
+        demographic_by_age_sex.csv から読んだ全行。
+
+    Returns
+    -------
+    list[StatTable]
+        長さ 5 の StatTable リスト。
+    """
+    return [
+        _build_parent_child_stat(age_diff_parent_child, "father", arrays),
+        _build_parent_child_stat(age_diff_parent_child, "mother", arrays),
+        _build_couple_stat(age_diff_couple, arrays),
+        _build_pyramid_stat(demographic_by_age_sex, "M", arrays),
+        _build_pyramid_stat(demographic_by_age_sex, "F", arrays),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# ObjectiveState
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ObjectiveState:
+    """差分更新版目的関数の状態コンテナ.
+
+    SA の内部ループで 1 人の age が変わるとき、
+    5 統計のヒストグラムを O(1) で差分更新しながら total_score を維持する。
+
+    Attributes
+    ----------
+    arrays : PopulationArrays
+        人口配列への参照（コピーしない）。
+    stats : list[StatTable]
+        5 統計分の StatTable リスト（インデックスの意味は build_objective_stats 参照）。
+    total_score : float
+        現在の目的スコア = Σ_s L1(stats[s])。
+    """
+
+    arrays: PopulationArrays
+    stats: list[StatTable]
+    total_score: float
+
+    @classmethod
+    def from_arrays(
+        cls,
+        arrays: PopulationArrays,
+        age_diff_parent_child: list[AgeDiffParentChildRow],
+        age_diff_couple: list[AgeDiffCoupleRow],
+        demographic_by_age_sex: list[DemographicByAgeSexRow],
+    ) -> ObjectiveState:
+        """PopulationArrays と統計テーブルから ObjectiveState を構築する.
+
+        Parameters
+        ----------
+        arrays : PopulationArrays
+            初期人口配列（参照として保持。コピーしない）。
+        age_diff_parent_child : list[AgeDiffParentChildRow]
+            age_diff_parent_child.csv から読んだ全行。
+        age_diff_couple : list[AgeDiffCoupleRow]
+            age_diff_couple.csv から読んだ全行。
+        demographic_by_age_sex : list[DemographicByAgeSexRow]
+            demographic_by_age_sex.csv から読んだ全行。
+
+        Returns
+        -------
+        ObjectiveState
+            初期化済みの ObjectiveState。total_score は 5 統計の L1 合計。
+        """
+        stats = build_objective_stats(
+            arrays=arrays,
+            age_diff_parent_child=age_diff_parent_child,
+            age_diff_couple=age_diff_couple,
+            demographic_by_age_sex=demographic_by_age_sex,
+        )
+        total_score = sum(s.l1_score() for s in stats)
+        return cls(
+            arrays=arrays,
+            stats=stats,
+            total_score=total_score,
+        )
+
+    # -----------------------------------------------------------------------
+    # 差分更新
+    # -----------------------------------------------------------------------
+
+    def _compute_delta_for_change(self, person_idx: int, new_age: int) -> float:
+        """person_idx の age を new_age に変えたときのスコア差分を計算する（副作用なし）.
+
+        各統計に対して「old_age の寄与を除き、new_age の寄与を加えた」後の
+        L1 変化量を計算する。
+
+        Parameters
+        ----------
+        person_idx : int
+            変更対象の person の index。
+        new_age : int
+            変更後の age。
+
+        Returns
+        -------
+        float
+            スコア差分 (new_score - old_score)。負なら改善、正なら悪化。
+        """
+        old_age = int(self.arrays.age[person_idx])
+        if old_age == new_age:
+            return 0.0
+
+        delta = 0.0
+
+        # --- stats[3]: male pyramid, stats[4]: female pyramid ---
+        sex_id = int(self.arrays.sex[person_idx])
+        # sex_id=0 → stats[3], sex_id=1 → stats[4]
+        pyramid_idx = 3 + sex_id
+        pyramid_stat = self.stats[pyramid_idx]
+        delta += _delta_pyramid(pyramid_stat, old_age, new_age)
+
+        # --- stats[0]: father-child, stats[1]: mother-child ---
+        role_id = int(self.arrays.role[person_idx])
+        role_name = self.arrays.role_reg.name_of(role_id)
+        hid = int(self.arrays.household_id[person_idx])
+
+        if role_name in ("father", "mother"):
+            stat_idx = 0 if role_name == "father" else 1
+            stat = self.stats[stat_idx]
+            try:
+                child_role_id = self.arrays.role_reg.id_of("child")
+                child_mask = (self.arrays.household_id == hid) & (self.arrays.role == child_role_id)
+                child_ages = self.arrays.age[child_mask].astype(np.int64)
+                delta += _delta_parent_child_diffs(stat, old_age, new_age, child_ages)
+            except KeyError:
+                pass
+
+        elif role_name == "child":
+            # child の age 変化 → 同世帯の father/mother の差分が変化
+            try:
+                father_role_id = self.arrays.role_reg.id_of("father")
+                father_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == father_role_id
+                )
+                father_ages = self.arrays.age[father_mask].astype(np.int64)
+                if np.any(father_mask):
+                    delta += _delta_child_changes_parent_diff(
+                        self.stats[0], old_age, new_age, father_ages
+                    )
+            except KeyError:
+                pass
+
+            try:
+                mother_role_id = self.arrays.role_reg.id_of("mother")
+                mother_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == mother_role_id
+                )
+                mother_ages = self.arrays.age[mother_mask].astype(np.int64)
+                if np.any(mother_mask):
+                    delta += _delta_child_changes_parent_diff(
+                        self.stats[1], old_age, new_age, mother_ages
+                    )
+            except KeyError:
+                pass
+
+        elif role_name == "husband":
+            # husband の age 変化 → couple 差分が変化
+            try:
+                wife_role_id = self.arrays.role_reg.id_of("wife")
+                wife_mask = (self.arrays.household_id == hid) & (self.arrays.role == wife_role_id)
+                wife_ages = self.arrays.age[wife_mask].astype(np.int64)
+                if np.any(wife_mask):
+                    delta += _delta_husband_age_changes_couple(
+                        self.stats[2], old_age, new_age, wife_ages
+                    )
+            except KeyError:
+                pass
+
+        elif role_name == "wife":
+            # wife の age 変化 → couple 差分が変化（diff = husband - wife なので符号逆）
+            try:
+                husband_role_id = self.arrays.role_reg.id_of("husband")
+                husband_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == husband_role_id
+                )
+                husband_ages = self.arrays.age[husband_mask].astype(np.int64)
+                if np.any(husband_mask):
+                    delta += _delta_wife_age_changes_couple(
+                        self.stats[2], old_age, new_age, husband_ages
+                    )
+            except KeyError:
+                pass
+
+        return delta
+
+    def propose_change(self, person_idx: int, new_age: int) -> float:
+        """Age 変更の差分スコアを副作用なしで計算する.
+
+        Parameters
+        ----------
+        person_idx : int
+            変更対象の person の index（0-indexed）。
+        new_age : int
+            変更後の age（0 以上）。
+
+        Returns
+        -------
+        float
+            スコア差分 (new_score - old_score)。
+            負なら改善、正なら悪化、0 なら変化なし。
+        """
+        return self._compute_delta_for_change(person_idx, new_age)
+
+    def apply_change(self, person_idx: int, new_age: int) -> None:
+        """Age 変更を内部状態に適用する.
+
+        observed ヒストグラムと total_score を更新し、
+        arrays.age[person_idx] を new_age に書き換える。
+
+        Parameters
+        ----------
+        person_idx : int
+            変更対象の person の index（0-indexed）。
+        new_age : int
+            変更後の age（0 以上）。
+        """
+        old_age = int(self.arrays.age[person_idx])
+        if old_age == new_age:
+            return
+
+        # スコア差分を計算してから状態を更新
+        delta = self._compute_delta_for_change(person_idx, new_age)
+
+        # ヒストグラムを実更新
+        self._update_histograms(person_idx, old_age, new_age)
+
+        # arrays.age を更新
+        self.arrays.age[person_idx] = np.int16(new_age)
+
+        # total_score を更新
+        self.total_score += delta
+
+    def _update_histograms(self, person_idx: int, old_age: int, new_age: int) -> None:
+        """Observed ヒストグラムを差分更新する（arrays.age は更新前）.
+
+        Parameters
+        ----------
+        person_idx : int
+            変更対象の person の index。
+        old_age : int
+            変更前の age。
+        new_age : int
+            変更後の age。
+        """
+        sex_id = int(self.arrays.sex[person_idx])
+        pyramid_idx = 3 + sex_id
+        pyramid_stat = self.stats[pyramid_idx]
+        _apply_pyramid_update(pyramid_stat, old_age, new_age)
+
+        role_id = int(self.arrays.role[person_idx])
+        role_name = self.arrays.role_reg.name_of(role_id)
+        hid = int(self.arrays.household_id[person_idx])
+
+        if role_name in ("father", "mother"):
+            stat_idx = 0 if role_name == "father" else 1
+            stat = self.stats[stat_idx]
+            try:
+                child_role_id = self.arrays.role_reg.id_of("child")
+                child_mask = (self.arrays.household_id == hid) & (self.arrays.role == child_role_id)
+                child_ages = self.arrays.age[child_mask].astype(np.int64)
+                _apply_parent_child_update(stat, old_age, new_age, child_ages)
+            except KeyError:
+                pass
+
+        elif role_name == "child":
+            try:
+                father_role_id = self.arrays.role_reg.id_of("father")
+                father_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == father_role_id
+                )
+                father_ages = self.arrays.age[father_mask].astype(np.int64)
+                if np.any(father_mask):
+                    _apply_child_parent_diff_update(self.stats[0], old_age, new_age, father_ages)
+            except KeyError:
+                pass
+
+            try:
+                mother_role_id = self.arrays.role_reg.id_of("mother")
+                mother_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == mother_role_id
+                )
+                mother_ages = self.arrays.age[mother_mask].astype(np.int64)
+                if np.any(mother_mask):
+                    _apply_child_parent_diff_update(self.stats[1], old_age, new_age, mother_ages)
+            except KeyError:
+                pass
+
+        elif role_name == "husband":
+            try:
+                wife_role_id = self.arrays.role_reg.id_of("wife")
+                wife_mask = (self.arrays.household_id == hid) & (self.arrays.role == wife_role_id)
+                wife_ages = self.arrays.age[wife_mask].astype(np.int64)
+                if np.any(wife_mask):
+                    _apply_husband_couple_update(self.stats[2], old_age, new_age, wife_ages)
+            except KeyError:
+                pass
+
+        elif role_name == "wife":
+            try:
+                husband_role_id = self.arrays.role_reg.id_of("husband")
+                husband_mask = (self.arrays.household_id == hid) & (
+                    self.arrays.role == husband_role_id
+                )
+                husband_ages = self.arrays.age[husband_mask].astype(np.int64)
+                if np.any(husband_mask):
+                    _apply_wife_couple_update(self.stats[2], old_age, new_age, husband_ages)
+            except KeyError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 差分計算ヘルパー（副作用なし）
+# ---------------------------------------------------------------------------
+
+
+def _delta_pyramid(stat: StatTable, old_age: int, new_age: int) -> float:
+    """Pyramid 統計の L1 変化量を計算する（副作用なし）.
+
+    old_age → new_age の変化で observed[old_bin] -= 1, observed[new_bin] += 1 が起きる。
+
+    Parameters
+    ----------
+    stat : StatTable
+        pyramid 統計テーブル。
+    old_age : int
+        変更前の age。
+    new_age : int
+        変更後の age。
+
+    Returns
+    -------
+    float
+        スコア変化量 Δ（新スコア - 旧スコア）。
+    """
+    n_bins = len(stat.observed)
+    old_bin = _bin_index(stat.bin_edges, float(old_age))
+    new_bin = _bin_index(stat.bin_edges, float(new_age))
+
+    if old_bin == new_bin:
+        return 0.0
+
+    delta = 0.0
+
+    # old_bin: observed が 1 減る
+    if 0 <= old_bin < n_bins:
+        obs = int(stat.observed[old_bin])
+        tgt = int(stat.target[old_bin])
+        old_contrib = abs(obs - tgt)
+        new_contrib = abs((obs - 1) - tgt)
+        delta += new_contrib - old_contrib
+
+    # new_bin: observed が 1 増える
+    if 0 <= new_bin < n_bins:
+        obs = int(stat.observed[new_bin])
+        tgt = int(stat.target[new_bin])
+        old_contrib = abs(obs - tgt)
+        new_contrib = abs((obs + 1) - tgt)
+        delta += new_contrib - old_contrib
+
+    return delta
+
+
+def _delta_parent_child_diffs(
+    stat: StatTable,
+    parent_old_age: int,
+    parent_new_age: int,
+    child_ages: np.ndarray,
+) -> float:
+    """親の age 変化による親子差分統計の L1 変化量を計算する（副作用なし）.
+
+    Parameters
+    ----------
+    stat : StatTable
+        親子差分統計テーブル。
+    parent_old_age : int
+        親の変更前 age。
+    parent_new_age : int
+        親の変更後 age。
+    child_ages : np.ndarray
+        同世帯の child の age 配列。
+
+    Returns
+    -------
+    float
+        スコア変化量 Δ。
+    """
+    if len(child_ages) == 0:
+        return 0.0
+
+    n_bins = len(stat.observed)
+    delta = 0.0
+
+    # 一時 observed を作成してデルタを計算
+    temp_observed = stat.observed.copy()
+
+    for child_age in child_ages:
+        old_diff = float(parent_old_age - int(child_age))
+        new_diff = float(parent_new_age - int(child_age))
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            obs = int(temp_observed[old_bin])
+            tgt = int(stat.target[old_bin])
+            delta += abs((obs - 1) - tgt) - abs(obs - tgt)
+            temp_observed[old_bin] -= 1
+
+        if 0 <= new_bin < n_bins:
+            obs = int(temp_observed[new_bin])
+            tgt = int(stat.target[new_bin])
+            delta += abs((obs + 1) - tgt) - abs(obs - tgt)
+            temp_observed[new_bin] += 1
+
+    return delta
+
+
+def _delta_child_changes_parent_diff(
+    stat: StatTable,
+    child_old_age: int,
+    child_new_age: int,
+    parent_ages: np.ndarray,
+) -> float:
+    """Child の age 変化による親子差分統計の L1 変化量を計算する（副作用なし）.
+
+    diff = parent_age - child_age なので、child_age が上がると diff が下がる。
+
+    Parameters
+    ----------
+    stat : StatTable
+        親子差分統計テーブル。
+    child_old_age : int
+        child の変更前 age。
+    child_new_age : int
+        child の変更後 age。
+    parent_ages : np.ndarray
+        同世帯の親（father または mother）の age 配列。
+
+    Returns
+    -------
+    float
+        スコア変化量 Δ。
+    """
+    if len(parent_ages) == 0:
+        return 0.0
+
+    n_bins = len(stat.observed)
+    delta = 0.0
+    temp_observed = stat.observed.copy()
+
+    for parent_age in parent_ages:
+        old_diff = float(int(parent_age) - child_old_age)
+        new_diff = float(int(parent_age) - child_new_age)
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            obs = int(temp_observed[old_bin])
+            tgt = int(stat.target[old_bin])
+            delta += abs((obs - 1) - tgt) - abs(obs - tgt)
+            temp_observed[old_bin] -= 1
+
+        if 0 <= new_bin < n_bins:
+            obs = int(temp_observed[new_bin])
+            tgt = int(stat.target[new_bin])
+            delta += abs((obs + 1) - tgt) - abs(obs - tgt)
+            temp_observed[new_bin] += 1
+
+    return delta
+
+
+def _delta_husband_age_changes_couple(
+    stat: StatTable,
+    husband_old_age: int,
+    husband_new_age: int,
+    wife_ages: np.ndarray,
+) -> float:
+    """Husband の age 変化による couple 差分統計の L1 変化量を計算する（副作用なし）.
+
+    diff = husband_age - wife_age
+
+    Parameters
+    ----------
+    stat : StatTable
+        couple 差分統計テーブル。
+    husband_old_age : int
+        夫の変更前 age。
+    husband_new_age : int
+        夫の変更後 age。
+    wife_ages : np.ndarray
+        同世帯の妻の age 配列。
+
+    Returns
+    -------
+    float
+        スコア変化量 Δ。
+    """
+    if len(wife_ages) == 0:
+        return 0.0
+
+    n_bins = len(stat.observed)
+    delta = 0.0
+    temp_observed = stat.observed.copy()
+
+    for wife_age in wife_ages:
+        old_diff = float(husband_old_age - int(wife_age))
+        new_diff = float(husband_new_age - int(wife_age))
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            obs = int(temp_observed[old_bin])
+            tgt = int(stat.target[old_bin])
+            delta += abs((obs - 1) - tgt) - abs(obs - tgt)
+            temp_observed[old_bin] -= 1
+
+        if 0 <= new_bin < n_bins:
+            obs = int(temp_observed[new_bin])
+            tgt = int(stat.target[new_bin])
+            delta += abs((obs + 1) - tgt) - abs(obs - tgt)
+            temp_observed[new_bin] += 1
+
+    return delta
+
+
+def _delta_wife_age_changes_couple(
+    stat: StatTable,
+    wife_old_age: int,
+    wife_new_age: int,
+    husband_ages: np.ndarray,
+) -> float:
+    """Wife の age 変化による couple 差分統計の L1 変化量を計算する（副作用なし）.
+
+    diff = husband_age - wife_age なので wife_age が上がると diff が下がる。
+
+    Parameters
+    ----------
+    stat : StatTable
+        couple 差分統計テーブル。
+    wife_old_age : int
+        妻の変更前 age。
+    wife_new_age : int
+        妻の変更後 age。
+    husband_ages : np.ndarray
+        同世帯の夫の age 配列。
+
+    Returns
+    -------
+    float
+        スコア変化量 Δ。
+    """
+    if len(husband_ages) == 0:
+        return 0.0
+
+    n_bins = len(stat.observed)
+    delta = 0.0
+    temp_observed = stat.observed.copy()
+
+    for husband_age in husband_ages:
+        old_diff = float(int(husband_age) - wife_old_age)
+        new_diff = float(int(husband_age) - wife_new_age)
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            obs = int(temp_observed[old_bin])
+            tgt = int(stat.target[old_bin])
+            delta += abs((obs - 1) - tgt) - abs(obs - tgt)
+            temp_observed[old_bin] -= 1
+
+        if 0 <= new_bin < n_bins:
+            obs = int(temp_observed[new_bin])
+            tgt = int(stat.target[new_bin])
+            delta += abs((obs + 1) - tgt) - abs(obs - tgt)
+            temp_observed[new_bin] += 1
+
+    return delta
+
+
+# ---------------------------------------------------------------------------
+# ヒストグラム実更新ヘルパー（apply_change 用）
+# ---------------------------------------------------------------------------
+
+
+def _apply_pyramid_update(stat: StatTable, old_age: int, new_age: int) -> None:
+    """Pyramid 統計の observed ヒストグラムを実更新する.
+
+    Parameters
+    ----------
+    stat : StatTable
+        pyramid 統計テーブル（インプレース更新）。
+    old_age : int
+        変更前の age。
+    new_age : int
+        変更後の age。
+    """
+    n_bins = len(stat.observed)
+    old_bin = _bin_index(stat.bin_edges, float(old_age))
+    new_bin = _bin_index(stat.bin_edges, float(new_age))
+
+    if old_bin == new_bin:
+        return
+
+    if 0 <= old_bin < n_bins:
+        stat.observed[old_bin] -= 1
+    if 0 <= new_bin < n_bins:
+        stat.observed[new_bin] += 1
+
+
+def _apply_parent_child_update(
+    stat: StatTable,
+    parent_old_age: int,
+    parent_new_age: int,
+    child_ages: np.ndarray,
+) -> None:
+    """親子差分統計の observed を実更新する（親の age 変化）.
+
+    Parameters
+    ----------
+    stat : StatTable
+        親子差分統計テーブル（インプレース更新）。
+    parent_old_age : int
+        親の変更前 age。
+    parent_new_age : int
+        親の変更後 age。
+    child_ages : np.ndarray
+        同世帯の child age 配列。
+    """
+    n_bins = len(stat.observed)
+    for child_age in child_ages:
+        old_diff = float(parent_old_age - int(child_age))
+        new_diff = float(parent_new_age - int(child_age))
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            stat.observed[old_bin] -= 1
+        if 0 <= new_bin < n_bins:
+            stat.observed[new_bin] += 1
+
+
+def _apply_child_parent_diff_update(
+    stat: StatTable,
+    child_old_age: int,
+    child_new_age: int,
+    parent_ages: np.ndarray,
+) -> None:
+    """親子差分統計の observed を実更新する（child の age 変化）.
+
+    Parameters
+    ----------
+    stat : StatTable
+        親子差分統計テーブル（インプレース更新）。
+    child_old_age : int
+        child の変更前 age。
+    child_new_age : int
+        child の変更後 age。
+    parent_ages : np.ndarray
+        同世帯の親（father または mother）の age 配列。
+    """
+    n_bins = len(stat.observed)
+    for parent_age in parent_ages:
+        old_diff = float(int(parent_age) - child_old_age)
+        new_diff = float(int(parent_age) - child_new_age)
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            stat.observed[old_bin] -= 1
+        if 0 <= new_bin < n_bins:
+            stat.observed[new_bin] += 1
+
+
+def _apply_husband_couple_update(
+    stat: StatTable,
+    husband_old_age: int,
+    husband_new_age: int,
+    wife_ages: np.ndarray,
+) -> None:
+    """Couple 差分統計の observed を実更新する（husband の age 変化）.
+
+    Parameters
+    ----------
+    stat : StatTable
+        couple 差分統計テーブル（インプレース更新）。
+    husband_old_age : int
+        夫の変更前 age。
+    husband_new_age : int
+        夫の変更後 age。
+    wife_ages : np.ndarray
+        同世帯の妻の age 配列。
+    """
+    n_bins = len(stat.observed)
+    for wife_age in wife_ages:
+        old_diff = float(husband_old_age - int(wife_age))
+        new_diff = float(husband_new_age - int(wife_age))
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            stat.observed[old_bin] -= 1
+        if 0 <= new_bin < n_bins:
+            stat.observed[new_bin] += 1
+
+
+def _apply_wife_couple_update(
+    stat: StatTable,
+    wife_old_age: int,
+    wife_new_age: int,
+    husband_ages: np.ndarray,
+) -> None:
+    """Couple 差分統計の observed を実更新する（wife の age 変化）.
+
+    Parameters
+    ----------
+    stat : StatTable
+        couple 差分統計テーブル（インプレース更新）。
+    wife_old_age : int
+        妻の変更前 age。
+    wife_new_age : int
+        妻の変更後 age。
+    husband_ages : np.ndarray
+        同世帯の夫の age 配列。
+    """
+    n_bins = len(stat.observed)
+    for husband_age in husband_ages:
+        old_diff = float(int(husband_age) - wife_old_age)
+        new_diff = float(int(husband_age) - wife_new_age)
+
+        old_bin = _bin_index(stat.bin_edges, old_diff)
+        new_bin = _bin_index(stat.bin_edges, new_diff)
+
+        if old_bin == new_bin:
+            continue
+
+        if 0 <= old_bin < n_bins:
+            stat.observed[old_bin] -= 1
+        if 0 <= new_bin < n_bins:
+            stat.observed[new_bin] += 1

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -12,10 +12,11 @@ TDD サイクル:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypedDict
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from synthpop_jp.init.initial_population import InitStats, generate_initial_population
@@ -29,9 +30,22 @@ from synthpop_jp.io.loaders import (
     load_family_type_mapping,
     load_household_size_by_family_type,
 )
-from synthpop_jp.optimize.objective import ObjectiveState, build_objective_stats
+from synthpop_jp.io.schemas import (
+    AgeDiffCoupleRow,
+    AgeDiffParentChildRow,
+    DemographicByAgeSexRow,
+)
+from synthpop_jp.optimize.objective import ObjectiveState
 from synthpop_jp.optimize.state import PopulationArrays
 from synthpop_jp.rng import SeedRegistry
+
+
+class ObjectiveInput(TypedDict):
+    """ObjectiveState 構築に必要な統計テーブルをまとめた型."""
+
+    age_diff_parent_child: list[AgeDiffParentChildRow]
+    age_diff_couple: list[AgeDiffCoupleRow]
+    demographic_by_age_sex: list[DemographicByAgeSexRow]
 
 
 # ---------------------------------------------------------------------------
@@ -90,19 +104,17 @@ def sample_arrays(sample_stats: InitStats, rng: np.random.Generator) -> Populati
 
 
 @pytest.fixture
-def objective_input(sample_stats: InitStats):
+def objective_input(sample_stats: InitStats) -> ObjectiveInput:
     """ObjectiveState 構築に必要な統計テーブルをまとめた dict."""
-    return {
-        "age_diff_parent_child": load_age_diff_parent_child(
-            _DATA_DIR / "age_diff_parent_child.csv"
-        ),
-        "age_diff_couple": load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
-        "demographic_by_age_sex": sample_stats.demographic_by_age_sex,
-    }
+    return ObjectiveInput(
+        age_diff_parent_child=load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv"),
+        age_diff_couple=load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        demographic_by_age_sex=sample_stats.demographic_by_age_sex,
+    )
 
 
 @pytest.fixture
-def objective(sample_arrays: PopulationArrays, objective_input: dict) -> ObjectiveState:
+def objective(sample_arrays: PopulationArrays, objective_input: ObjectiveInput) -> ObjectiveState:
     """ObjectiveState を sample_case から初期化."""
     return ObjectiveState.from_arrays(
         arrays=sample_arrays,
@@ -145,8 +157,10 @@ class TestFromArrays:
     def test_total_score_equals_sum_of_l1_per_stat(self, objective: ObjectiveState) -> None:
         """total_score が各統計の L1 ノルムの合計に一致する."""
         expected = float(
-            sum(np.abs(stat.observed.astype(np.int64) - stat.target.astype(np.int64)).sum()
-                for stat in objective.stats)
+            sum(
+                np.abs(stat.observed.astype(np.int64) - stat.target.astype(np.int64)).sum()
+                for stat in objective.stats
+            )
         )
         assert objective.total_score == pytest.approx(expected, abs=1e-6)
 
@@ -214,9 +228,7 @@ class TestProposeChangeNoSideEffect:
 class TestApplyChangeConsistency:
     """apply_change と propose_change の整合性テスト."""
 
-    def test_apply_change_updates_total_score_consistently(
-        self, objective: ObjectiveState
-    ) -> None:
+    def test_apply_change_updates_total_score_consistently(self, objective: ObjectiveState) -> None:
         """apply_change 後の total_score = before + propose_change."""
         before_score = objective.total_score
         idx = 0
@@ -270,9 +282,7 @@ class TestApplyChangeReversibility:
 
         assert objective.total_score == pytest.approx(original_score, abs=1e-6)
 
-    def test_apply_and_revert_restores_observed_histograms(
-        self, objective: ObjectiveState
-    ) -> None:
+    def test_apply_and_revert_restores_observed_histograms(self, objective: ObjectiveState) -> None:
         """apply → revert で全統計の observed が元に戻る."""
         observed_originals = [stat.observed.copy() for stat in objective.stats]
 
@@ -312,9 +322,9 @@ class TestApplyChangeReversibility:
 
 def _full_recompute_score(
     arrays: PopulationArrays,
-    age_diff_parent_child,
-    age_diff_couple,
-    demographic_by_age_sex,
+    age_diff_parent_child: list[AgeDiffParentChildRow],
+    age_diff_couple: list[AgeDiffCoupleRow],
+    demographic_by_age_sex: list[DemographicByAgeSexRow],
 ) -> float:
     """全再計算でスコアを求めるヘルパー（property test 用）."""
     fresh = ObjectiveState.from_arrays(
@@ -330,7 +340,7 @@ class TestDifferentialUpdateEqualsFullRecompute:
     """差分更新が全再計算と bitwise 一致することを確認する（最重要テスト）."""
 
     def test_propose_equals_full_recompute_delta_single(
-        self, objective: ObjectiveState, objective_input: dict
+        self, objective: ObjectiveState, objective_input: ObjectiveInput
     ) -> None:
         """単一の propose_change が全再計算差分に一致する（固定ケース）."""
         idx = 0
@@ -358,12 +368,16 @@ class TestDifferentialUpdateEqualsFullRecompute:
         person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
         new_age=st.integers(min_value=0, max_value=100),
     )
-    @settings(max_examples=50, deadline=5000)
+    @settings(
+        max_examples=50,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
     def test_propose_equals_full_recompute_delta_property(
         self,
         person_idx_frac: float,
         new_age: int,
-        objective_input: dict,
+        objective_input: ObjectiveInput,
         sample_stats: InitStats,
     ) -> None:
         """任意の (person_idx, new_age) で propose_change が全再計算差分に一致する."""
@@ -405,12 +419,16 @@ class TestDifferentialUpdateEqualsFullRecompute:
         person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
         new_age=st.integers(min_value=0, max_value=100),
     )
-    @settings(max_examples=30, deadline=5000)
+    @settings(
+        max_examples=30,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
     def test_apply_then_revert_restores_score_property(
         self,
         person_idx_frac: float,
         new_age: int,
-        objective_input: dict,
+        objective_input: ObjectiveInput,
         sample_stats: InitStats,
     ) -> None:
         """apply → revert で total_score が元に戻る（property test）."""
@@ -467,6 +485,5 @@ class TestPerformanceSkeleton:
         # （厳密な 100μs/回 の確認は pytest-benchmark で行う）
         avg_us = elapsed / n_trials * 1e6
         assert elapsed < 1.0, (
-            f"1000 回の propose_change が {elapsed:.3f} 秒 かかった "
-            f"(avg={avg_us:.1f}μs/回)"
+            f"1000 回の propose_change が {elapsed:.3f} 秒 かかった (avg={avg_us:.1f}μs/回)"
         )

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -1,0 +1,472 @@
+"""Tests for ObjectiveState — 差分更新版目的関数.
+
+TDD サイクル:
+  Cycle 1: from_arrays で 5 統計の観測ヒストグラムが初期化され total_score が計算できる
+  Cycle 2: propose_change が副作用なし
+  Cycle 3: apply_change 後の total_score が before + propose_change に一致
+  Cycle 4: apply_change → 元に戻す apply_change で total_score が復元される
+  Cycle 5: hypothesis property test — 差分更新 ≡ 全再計算（最重要）
+  Cycle 6: pytest-benchmark skeleton — propose_change が 100μs 以下
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from synthpop_jp.init.initial_population import InitStats, generate_initial_population
+from synthpop_jp.io.loaders import (
+    load_age_diff_couple,
+    load_age_diff_parent_child,
+    load_children_count_dist,
+    load_demographic_by_age_sex,
+    load_demographic_by_family_type_role,
+    load_family_type_counts,
+    load_family_type_mapping,
+    load_household_size_by_family_type,
+)
+from synthpop_jp.optimize.objective import ObjectiveState, build_objective_stats
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.rng import SeedRegistry
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml 探索によるリポジトリルート解決（docs/rules/tdd.md §10）
+# ---------------------------------------------------------------------------
+
+
+def _find_repo_root() -> Path:
+    """pyproject.toml を含む最近接の祖先を repo root とみなす."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError(f"pyproject.toml が {here} から辿れない階層に見つからない")
+
+
+_REPO_ROOT = _find_repo_root()
+_DATA_DIR = _REPO_ROOT / "data" / "sample_case"
+_CONFIGS_DIR = _REPO_ROOT / "configs"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """固定 seed の乱数発生器."""
+    return SeedRegistry(root=42).rng("init")
+
+
+@pytest.fixture
+def sample_stats() -> InitStats:
+    """sample_case から読み込んだ統計データ."""
+    return InitStats(
+        family_type_counts=load_family_type_counts(_DATA_DIR / "family_type_counts.csv"),
+        children_count_dist=load_children_count_dist(_DATA_DIR / "children_count_dist.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+        family_type_mapping=load_family_type_mapping(_CONFIGS_DIR / "family_type_mapping.yaml"),
+        household_size_by_family_type=load_household_size_by_family_type(
+            _DATA_DIR / "household_size_by_family_type.csv"
+        ),
+        demographic_by_family_type_role=load_demographic_by_family_type_role(
+            _DATA_DIR / "demographic_by_family_type_role.csv"
+        ),
+    )
+
+
+@pytest.fixture
+def sample_arrays(sample_stats: InitStats, rng: np.random.Generator) -> PopulationArrays:
+    """sample_case から生成した初期人口."""
+    return generate_initial_population(sample_stats, rng)
+
+
+@pytest.fixture
+def objective_input(sample_stats: InitStats):
+    """ObjectiveState 構築に必要な統計テーブルをまとめた dict."""
+    return {
+        "age_diff_parent_child": load_age_diff_parent_child(
+            _DATA_DIR / "age_diff_parent_child.csv"
+        ),
+        "age_diff_couple": load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        "demographic_by_age_sex": sample_stats.demographic_by_age_sex,
+    }
+
+
+@pytest.fixture
+def objective(sample_arrays: PopulationArrays, objective_input: dict) -> ObjectiveState:
+    """ObjectiveState を sample_case から初期化."""
+    return ObjectiveState.from_arrays(
+        arrays=sample_arrays,
+        age_diff_parent_child=objective_input["age_diff_parent_child"],
+        age_diff_couple=objective_input["age_diff_couple"],
+        demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1: from_arrays で 5 統計が初期化され total_score が計算できる
+# ---------------------------------------------------------------------------
+
+
+class TestFromArrays:
+    """ObjectiveState.from_arrays の初期化テスト."""
+
+    def test_total_score_is_nonnegative(self, objective: ObjectiveState) -> None:
+        """total_score は L1 ノルムのため非負である."""
+        assert objective.total_score >= 0.0
+
+    def test_total_score_is_finite(self, objective: ObjectiveState) -> None:
+        """total_score は有限値である（nan/inf でない）."""
+        assert np.isfinite(objective.total_score)
+
+    def test_has_five_stat_tables(self, objective: ObjectiveState) -> None:
+        """5 統計分の stat テーブルが存在する."""
+        assert len(objective.stats) == 5
+
+    def test_observed_counts_are_nonnegative(self, objective: ObjectiveState) -> None:
+        """全統計の observed カウントが非負整数である."""
+        for stat in objective.stats:
+            assert np.all(stat.observed >= 0)
+
+    def test_target_counts_are_nonnegative(self, objective: ObjectiveState) -> None:
+        """全統計の target カウントが非負整数である."""
+        for stat in objective.stats:
+            assert np.all(stat.target >= 0)
+
+    def test_total_score_equals_sum_of_l1_per_stat(self, objective: ObjectiveState) -> None:
+        """total_score が各統計の L1 ノルムの合計に一致する."""
+        expected = float(
+            sum(np.abs(stat.observed.astype(np.int64) - stat.target.astype(np.int64)).sum()
+                for stat in objective.stats)
+        )
+        assert objective.total_score == pytest.approx(expected, abs=1e-6)
+
+    def test_male_pyramid_observed_sum_matches_male_persons(
+        self, objective: ObjectiveState, sample_arrays: PopulationArrays
+    ) -> None:
+        """male pyramid の observed 合計 = 男性人数."""
+        n_males = int((sample_arrays.sex == 0).sum())
+        # stats[3] は male pyramid
+        male_pyramid_observed_sum = int(objective.stats[3].observed.sum())
+        assert male_pyramid_observed_sum == n_males
+
+    def test_female_pyramid_observed_sum_matches_female_persons(
+        self, objective: ObjectiveState, sample_arrays: PopulationArrays
+    ) -> None:
+        """female pyramid の observed 合計 = 女性人数."""
+        n_females = int((sample_arrays.sex == 1).sum())
+        # stats[4] は female pyramid
+        female_pyramid_observed_sum = int(objective.stats[4].observed.sum())
+        assert female_pyramid_observed_sum == n_females
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: propose_change が副作用なし
+# ---------------------------------------------------------------------------
+
+
+class TestProposeChangeNoSideEffect:
+    """propose_change は副作用を持たない."""
+
+    def test_propose_does_not_change_total_score(self, objective: ObjectiveState) -> None:
+        """propose_change 後も total_score が変わらない."""
+        before = objective.total_score
+        # 最初の person の age を 1 増やす提案
+        new_age = int(objective.arrays.age[0]) + 1
+        objective.propose_change(0, new_age)
+        assert objective.total_score == before
+
+    def test_propose_does_not_change_arrays_age(self, objective: ObjectiveState) -> None:
+        """propose_change 後も arrays.age が変わらない."""
+        old_age = int(objective.arrays.age[0])
+        new_age = old_age + 1
+        objective.propose_change(0, new_age)
+        assert int(objective.arrays.age[0]) == old_age
+
+    def test_propose_returns_finite_float(self, objective: ObjectiveState) -> None:
+        """propose_change の戻り値は有限の float である."""
+        new_age = int(objective.arrays.age[0]) + 1
+        delta = objective.propose_change(0, new_age)
+        assert isinstance(delta, float)
+        assert np.isfinite(delta)
+
+    def test_propose_no_change_returns_zero(self, objective: ObjectiveState) -> None:
+        """age を変えない propose_change の差分は 0 である."""
+        current_age = int(objective.arrays.age[0])
+        delta = objective.propose_change(0, current_age)
+        assert delta == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: apply_change 後の total_score が before + propose_change に一致
+# ---------------------------------------------------------------------------
+
+
+class TestApplyChangeConsistency:
+    """apply_change と propose_change の整合性テスト."""
+
+    def test_apply_change_updates_total_score_consistently(
+        self, objective: ObjectiveState
+    ) -> None:
+        """apply_change 後の total_score = before + propose_change."""
+        before_score = objective.total_score
+        idx = 0
+        new_age = int(objective.arrays.age[idx]) + 2
+        delta = objective.propose_change(idx, new_age)
+        objective.apply_change(idx, new_age)
+        expected = before_score + delta
+        assert objective.total_score == pytest.approx(expected, abs=1e-6)
+
+    def test_apply_change_updates_arrays_age(self, objective: ObjectiveState) -> None:
+        """apply_change 後は arrays.age が new_age に更新されている."""
+        idx = 0
+        new_age = int(objective.arrays.age[idx]) + 2
+        objective.apply_change(idx, new_age)
+        assert int(objective.arrays.age[idx]) == new_age
+
+    def test_apply_change_updates_observed_histogram(self, objective: ObjectiveState) -> None:
+        """apply_change 後に observed ヒストグラムが変化している."""
+        idx = 0
+        old_age = int(objective.arrays.age[idx])
+        new_age = old_age + 5
+
+        # male pyramid の観測値を記録
+        observed_before = objective.stats[3].observed.copy()
+        objective.apply_change(idx, new_age)
+        observed_after = objective.stats[3].observed.copy()
+
+        # old_age と new_age が同じビンでない限り変化するはず（男性の場合）
+        sex_id = int(objective.arrays.sex[idx])
+        if sex_id == 0 and old_age != new_age:  # M
+            assert not np.array_equal(observed_before, observed_after)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: apply_change → 元に戻す apply_change で total_score が復元される
+# ---------------------------------------------------------------------------
+
+
+class TestApplyChangeReversibility:
+    """apply_change の可逆性テスト."""
+
+    def test_apply_and_revert_restores_total_score(self, objective: ObjectiveState) -> None:
+        """apply → revert で total_score が元に戻る."""
+        original_score = objective.total_score
+        idx = 0
+        old_age = int(objective.arrays.age[idx])
+        new_age = old_age + 3
+
+        objective.apply_change(idx, new_age)
+        objective.apply_change(idx, old_age)  # 元に戻す
+
+        assert objective.total_score == pytest.approx(original_score, abs=1e-6)
+
+    def test_apply_and_revert_restores_observed_histograms(
+        self, objective: ObjectiveState
+    ) -> None:
+        """apply → revert で全統計の observed が元に戻る."""
+        observed_originals = [stat.observed.copy() for stat in objective.stats]
+
+        idx = 0
+        old_age = int(objective.arrays.age[idx])
+        new_age = old_age + 3
+
+        objective.apply_change(idx, new_age)
+        objective.apply_change(idx, old_age)
+
+        for i, stat in enumerate(objective.stats):
+            assert np.array_equal(stat.observed, observed_originals[i]), (
+                f"stats[{i}] の observed が復元されていない"
+            )
+
+    def test_multiple_apply_and_revert(self, objective: ObjectiveState) -> None:
+        """複数回の apply → revert でも total_score が元に戻る."""
+        original_score = objective.total_score
+        n_persons = objective.arrays.n_persons
+
+        for i in range(min(5, n_persons)):
+            old_age = int(objective.arrays.age[i])
+            new_age = old_age + 1
+            objective.apply_change(i, new_age)
+
+        for i in range(min(5, n_persons) - 1, -1, -1):
+            old_age = int(objective.arrays.age[i]) - 1  # apply 前の値
+            objective.apply_change(i, old_age)
+
+        assert objective.total_score == pytest.approx(original_score, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5: hypothesis property test — 差分更新 ≡ 全再計算（最重要）
+# ---------------------------------------------------------------------------
+
+
+def _full_recompute_score(
+    arrays: PopulationArrays,
+    age_diff_parent_child,
+    age_diff_couple,
+    demographic_by_age_sex,
+) -> float:
+    """全再計算でスコアを求めるヘルパー（property test 用）."""
+    fresh = ObjectiveState.from_arrays(
+        arrays=arrays,
+        age_diff_parent_child=age_diff_parent_child,
+        age_diff_couple=age_diff_couple,
+        demographic_by_age_sex=demographic_by_age_sex,
+    )
+    return fresh.total_score
+
+
+class TestDifferentialUpdateEqualsFullRecompute:
+    """差分更新が全再計算と bitwise 一致することを確認する（最重要テスト）."""
+
+    def test_propose_equals_full_recompute_delta_single(
+        self, objective: ObjectiveState, objective_input: dict
+    ) -> None:
+        """単一の propose_change が全再計算差分に一致する（固定ケース）."""
+        idx = 0
+        new_age = min(int(objective.arrays.age[idx]) + 5, 80)
+
+        # 差分更新で計算
+        delta_differential = objective.propose_change(idx, new_age)
+        score_before = objective.total_score
+
+        # 全再計算: age を変えた配列で再初期化
+        old_age = int(objective.arrays.age[idx])
+        objective.arrays.age[idx] = np.int16(new_age)
+        score_after_full = _full_recompute_score(
+            objective.arrays,
+            objective_input["age_diff_parent_child"],
+            objective_input["age_diff_couple"],
+            objective_input["demographic_by_age_sex"],
+        )
+        objective.arrays.age[idx] = np.int16(old_age)  # 元に戻す
+
+        expected_delta = score_after_full - score_before
+        assert delta_differential == pytest.approx(expected_delta, abs=1e-6)
+
+    @given(
+        person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+        new_age=st.integers(min_value=0, max_value=100),
+    )
+    @settings(max_examples=50, deadline=5000)
+    def test_propose_equals_full_recompute_delta_property(
+        self,
+        person_idx_frac: float,
+        new_age: int,
+        objective_input: dict,
+        sample_stats: InitStats,
+    ) -> None:
+        """任意の (person_idx, new_age) で propose_change が全再計算差分に一致する."""
+        # 毎回 fresh な ObjectiveState と PopulationArrays を生成
+        rng = SeedRegistry(root=42).rng("init")
+        arrays = generate_initial_population(sample_stats, rng)
+        obj = ObjectiveState.from_arrays(
+            arrays=arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+        )
+
+        n_persons = obj.arrays.n_persons
+        idx = max(0, min(int(person_idx_frac * n_persons), n_persons - 1))
+        score_before = obj.total_score
+
+        # 差分更新で delta を計算
+        delta_differential = obj.propose_change(idx, new_age)
+
+        # 全再計算: age を変えた配列で再初期化
+        old_age = int(obj.arrays.age[idx])
+        obj.arrays.age[idx] = np.int16(new_age)
+        score_after_full = _full_recompute_score(
+            obj.arrays,
+            objective_input["age_diff_parent_child"],
+            objective_input["age_diff_couple"],
+            objective_input["demographic_by_age_sex"],
+        )
+        obj.arrays.age[idx] = np.int16(old_age)  # 元に戻す
+
+        expected_delta = score_after_full - score_before
+        assert delta_differential == pytest.approx(expected_delta, abs=1e-6), (
+            f"idx={idx}, old_age={old_age}, new_age={new_age}: "
+            f"differential={delta_differential:.6f}, full={expected_delta:.6f}"
+        )
+
+    @given(
+        person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+        new_age=st.integers(min_value=0, max_value=100),
+    )
+    @settings(max_examples=30, deadline=5000)
+    def test_apply_then_revert_restores_score_property(
+        self,
+        person_idx_frac: float,
+        new_age: int,
+        objective_input: dict,
+        sample_stats: InitStats,
+    ) -> None:
+        """apply → revert で total_score が元に戻る（property test）."""
+        rng = SeedRegistry(root=42).rng("init")
+        arrays = generate_initial_population(sample_stats, rng)
+        obj = ObjectiveState.from_arrays(
+            arrays=arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+        )
+
+        n_persons = obj.arrays.n_persons
+        idx = max(0, min(int(person_idx_frac * n_persons), n_persons - 1))
+        original_score = obj.total_score
+        old_age = int(obj.arrays.age[idx])
+
+        obj.apply_change(idx, new_age)
+        obj.apply_change(idx, old_age)
+
+        assert obj.total_score == pytest.approx(original_score, abs=1e-6), (
+            f"idx={idx}, old_age={old_age}, new_age={new_age}: "
+            f"restored={obj.total_score:.6f}, original={original_score:.6f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6: pytest-benchmark skeleton — propose_change が 100μs 以下
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceSkeleton:
+    """propose_change の性能テスト（skeleton）."""
+
+    def test_propose_change_is_fast_skeleton(self, objective: ObjectiveState) -> None:
+        """propose_change が 1000 回実行できる（性能の sanity check）.
+
+        本格計測は Issue #6 で pytest-benchmark を使う。
+        ここでは 1000 回のループが 1 秒以内に終わることを確認する。
+        """
+        import time
+
+        n_persons = objective.arrays.n_persons
+        n_trials = 1000
+
+        start = time.perf_counter()
+        for i in range(n_trials):
+            idx = i % n_persons
+            new_age = (int(objective.arrays.age[idx]) + 1) % 80
+            objective.propose_change(idx, new_age)
+        elapsed = time.perf_counter() - start
+
+        # 1000 回で 1 秒以内 → 平均 1ms/回、100μs 目標より余裕あり
+        # （厳密な 100μs/回 の確認は pytest-benchmark で行う）
+        avg_us = elapsed / n_trials * 1e6
+        assert elapsed < 1.0, (
+            f"1000 回の propose_change が {elapsed:.3f} 秒 かかった "
+            f"(avg={avg_us:.1f}μs/回)"
+        )

--- a/tests/optimize/test_objective.py
+++ b/tests/optimize/test_objective.py
@@ -162,7 +162,7 @@ class TestFromArrays:
                 for stat in objective.stats
             )
         )
-        assert objective.total_score == pytest.approx(expected, abs=1e-6)
+        assert abs(objective.total_score - expected) < 1e-6
 
     def test_male_pyramid_observed_sum_matches_male_persons(
         self, objective: ObjectiveState, sample_arrays: PopulationArrays
@@ -217,7 +217,7 @@ class TestProposeChangeNoSideEffect:
         """age を変えない propose_change の差分は 0 である."""
         current_age = int(objective.arrays.age[0])
         delta = objective.propose_change(0, current_age)
-        assert delta == pytest.approx(0.0, abs=1e-9)
+        assert abs(delta) < 1e-9
 
 
 # ---------------------------------------------------------------------------
@@ -236,7 +236,7 @@ class TestApplyChangeConsistency:
         delta = objective.propose_change(idx, new_age)
         objective.apply_change(idx, new_age)
         expected = before_score + delta
-        assert objective.total_score == pytest.approx(expected, abs=1e-6)
+        assert abs(objective.total_score - expected) < 1e-6
 
     def test_apply_change_updates_arrays_age(self, objective: ObjectiveState) -> None:
         """apply_change 後は arrays.age が new_age に更新されている."""
@@ -280,7 +280,7 @@ class TestApplyChangeReversibility:
         objective.apply_change(idx, new_age)
         objective.apply_change(idx, old_age)  # 元に戻す
 
-        assert objective.total_score == pytest.approx(original_score, abs=1e-6)
+        assert abs(objective.total_score - original_score) < 1e-6
 
     def test_apply_and_revert_restores_observed_histograms(self, objective: ObjectiveState) -> None:
         """apply → revert で全統計の observed が元に戻る."""
@@ -312,7 +312,7 @@ class TestApplyChangeReversibility:
             old_age = int(objective.arrays.age[i]) - 1  # apply 前の値
             objective.apply_change(i, old_age)
 
-        assert objective.total_score == pytest.approx(original_score, abs=1e-6)
+        assert abs(objective.total_score - original_score) < 1e-6
 
 
 # ---------------------------------------------------------------------------
@@ -362,7 +362,7 @@ class TestDifferentialUpdateEqualsFullRecompute:
         objective.arrays.age[idx] = np.int16(old_age)  # 元に戻す
 
         expected_delta = score_after_full - score_before
-        assert delta_differential == pytest.approx(expected_delta, abs=1e-6)
+        assert abs(delta_differential - expected_delta) < 1e-6
 
     @given(
         person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
@@ -410,7 +410,7 @@ class TestDifferentialUpdateEqualsFullRecompute:
         obj.arrays.age[idx] = np.int16(old_age)  # 元に戻す
 
         expected_delta = score_after_full - score_before
-        assert delta_differential == pytest.approx(expected_delta, abs=1e-6), (
+        assert abs(delta_differential - expected_delta) < 1e-6, (
             f"idx={idx}, old_age={old_age}, new_age={new_age}: "
             f"differential={delta_differential:.6f}, full={expected_delta:.6f}"
         )
@@ -449,7 +449,7 @@ class TestDifferentialUpdateEqualsFullRecompute:
         obj.apply_change(idx, new_age)
         obj.apply_change(idx, old_age)
 
-        assert obj.total_score == pytest.approx(original_score, abs=1e-6), (
+        assert abs(obj.total_score - original_score) < 1e-6, (
             f"idx={idx}, old_age={old_age}, new_age={new_age}: "
             f"restored={obj.total_score:.6f}, original={original_score:.6f}"
         )


### PR DESCRIPTION
## 背景と価値

SA（シミュレーテッドアニーリング）の 1 ステップで 1 人の年齢が変わるたびに全人口を再計算すると、計算コストが O(N) になりスケールしない。本 PR では「差分更新」により O(1) でスコアを更新する `ObjectiveState` を実装し、SA の内部ループが高速に回せるようにする。

## 変更内容

### 新規実装

- **`src/synthpop_jp/optimize/objective.py`** (約 1,250 行追加)
  - `StatTable`: 1 統計分の observed/target ヒストグラムを保持
  - `_bin_index()`: `np.histogram` と一致するビン計算（境界値バグ修正済み）
  - `build_objective_stats()`: 5 統計の StatTable を構築
  - `ObjectiveState`: `from_arrays()` / `propose_change()` / `apply_change()` 実装

### 既存ファイルの変更

- **`src/synthpop_jp/optimize/state.py`**: `role_reg`, `sex_reg`, `family_reg` の公開プロパティを追加（pyright 対応）
- **`tests/optimize/test_objective.py`**: `ObjectiveInput` TypedDict 追加、型アノテーション整備、hypothesis HealthCheck 指定改善

## テスト結果

- 全 22 テスト pass（6 TDD サイクル、hypothesis property test 含む）
- 全テストスイート: 213 passed, 2 skipped（pre-existing）

## CI parity

- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pyright` ✅ (実装ファイルのエラーゼロ)
- `uv run pytest` ✅ 213 passed

## 重要な設計決定

`_bin_index()` ヘルパーで `np.histogram` の「最後ビンは右端閉区間」挙動を再現。これがないと `new_age == bin_edges[-1]` の境界値で差分更新と全再計算が一致しない（hypothesis が発見した実際のバグ）。

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)