### PR TITLE
[phase-2] #31 SA の収束過程を trace.jsonl + rich 進捗で追える

### DIFF
--- a/docs/spec/experiment_report_format.md
+++ b/docs/spec/experiment_report_format.md
@@ -106,6 +106,50 @@ Phase 3b で次の順で生成する:
 
 **JSON Schema を `schemas/metrics.schema.json` として Phase 3b でコミット。**
 
-## 7. 履歴
+## 7. `trace.jsonl` スキーマ（Issue #31）
+
+`synthpop-jp generate` を実行すると `outputs/<run_dir>/trace.jsonl` が生成される。
+1 行 = 1 JSON object の形式（JSON Lines 形式）。
+
+### 7.1 スキーマ定義
+
+```json
+{
+  "iter":          "int      — 反復番号（0-indexed）",
+  "temperature":   "float    — その反復の SA 温度",
+  "current_score": "float    — 受理後の現在スコア（最後に受理された遷移後の値）",
+  "best_score":    "float    — これまでの最良スコア",
+  "accepted":      "bool     — この反復で遷移が受理されたか",
+  "delta":         "float    — スコア差分（new_score - old_score）",
+  "timestamp":     "string   — 記録時刻（ISO 8601 形式、UTC、例: 2026-04-24T00:00:00+00:00）"
+}
+```
+
+pydantic モデル定義: `src/synthpop_jp/optimize/trace.py` の `TraceEvent`。
+
+### 7.2 生成ポリシー
+
+- 書き出し頻度: `AnnealingConfig.log_every_n_iters`（既定 1000）反復ごとに 1 行
+- 有効/無効の切り替え: `AnnealingConfig.trace_enabled`（既定 True）
+- ファイルが存在しない場合は自動作成。親ディレクトリも自動作成される
+- `--dry-run` 実行では trace.jsonl は生成されない
+- 行数の目安: `max_iters // log_every_n_iters`（20 万反復 / 1000 = 200 行）
+- 1 行あたりの目安サイズ: 100〜200 バイト → 20 万反復で約 20〜40 MB
+
+### 7.3 読み込みヘルパー
+
+```python
+from pathlib import Path
+from synthpop_jp.optimize.trace import read_trace
+
+df = read_trace(Path("outputs/run/trace.jsonl"))
+# df.columns: ["iter", "temperature", "current_score", "best_score",
+#              "accepted", "delta", "timestamp"]
+```
+
+Phase 3b で収束グラフの生成に使う（スコープ外: #11 ロードマップ）。
+
+## 8. 履歴
 
 - 2026-04-23: v0.0.1 骨子作成（Phase 0）
+- 2026-04-24: §7「trace.jsonl スキーマ」追記（Issue #31）

--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -453,12 +453,19 @@ def generate(
     cooling = ExponentialCooling(T0=annealing_cfg.T0, alpha=annealing_cfg.alpha)
     runner_sa = SARunner(rng=seed_reg.rng("sa_runner"))
 
+    # trace.jsonl の書き出し先は dry_run でない場合にのみ設定する
+    # progress_enabled は dry_run=True または log_level=ERROR のとき抑制する
+    trace_path_for_run = output_dir / "trace.jsonl" if not dry_run else None
+    progress_enabled_for_run = not dry_run and log_level != LogLevel.ERROR
+
     sa_result = runner_sa.run(
         arrays=arrays,
         objective=objective,
         transition=transition,
         cooling=cooling,
         config=annealing_cfg,
+        trace_path=trace_path_for_run,
+        progress_enabled=progress_enabled_for_run,
     )
 
     best_score = sa_result.final_state.best_score
@@ -551,6 +558,8 @@ def generate(
     console.print(f"  {hh_csv_path.name}")
     console.print(f"  {persons_csv_path.name}")
     console.print(f"  {metrics_path.name}")
+    if annealing_cfg.trace_enabled:
+        console.print("  trace.jsonl")
 
 
 @app.command()

--- a/src/synthpop_jp/config.py
+++ b/src/synthpop_jp/config.py
@@ -50,6 +50,11 @@ class AnnealingConfig(BaseModel):
         この値以下になったら停止する（0.0 は無効）。デフォルト 0.0。
     patience : int
         best_score が改善しない反復数の上限。0 は無効。デフォルト 0。
+    log_every_n_iters : int
+        trace.jsonl および rich 進捗バーの更新頻度（反復数）。デフォルト 1000。
+    trace_enabled : bool
+        True のとき trace.jsonl を書き出す。False のとき trace を書き出さない。
+        デフォルト True。
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -60,6 +65,8 @@ class AnnealingConfig(BaseModel):
     evals_per_agent: int = 1000
     target_threshold: float = 0.0
     patience: int = 0
+    log_every_n_iters: int = 1000
+    trace_enabled: bool = True
 
     @field_validator("T0")
     @classmethod

--- a/src/synthpop_jp/optimize/annealing.py
+++ b/src/synthpop_jp/optimize/annealing.py
@@ -1,4 +1,4 @@
-"""Simulated Annealing runner (Issue #30).
+"""Simulated Annealing runner (Issue #30, #31).
 
 SA（シミュレーテッドアニーリング）の中核ループを実装するモジュール。
 
@@ -14,12 +14,15 @@ SA（シミュレーテッドアニーリング）の中核ループを実装す
   受理なら ``objective.apply_change()``（内部で arrays.age も更新される）
 - ``best_score`` / ``best_arrays`` をスコア改善時のみ更新
 - 温度管理は ``CoolingSchedule`` に外注し、将来の LinearCooling 追加を容易にする
-- trace / rich.live は Issue #31 のスコープ（本 Issue には含まない）
+- trace.jsonl 書き出し（Issue #31）: ``config.trace_enabled=True`` かつ ``trace_path`` 指定時に有効
+- rich.Progress 進捗バー（Issue #31）: ``progress_enabled=True`` のとき有効
 """
 
 from __future__ import annotations
 
 import copy
+import datetime
+import types
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -28,11 +31,120 @@ import numpy as np
 from synthpop_jp.optimize.transitions import TransitionError
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
+    from rich.progress import Progress, TaskID
+
     from synthpop_jp.config import AnnealingConfig
     from synthpop_jp.optimize.cooling import CoolingSchedule
     from synthpop_jp.optimize.objective import ObjectiveState
     from synthpop_jp.optimize.state import PopulationArrays
     from synthpop_jp.optimize.transitions import AgeChangeTransition
+
+
+# ---------------------------------------------------------------------------
+# 内部ヘルパー
+# ---------------------------------------------------------------------------
+
+
+class _NullWriter:
+    """trace が無効のときに TraceWriter の代替として使う null オブジェクト."""
+
+    def __enter__(self) -> _NullWriter:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        pass
+
+    def write(self, event: object) -> None:
+        """何もしない."""
+
+
+def _build_progress(
+    *,
+    max_iters: int,
+    eval_limit: int,
+    enabled: bool,
+) -> _NullProgressCtx | _RichProgressCtx:
+    """rich.Progress コンテキストマネージャを作る.
+
+    ``enabled=False`` のとき null オブジェクトを返す。
+    """
+    if not enabled:
+        return _NullProgressCtx()
+    return _RichProgressCtx(max_iters=max_iters, eval_limit=eval_limit)
+
+
+class _NullProgressCtx:
+    """progress_enabled=False のときに使う null コンテキスト."""
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        pass
+
+
+class _RichProgressCtx:
+    """rich.Progress を wrap するコンテキストマネージャ."""
+
+    def __init__(self, *, max_iters: int, eval_limit: int) -> None:
+        self._total = eval_limit if eval_limit > 0 else max_iters
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+
+    def __enter__(self) -> tuple[TaskID, Progress]:
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            SpinnerColumn,
+            TaskProgressColumn,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        )
+
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]SA最適化[/bold blue]"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TaskProgressColumn(),
+            TextColumn("[green]score:{task.fields[current_score]:.1f}[/green]"),
+            TextColumn("[cyan]best:{task.fields[best_score]:.1f}[/cyan]"),
+            TextColumn("[yellow]accept:{task.fields[accept_rate]:.3f}[/yellow]"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+        )
+        self._progress.__enter__()
+        self._task_id = self._progress.add_task(
+            "SA",
+            total=self._total,
+            current_score=0.0,
+            best_score=0.0,
+            accept_rate=0.0,
+        )
+        return (self._task_id, self._progress)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        if self._progress is not None:
+            self._progress.__exit__(exc_type, exc_val, exc_tb)
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +273,8 @@ class SARunner:
         transition: AgeChangeTransition,
         cooling: CoolingSchedule,
         config: AnnealingConfig,
+        trace_path: Path | None = None,
+        progress_enabled: bool = True,
     ) -> SAResult:
         """SA ループを実行して SAResult を返す.
 
@@ -176,12 +290,20 @@ class SARunner:
             冷却スケジュール。``get_temperature(iter)`` で温度を取得する。
         config : AnnealingConfig
             SA の実行パラメータ。
+        trace_path : Path | None
+            trace.jsonl の書き出し先パス。``config.trace_enabled=True`` かつ
+            ``trace_path`` が指定されている場合のみ書き出す。デフォルト None。
+        progress_enabled : bool
+            True のとき rich.Progress 進捗バーを表示する。デフォルト True。
+            CLI ``--dry-run`` または ``--log-level ERROR`` のとき False を渡す。
 
         Returns
         -------
         SAResult
             最良配列・最終状態・スコア履歴を含む実行結果。
         """
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter
+
         # 初期状態
         initial_score = float(objective.total_score)
         state = SAState(
@@ -207,62 +329,118 @@ class SARunner:
         # 最大反復回数
         max_iters = config.max_iters if config.max_iters > 0 else int(1e18)
 
-        iter_n = 0
-        while iter_n < max_iters:
-            # evals_per_agent 停止
-            if eval_limit > 0 and iter_n >= eval_limit:
-                break
+        # trace writer の準備
+        use_trace = config.trace_enabled and trace_path is not None
+        log_every = config.log_every_n_iters if config.log_every_n_iters > 0 else 1
 
-            # target_threshold 停止
-            if config.target_threshold > 0.0 and state.best_score <= config.target_threshold:
-                break
+        # rich.Progress の準備
+        _progress_ctx = _build_progress(
+            max_iters=max_iters,
+            eval_limit=eval_limit,
+            enabled=progress_enabled,
+        )
 
-            # patience 停止
-            if config.patience > 0 and patience_counter >= config.patience:
-                break
+        with _progress_ctx as progress_info:
+            task_id = progress_info[0] if progress_info is not None else None
+            rich_progress = progress_info[1] if progress_info is not None else None
 
-            # 温度取得
-            temperature = cooling.get_temperature(iter_n)
+            # 直近 log_every 反復の受理数（受理率計算用）
+            recent_accepted = 0
 
-            # 遷移提案（ハード制約違反で TransitionError が起きたらスキップ）
-            try:
-                person_idx, new_age = transition.propose()
-            except TransitionError:
-                iter_n += 1
-                state.iter = iter_n
-                state.n_total += 1
-                patience_counter += 1
-                continue
-
-            # 差分スコア計算
-            delta = objective.propose_change(person_idx, new_age)
-
-            # Metropolis 受理判定
-            accepted = metropolis_accept(delta=delta, temperature=temperature, rng=self._rng)
-
-            state.n_total += 1
-
-            if accepted:
-                # 遷移を受理
-                objective.apply_change(person_idx, new_age)
-                state.n_accepted += 1
-                state.current_score = float(objective.total_score)
-
-                # best_score 更新
-                if state.current_score < state.best_score:
-                    state.best_score = state.current_score
-                    best_arrays = copy.deepcopy(arrays)
-                    scores.append(state.best_score)
-
-            # patience カウンタ更新
-            if state.best_score < prev_best:
-                patience_counter = 0
-                prev_best = state.best_score
+            # trace writer は use_trace のときだけ開く
+            writer_ctx: TraceWriter | _NullWriter
+            if use_trace and trace_path is not None:
+                writer_ctx = TraceWriter(trace_path)
             else:
-                patience_counter += 1
+                writer_ctx = _NullWriter()
 
-            iter_n += 1
-            state.iter = iter_n
+            with writer_ctx as writer:
+                iter_n = 0
+                while iter_n < max_iters:
+                    # evals_per_agent 停止
+                    if eval_limit > 0 and iter_n >= eval_limit:
+                        break
+
+                    # target_threshold 停止
+                    target_ok = config.target_threshold > 0.0
+                    if target_ok and state.best_score <= config.target_threshold:
+                        break
+
+                    # patience 停止
+                    if config.patience > 0 and patience_counter >= config.patience:
+                        break
+
+                    # 温度取得
+                    temperature = cooling.get_temperature(iter_n)
+
+                    # 遷移提案（ハード制約違反で TransitionError が起きたらスキップ）
+                    try:
+                        person_idx, new_age = transition.propose()
+                    except TransitionError:
+                        iter_n += 1
+                        state.iter = iter_n
+                        state.n_total += 1
+                        patience_counter += 1
+                        continue
+
+                    # 差分スコア計算
+                    delta = objective.propose_change(person_idx, new_age)
+
+                    # Metropolis 受理判定
+                    accepted = metropolis_accept(
+                        delta=delta, temperature=temperature, rng=self._rng
+                    )
+
+                    state.n_total += 1
+
+                    if accepted:
+                        # 遷移を受理
+                        objective.apply_change(person_idx, new_age)
+                        state.n_accepted += 1
+                        state.current_score = float(objective.total_score)
+                        recent_accepted += 1
+
+                        # best_score 更新
+                        if state.current_score < state.best_score:
+                            state.best_score = state.current_score
+                            best_arrays = copy.deepcopy(arrays)
+                            scores.append(state.best_score)
+
+                    # patience カウンタ更新
+                    if state.best_score < prev_best:
+                        patience_counter = 0
+                        prev_best = state.best_score
+                    else:
+                        patience_counter += 1
+
+                    iter_n += 1
+                    state.iter = iter_n
+
+                    # log_every_n_iters ごとに trace 書き出し + 進捗更新
+                    if iter_n % log_every == 0:
+                        if use_trace:
+                            ts = datetime.datetime.now(datetime.UTC).isoformat()
+                            event = TraceEvent(
+                                iter=iter_n,
+                                temperature=temperature,
+                                current_score=state.current_score,
+                                best_score=state.best_score,
+                                accepted=accepted,
+                                delta=delta,
+                                timestamp=ts,
+                            )
+                            writer.write(event)
+
+                        if rich_progress is not None and task_id is not None:
+                            accept_rate = recent_accepted / log_every
+                            rich_progress.update(
+                                task_id,
+                                completed=iter_n,
+                                current_score=state.current_score,
+                                best_score=state.best_score,
+                                accept_rate=accept_rate,
+                            )
+                        recent_accepted = 0
 
         state.iter = iter_n
         return SAResult(

--- a/src/synthpop_jp/optimize/trace.py
+++ b/src/synthpop_jp/optimize/trace.py
@@ -1,0 +1,186 @@
+"""SA 収束過程トレース — Issue #31.
+
+SA ループの各反復記録（trace.jsonl）を書き出し・読み込みするモジュール。
+
+提供するもの:
+- ``TraceEvent``: 1 反復分のデータを保持する pydantic モデル
+- ``TraceWriter``: trace.jsonl へ 1 行ずつ追記するコンテキストマネージャ
+- ``read_trace(path)``: trace.jsonl を ``pandas.DataFrame`` に変換するヘルパー
+
+trace.jsonl のスキーマ（1 行 = 1 JSON object）::
+
+    {"iter": int, "temperature": float, "current_score": float,
+     "best_score": float, "accepted": bool, "delta": float,
+     "timestamp": str (ISO 8601)}
+
+使い方::
+
+    from pathlib import Path
+    from synthpop_jp.optimize.trace import TraceEvent, TraceWriter, read_trace
+
+    with TraceWriter(Path("outputs/run/trace.jsonl")) as writer:
+        writer.write(
+            TraceEvent(
+                iter=0,
+                temperature=100.0,
+                current_score=500.0,
+                best_score=500.0,
+                accepted=True,
+                delta=-10.0,
+                timestamp="2026-04-24T00:00:00Z",
+            )
+        )
+
+    df = read_trace(Path("outputs/run/trace.jsonl"))
+    print(df[["iter", "best_score"]].head())
+"""
+
+from __future__ import annotations
+
+import io
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# TraceEvent — 1 反復分のデータ
+# ---------------------------------------------------------------------------
+
+
+class TraceEvent(BaseModel):
+    """SA 1 反復分のトレースデータ.
+
+    Attributes
+    ----------
+    iter : int
+        反復番号（0-indexed）。
+    temperature : float
+        その反復の SA 温度。
+    current_score : float
+        受理後の現在スコア（最後に受理された遷移後の値）。
+    best_score : float
+        これまでの最良スコア。
+    accepted : bool
+        この反復で遷移が受理されたか。
+    delta : float
+        スコア差分（new_score - old_score）。
+    timestamp : str
+        記録時刻（ISO 8601 形式、例: "2026-04-24T00:00:00Z"）。
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    iter: int
+    temperature: float
+    current_score: float
+    best_score: float
+    accepted: bool
+    delta: float
+    timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# TraceWriter — trace.jsonl への追記
+# ---------------------------------------------------------------------------
+
+
+class TraceWriter:
+    """trace.jsonl へ 1 行ずつ追記するコンテキストマネージャ.
+
+    コンテキストマネージャ（``with`` 文）として使うことでファイルを安全に閉じる。
+
+    Parameters
+    ----------
+    path : Path
+        書き込み先のファイルパス。親ディレクトリは自動作成される。
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from synthpop_jp.optimize.trace import TraceEvent, TraceWriter
+    >>> with TraceWriter(Path("trace.jsonl")) as writer:  # doctest: +SKIP
+    ...     writer.write(TraceEvent(...))
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._file: io.TextIOWrapper | None = None
+
+    def __enter__(self) -> TraceWriter:
+        """ファイルを開いて書き込み準備をする."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self._path.open("a", encoding="utf-8")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        """ファイルを閉じる."""
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def write(self, event: TraceEvent) -> None:
+        """TraceEvent を 1 行 JSON として追記する.
+
+        Parameters
+        ----------
+        event : TraceEvent
+            書き込むトレースイベント。
+
+        Raises
+        ------
+        RuntimeError
+            コンテキストマネージャの外で呼ばれた場合。
+        """
+        if self._file is None:
+            msg = "TraceWriter は `with` 文で使ってください"
+            raise RuntimeError(msg)
+        self._file.write(event.model_dump_json() + "\n")
+
+
+# ---------------------------------------------------------------------------
+# read_trace — trace.jsonl を DataFrame に変換
+# ---------------------------------------------------------------------------
+
+
+def read_trace(path: Path) -> pd.DataFrame:
+    """trace.jsonl を読み込んで pandas DataFrame に変換する.
+
+    Parameters
+    ----------
+    path : Path
+        読み込む trace.jsonl のパス。
+
+    Returns
+    -------
+    pd.DataFrame
+        各行が 1 TraceEvent に対応する DataFrame。
+        カラム: iter, temperature, current_score, best_score, accepted, delta, timestamp。
+
+    Raises
+    ------
+    FileNotFoundError
+        指定されたパスにファイルが存在しない場合。
+    """
+    import json
+
+    import pandas as pd
+
+    records: list[dict[str, object]] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    return pd.DataFrame(records)

--- a/tests/optimize/test_trace.py
+++ b/tests/optimize/test_trace.py
@@ -299,9 +299,9 @@ class TestReadTrace:
             )
 
         df = read_trace(trace_path)
-        assert df["iter"].iloc[0] == 999
-        assert abs(df["current_score"].iloc[0] - 123.45) < 1e-6
-        assert abs(df["best_score"].iloc[0] - 100.0) < 1e-6
+        assert int(df["iter"].iloc[0]) == 999  # type: ignore[arg-type]
+        assert abs(float(df["current_score"].iloc[0]) - 123.45) < 1e-6  # type: ignore[arg-type]
+        assert abs(float(df["best_score"].iloc[0]) - 100.0) < 1e-6  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -407,7 +407,7 @@ class TestSARunnerTraceIntegration:
 
         assert not trace_path.exists()
 
-    def test_trace_file_not_created_without_path(self, tmp_path: Path) -> None:  # noqa: ARG002
+    def test_trace_file_not_created_without_path(self, tmp_path: Path) -> None:
         """trace_path=None のとき trace ファイルが作られない."""
         config = self._make_config(max_iters=50, log_every_n_iters=10, trace_enabled=True)
         self._run_with_mock(config, trace_path=None)
@@ -438,7 +438,15 @@ class TestSARunnerTraceIntegration:
         lines = trace_path.read_text(encoding="utf-8").splitlines()
         assert len(lines) > 0
 
-        required_keys = {"iter", "temperature", "current_score", "best_score", "accepted", "delta", "timestamp"}
+        required_keys = {
+            "iter",
+            "temperature",
+            "current_score",
+            "best_score",
+            "accepted",
+            "delta",
+            "timestamp",
+        }
         for line in lines:
             data = json.loads(line)
             missing = required_keys - set(data.keys())

--- a/tests/optimize/test_trace.py
+++ b/tests/optimize/test_trace.py
@@ -1,0 +1,502 @@
+"""Tests for TraceEvent, TraceWriter, read_trace — Issue #31.
+
+TDD サイクル:
+  Cycle 1: TraceEvent pydantic モデル（schema 通り）
+  Cycle 2: TraceWriter.write(event) が 1 行 JSON を append
+  Cycle 3: read_trace(path) が DataFrame に変換
+  Cycle 4: AnnealingConfig に log_every_n_iters / trace_enabled 追加
+  Cycle 5: SARunner.run に trace 統合（trace_enabled=True でファイル生成）
+  Cycle 6: config.trace_enabled=False で trace ファイルが作られない
+  Cycle 7: 更新頻度 log_every_n_iters の検証
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from synthpop_jp.config import AnnealingConfig
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.optimize.state import PopulationArrays
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+ALL_ROLES = ["husband", "wife", "father", "mother", "child", "parent", "single"]
+ALL_FAMILY_TYPES = [
+    "couple",
+    "couple_and_children",
+    "single",
+    "lone_parent_and_children",
+    "couple_and_a_parent",
+]
+
+
+def make_registries() -> tuple[FamilyTypeRegistry, RoleRegistry, SexRegistry]:
+    """テスト用 Registry を返す."""
+    family_reg = FamilyTypeRegistry()
+    for ft in ALL_FAMILY_TYPES:
+        family_reg.register(ft)
+    role_reg = RoleRegistry()
+    for r in ALL_ROLES:
+        role_reg.register(r)
+    sex_reg = SexRegistry()
+    return family_reg, role_reg, sex_reg
+
+
+def make_small_arrays(n_persons: int = 10) -> PopulationArrays:
+    """単純な配列を返す（テスト用）.
+
+    全員を単身世帯（single）とする。
+    """
+    family_reg, role_reg, sex_reg = make_registries()
+    households = [
+        Household(
+            household_id=i + 1,
+            family_type="single",
+            members=[
+                Person(
+                    household_id=i + 1,
+                    role="single",  # type: ignore[arg-type]
+                    sex="M",  # type: ignore[arg-type]
+                    age=30 + i,
+                )
+            ],
+        )
+        for i in range(n_persons)
+    ]
+    return PopulationArrays.from_households(households, family_reg, role_reg, sex_reg)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1: TraceEvent pydantic モデル
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEvent:
+    """TraceEvent のスキーマ検証."""
+
+    def test_trace_event_fields(self) -> None:
+        """TraceEvent が必須フィールドをすべて持つ."""
+        from synthpop_jp.optimize.trace import TraceEvent
+
+        event = TraceEvent(
+            iter=10,
+            temperature=50.0,
+            current_score=123.4,
+            best_score=100.0,
+            accepted=True,
+            delta=-5.0,
+            timestamp="2026-04-24T00:00:00Z",
+        )
+        assert event.iter == 10
+        assert abs(event.temperature - 50.0) < 1e-9
+        assert abs(event.current_score - 123.4) < 1e-9
+        assert abs(event.best_score - 100.0) < 1e-9
+        assert event.accepted is True
+        assert abs(event.delta - (-5.0)) < 1e-9
+        assert event.timestamp == "2026-04-24T00:00:00Z"
+
+    def test_trace_event_json_serializable(self) -> None:
+        """TraceEvent が JSON シリアライズ可能（1 行形式）."""
+        from synthpop_jp.optimize.trace import TraceEvent
+
+        event = TraceEvent(
+            iter=1,
+            temperature=99.0,
+            current_score=200.0,
+            best_score=200.0,
+            accepted=False,
+            delta=5.0,
+            timestamp="2026-04-24T01:00:00Z",
+        )
+        serialized = event.model_dump_json()
+        data = json.loads(serialized)
+        assert data["iter"] == 1
+        assert data["accepted"] is False
+
+    def test_trace_event_requires_all_fields(self) -> None:
+        """TraceEvent は必須フィールドが不足するとエラー."""
+        from pydantic import ValidationError
+
+        from synthpop_jp.optimize.trace import TraceEvent
+
+        with pytest.raises(ValidationError):
+            TraceEvent(  # type: ignore[call-arg]
+                iter=1,
+                temperature=10.0,
+                # current_score 欠落
+                best_score=10.0,
+                accepted=True,
+                delta=0.0,
+                timestamp="2026-04-24T00:00:00Z",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: TraceWriter.write が 1 行 JSON を append
+# ---------------------------------------------------------------------------
+
+
+class TestTraceWriter:
+    """TraceWriter の書き込みテスト."""
+
+    def test_write_single_event(self, tmp_path: Path) -> None:
+        """write() が 1 行 JSON を追記する."""
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter
+
+        trace_path = tmp_path / "trace.jsonl"
+        event = TraceEvent(
+            iter=0,
+            temperature=100.0,
+            current_score=500.0,
+            best_score=500.0,
+            accepted=True,
+            delta=-10.0,
+            timestamp="2026-04-24T00:00:00Z",
+        )
+
+        with TraceWriter(trace_path) as writer:
+            writer.write(event)
+
+        lines = trace_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["iter"] == 0
+        assert abs(data["temperature"] - 100.0) < 1e-9
+
+    def test_write_multiple_events_appends(self, tmp_path: Path) -> None:
+        """複数回 write() すると複数行になる."""
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter
+
+        trace_path = tmp_path / "trace.jsonl"
+
+        with TraceWriter(trace_path) as writer:
+            for i in range(5):
+                writer.write(
+                    TraceEvent(
+                        iter=i * 100,
+                        temperature=100.0 - i,
+                        current_score=500.0 - i,
+                        best_score=500.0 - i,
+                        accepted=True,
+                        delta=-1.0,
+                        timestamp="2026-04-24T00:00:00Z",
+                    )
+                )
+
+        lines = trace_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 5
+        # 最後の行の iter が 400 であること
+        last = json.loads(lines[-1])
+        assert last["iter"] == 400
+
+    def test_writer_creates_parent_dir(self, tmp_path: Path) -> None:
+        """親ディレクトリが存在しない場合でも自動作成する."""
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter
+
+        trace_path = tmp_path / "nested" / "dir" / "trace.jsonl"
+
+        with TraceWriter(trace_path) as writer:
+            writer.write(
+                TraceEvent(
+                    iter=0,
+                    temperature=100.0,
+                    current_score=100.0,
+                    best_score=100.0,
+                    accepted=False,
+                    delta=5.0,
+                    timestamp="2026-04-24T00:00:00Z",
+                )
+            )
+
+        assert trace_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: read_trace(path) -> pd.DataFrame
+# ---------------------------------------------------------------------------
+
+
+class TestReadTrace:
+    """read_trace のテスト."""
+
+    def test_read_trace_returns_dataframe(self, tmp_path: Path) -> None:
+        """read_trace が DataFrame を返す."""
+        import pandas as pd
+
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter, read_trace
+
+        trace_path = tmp_path / "trace.jsonl"
+        events = [
+            TraceEvent(
+                iter=i * 100,
+                temperature=100.0 - i,
+                current_score=500.0 - i * 2,
+                best_score=500.0 - i * 2,
+                accepted=True,
+                delta=-2.0,
+                timestamp="2026-04-24T00:00:00Z",
+            )
+            for i in range(3)
+        ]
+        with TraceWriter(trace_path) as writer:
+            for e in events:
+                writer.write(e)
+
+        df = read_trace(trace_path)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 3
+
+    def test_read_trace_columns(self, tmp_path: Path) -> None:
+        """DataFrame に iter / current_score カラムがある."""
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter, read_trace
+
+        trace_path = tmp_path / "trace.jsonl"
+        with TraceWriter(trace_path) as writer:
+            writer.write(
+                TraceEvent(
+                    iter=42,
+                    temperature=80.0,
+                    current_score=300.0,
+                    best_score=280.0,
+                    accepted=False,
+                    delta=20.0,
+                    timestamp="2026-04-24T00:00:00Z",
+                )
+            )
+
+        df = read_trace(trace_path)
+        assert "iter" in df.columns
+        assert "current_score" in df.columns
+        assert "best_score" in df.columns
+        assert "temperature" in df.columns
+        assert "accepted" in df.columns
+
+    def test_read_trace_values_match(self, tmp_path: Path) -> None:
+        """DataFrame の値が書き込んだイベントと一致する."""
+        from synthpop_jp.optimize.trace import TraceEvent, TraceWriter, read_trace
+
+        trace_path = tmp_path / "trace.jsonl"
+        with TraceWriter(trace_path) as writer:
+            writer.write(
+                TraceEvent(
+                    iter=999,
+                    temperature=55.5,
+                    current_score=123.45,
+                    best_score=100.0,
+                    accepted=True,
+                    delta=-23.45,
+                    timestamp="2026-04-24T09:00:00Z",
+                )
+            )
+
+        df = read_trace(trace_path)
+        assert df["iter"].iloc[0] == 999
+        assert abs(df["current_score"].iloc[0] - 123.45) < 1e-6
+        assert abs(df["best_score"].iloc[0] - 100.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: AnnealingConfig に log_every_n_iters / trace_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestAnnealingConfigNewFields:
+    """AnnealingConfig の新フィールドテスト."""
+
+    def test_default_values(self) -> None:
+        """log_every_n_iters=1000, trace_enabled=True がデフォルト."""
+        config = AnnealingConfig()
+        assert config.log_every_n_iters == 1000
+        assert config.trace_enabled is True
+
+    def test_custom_values(self) -> None:
+        """カスタム値を設定できる."""
+        config = AnnealingConfig(log_every_n_iters=500, trace_enabled=False)
+        assert config.log_every_n_iters == 500
+        assert config.trace_enabled is False
+
+    def test_extra_field_forbidden(self) -> None:
+        """extra="forbid" が維持されている."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AnnealingConfig(unknown_field=True)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 & 6: SARunner.run に trace 統合 + trace_enabled=False
+# ---------------------------------------------------------------------------
+
+
+class TestSARunnerTraceIntegration:
+    """SARunner.run の trace 統合テスト."""
+
+    def _make_config(
+        self,
+        max_iters: int = 100,
+        log_every_n_iters: int = 10,
+        trace_enabled: bool = True,
+    ) -> AnnealingConfig:
+        return AnnealingConfig(
+            T0=100.0,
+            alpha=0.99,
+            max_iters=max_iters,
+            evals_per_agent=0,
+            target_threshold=0.0,
+            patience=0,
+            log_every_n_iters=log_every_n_iters,
+            trace_enabled=trace_enabled,
+        )
+
+    def _run_with_mock(
+        self,
+        config: AnnealingConfig,
+        trace_path: Path | None = None,
+        progress_enabled: bool = False,
+    ) -> None:
+        from synthpop_jp.optimize.annealing import SARunner
+        from synthpop_jp.optimize.cooling import ExponentialCooling
+
+        arrays = make_small_arrays(6)
+        objective = MagicMock()
+        objective.total_score = 100.0
+        objective.propose_change.return_value = -0.01
+        objective.apply_change.return_value = None
+
+        transition = MagicMock()
+        transition.propose.return_value = (0, 35)
+
+        cooling = ExponentialCooling(T0=config.T0, alpha=config.alpha)
+        rng = np.random.default_rng(42)
+        runner = SARunner(rng=rng)
+
+        runner.run(
+            arrays=arrays,
+            objective=objective,
+            transition=transition,
+            cooling=cooling,
+            config=config,
+            trace_path=trace_path,
+            progress_enabled=progress_enabled,
+        )
+
+    def test_trace_file_created_when_enabled(self, tmp_path: Path) -> None:
+        """trace_enabled=True + trace_path 指定でファイルが生成される."""
+        trace_path = tmp_path / "trace.jsonl"
+        config = self._make_config(max_iters=50, log_every_n_iters=10, trace_enabled=True)
+        self._run_with_mock(config, trace_path=trace_path)
+
+        assert trace_path.exists()
+        lines = trace_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) > 0
+
+    def test_trace_file_not_created_when_disabled(self, tmp_path: Path) -> None:
+        """trace_enabled=False のとき trace ファイルが作られない."""
+        trace_path = tmp_path / "trace.jsonl"
+        config = self._make_config(max_iters=50, log_every_n_iters=10, trace_enabled=False)
+        self._run_with_mock(config, trace_path=trace_path)
+
+        assert not trace_path.exists()
+
+    def test_trace_file_not_created_without_path(self, tmp_path: Path) -> None:  # noqa: ARG002
+        """trace_path=None のとき trace ファイルが作られない."""
+        config = self._make_config(max_iters=50, log_every_n_iters=10, trace_enabled=True)
+        self._run_with_mock(config, trace_path=None)
+        # 例外なく完了すれば OK
+
+    def test_trace_line_count_matches_log_every_n_iters(self, tmp_path: Path) -> None:
+        """trace の行数 = max_iters // log_every_n_iters."""
+        max_iters = 100
+        log_every = 10
+        trace_path = tmp_path / "trace.jsonl"
+        config = self._make_config(
+            max_iters=max_iters,
+            log_every_n_iters=log_every,
+            trace_enabled=True,
+        )
+        self._run_with_mock(config, trace_path=trace_path)
+
+        lines = trace_path.read_text(encoding="utf-8").splitlines()
+        expected = max_iters // log_every
+        assert len(lines) == expected, f"期待行数 {expected}、実際 {len(lines)}"
+
+    def test_trace_event_schema_in_file(self, tmp_path: Path) -> None:
+        """trace ファイルの各行が TraceEvent スキーマに準拠している."""
+        trace_path = tmp_path / "trace.jsonl"
+        config = self._make_config(max_iters=20, log_every_n_iters=10, trace_enabled=True)
+        self._run_with_mock(config, trace_path=trace_path)
+
+        lines = trace_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) > 0
+
+        required_keys = {"iter", "temperature", "current_score", "best_score", "accepted", "delta", "timestamp"}
+        for line in lines:
+            data = json.loads(line)
+            missing = required_keys - set(data.keys())
+            assert not missing, f"trace 行にキーが不足: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7: 更新頻度 log_every_n_iters
+# ---------------------------------------------------------------------------
+
+
+class TestLogEveryNIters:
+    """log_every_n_iters の更新頻度テスト."""
+
+    def test_trace_respects_log_every_n_iters(self, tmp_path: Path) -> None:
+        """異なる log_every_n_iters で行数が変わる."""
+        from synthpop_jp.optimize.annealing import SARunner
+        from synthpop_jp.optimize.cooling import ExponentialCooling
+
+        max_iters = 200
+
+        for log_every in [10, 20, 50]:
+            trace_path = tmp_path / f"trace_{log_every}.jsonl"
+            config = AnnealingConfig(
+                T0=100.0,
+                alpha=0.99,
+                max_iters=max_iters,
+                evals_per_agent=0,
+                target_threshold=0.0,
+                patience=0,
+                log_every_n_iters=log_every,
+                trace_enabled=True,
+            )
+
+            arrays = make_small_arrays(6)
+            objective = MagicMock()
+            objective.total_score = 100.0
+            objective.propose_change.return_value = -0.01
+            objective.apply_change.return_value = None
+            transition = MagicMock()
+            transition.propose.return_value = (0, 35)
+
+            cooling = ExponentialCooling(T0=100.0, alpha=0.99)
+            rng = np.random.default_rng(42)
+            runner = SARunner(rng=rng)
+
+            runner.run(
+                arrays=arrays,
+                objective=objective,
+                transition=transition,
+                cooling=cooling,
+                config=config,
+                trace_path=trace_path,
+                progress_enabled=False,
+            )
+
+            lines = trace_path.read_text(encoding="utf-8").splitlines()
+            expected = max_iters // log_every
+            assert len(lines) == expected, (
+                f"log_every={log_every}: 期待行数 {expected}、実際 {len(lines)}"
+            )


### PR DESCRIPTION
## 概要

Issue #31「SA の収束過程を trace.jsonl + rich 進捗で追える」の実装 PR。

研究者が `synthpop-jp generate` を実行すると、ターミナルに rich 進捗バーが表示され、
完走後に `outputs/<run_dir>/trace.jsonl` が生成され、後から pandas で収束過程を分析できる。

Closes #31

---

## 変更点

### 新規ファイル

- `src/synthpop_jp/optimize/trace.py` — `TraceEvent` (pydantic モデル) + `TraceWriter` (コンテキストマネージャ) + `read_trace()` (DataFrame ヘルパー)
- `tests/optimize/test_trace.py` — 7 サイクル 18 テスト

### 変更ファイル

- `src/synthpop_jp/config.py` — `AnnealingConfig` に `log_every_n_iters: int = 1000`, `trace_enabled: bool = True` を追加
- `src/synthpop_jp/optimize/annealing.py` — `SARunner.run` に `trace_path` / `progress_enabled` 引数を追加し、trace 書き出しと rich.Progress を統合
- `src/synthpop_jp/cli.py` — `generate` コマンドで `trace_path` / `progress_enabled` を渡す（`--dry-run` / `--log-level ERROR` で抑制）
- `docs/spec/experiment_report_format.md` — §7 `trace.jsonl` スキーマ節を追記

---

## trace.jsonl スキーマ

```json
{"iter": int, "temperature": float, "current_score": float, "best_score": float, "accepted": bool, "delta": float, "timestamp": "ISO8601"}
```

---

## テスト計画チェックリスト

- [x] `TraceEvent` pydantic スキーマ検証（Cycle 1）
- [x] `TraceWriter.write()` が 1 行 JSON を append（Cycle 2）
- [x] `read_trace()` が DataFrame に変換・値一致（Cycle 3）
- [x] `AnnealingConfig` 新フィールドのデフォルト値・extra="forbid"（Cycle 4）
- [x] `trace_enabled=True` + `trace_path` 指定でファイル生成（Cycle 5）
- [x] `trace_enabled=False` でファイル非生成（Cycle 6）
- [x] `log_every_n_iters` 更新頻度（行数 = max_iters // log_every_n_iters）（Cycle 7）
- [x] 既存 test_annealing.py 304 passed（後退なし）
- [x] CI parity 4 コマンド全緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)