### PR TITLE
[phase-2] PM が並列 Agent の進捗を make pm で把握できる

### DIFF
--- a/.claude/skills/multi_agent_orchestration.md
+++ b/.claude/skills/multi_agent_orchestration.md
@@ -130,6 +130,79 @@ Issue #12 (data contract)                          # 先行、他 4 つの土台
                  └─ Issue #15 (quickstart CLI)     # #14 を利用
 ```
 
+## Agent 側の進捗報告義務
+
+Phase 2 Wave 1 の Issue #27 と #29 で、サブエージェントが「テストをまとめて書いてから Green に進む」戦略を取り、
+10 分以上 Issue コメントもコミットもなく無音になった結果 timeout 停止する事案が連続発生した。
+根本原因は **Agent 側に明確な進捗報告義務がなかったこと**。
+本節では義務を定める。
+
+### plan コメントの投稿タイミング
+
+**最初の 1 commit と同時に** Issue にコメントとして plan を投稿する。後回し禁止。
+
+Issue #27 / #29 の事例：plan コメントを「実装が固まってから投稿しよう」と後回しにした結果、
+最初の commit すら入らないまま timeout した。PM は何が起きているか把握できなかった。
+
+```bash
+# 最初の test: コミットと同時に plan を投稿する
+gh issue comment <N> --body "## 実装計画
+..."
+git add tests/...
+git commit -m "test: <first test> (refs #<N>)"
+```
+
+### 進捗コメントの頻度
+
+**3 コミット毎、または最後のコメントから 10 分のどちらか先に達した時点**で、
+Issue に 1 コメントを投稿する。
+
+コメントの中身は 3 行以内：
+
+```
+- 何をやったか（例: WorktreeInfo dataclass と collect_worktree_info を実装）
+- 想定通りだったか（例: 想定通り、または「git worktree list の行形式が予想と違いパース修正」）
+- 次に何をやるか（例: IssueInfo 収集関数のテストに着手）
+```
+
+これは `.claude/skills/2_issue_impl.md` 手順 7「節目ごとに Issue へ進捗コメントを残す」と同義。
+フォーマットを固定することで PM 側の読み取りコストを下げる。
+
+### self-stall 宣言
+
+最終 commit から **15 分以上**、かつ進捗コメントも追加されていない状態を **self-stall** と呼ぶ。
+
+self-stall 状態になったら、作業を中断して以下を実行する：
+
+1. 現在の差分を中間コミットとして push（`wip:` プレフィックスでよい）
+2. `gh pr create --draft --base develop --title "WIP: <branch>"` で中間 Draft PR を作成
+3. Issue に「self-stall 宣言コメント」を投稿する：
+
+   ```
+   ## self-stall 宣言（PM 報告）
+   - 最終 commit から 15 分以上停止
+   - 現状: <何ができていて何が詰まっているか>
+   - 原因仮説: <詰まり原因>
+   - 要判断: <PM に判断を求めること、または次のアクション>
+   ```
+4. 完了報告を返す（PM がセッションを引き継ぐ）
+
+PM 側は `make pm` または `uv run python scripts/pm_status.py` で stale worktree を検知できる
+（最終 commit から 10 分で 🟡 警告、20 分で 🔴 危険マーク）。
+
+### PM による観測
+
+```bash
+# 全 active worktree の状態を 1 画面で確認
+make pm
+
+# Phase 2 の Issue に絞り、stale 閾値を 15 分に変更
+make pm ARGS="--phase 2 --stale-minutes 15"
+
+# JSON で機械可読出力
+make pm ARGS="--json"
+```
+
 ## 親セッションの監視ループ
 
 サブエージェントを `run_in_background: true` で起動したら:
@@ -201,4 +274,11 @@ Issue #12 (data contract)                          # 先行、他 4 つの土台
 ## 想定規模
 
 <N>〜<M> 行の実装 + <X>〜<Y> 行のテスト。
+
+## 進捗報告義務
+
+- 最初の commit と同時に plan コメントを Issue #<N> に投稿（後回し禁止、#27/#29 の timeout 事例を反省）
+- 3 コミット毎 or 10 分毎に 1 行進捗コメント（何をやったか / 想定通りか / 次は何か）
+- 最終 commit から 15 分停止で中間 Draft PR 作成 + self-stall 宣言コメント + 完了報告
+- PM は `make pm` で stale 検知（10 分 🟡 / 20 分 🔴）
 ```

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@
 #   make quickstart  # Phase 1 で実装（synthpop-jp quickstart）
 #   make docs        # Phase 4 で実装（mkdocs build）
 #   make paper       # Phase 6 で実装（paper_results 再現）
+#   make pm          # PM status ダッシュボード（並列 Agent 進捗確認）
 
-.PHONY: help setup lint format type test bench quickstart docs paper all
+.PHONY: help setup lint format type test bench quickstart docs paper pm all
 
 help:
 	@echo "Available targets:"
@@ -24,6 +25,7 @@ help:
 	@echo "  quickstart  Run synthpop-jp quickstart (Phase 1)"
 	@echo "  docs        Build mkdocs site (Phase 4)"
 	@echo "  paper       Reproduce paper_results (Phase 6)"
+	@echo "  pm          PM status dashboard (parallel Agent monitoring)"
 
 setup:
 	uv sync --frozen
@@ -53,5 +55,9 @@ docs:
 paper:
 	@echo "[Phase 6] paper_results reproduction — not yet implemented"
 	@exit 1
+
+.PHONY: pm
+pm:
+	uv run python scripts/pm_status.py $(ARGS)
 
 all: lint format type test

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "tests"],
+  "include": ["src", "tests", "scripts"],
   "exclude": ["**/__pycache__", ".venv", "outputs", "artifacts", "paper_results/tmp"],
   "pythonVersion": "3.12",
   "typeCheckingMode": "strict",

--- a/scripts/pm_status.py
+++ b/scripts/pm_status.py
@@ -1,0 +1,561 @@
+"""PM status dashboard — 並列 Agent の進捗を 1 コマンドで把握する.
+
+使い方::
+
+    uv run python scripts/pm_status.py
+    uv run python scripts/pm_status.py --phase 2 --stale-minutes 15
+    uv run python scripts/pm_status.py --json
+    make pm
+    make pm ARGS="--phase 2"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+from typing import Literal
+
+from rich.console import Console
+from rich.table import Table
+
+# ---------------------------------------------------------------------------
+# データ構造
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorktreeInfo:
+    """1 つの git worktree に関するメタ情報."""
+
+    path: str
+    branch: str
+    commits_ahead: int
+    uncommitted_count: int
+    last_commit_age: timedelta
+    plan_comment_exists: bool
+    progress_comment_count: int
+    pr_number: int | None
+    pr_state: str | None
+
+
+@dataclass
+class IssueInfo:
+    """1 つの GitHub Issue に関するメタ情報."""
+
+    number: int
+    title: str
+    state: str
+    blocked_by: list[int]
+    assigned_worktree: str | None
+
+
+@dataclass
+class PRInfo:
+    """1 つの GitHub PR に関するメタ情報."""
+
+    number: int
+    title: str
+    merged_at: str
+
+
+# ---------------------------------------------------------------------------
+# 外部コール層（テストでモック差し替え可能）
+# ---------------------------------------------------------------------------
+
+
+def _run_cmd(args: list[str], cwd: str | None = None) -> str:
+    """サブプロセスを実行して stdout を返す.
+
+    失敗時は RuntimeError を raise する。
+    """
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Command {args!r} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# worktree 情報収集
+# ---------------------------------------------------------------------------
+
+
+def _get_issue_comment_counts(branch: str) -> tuple[bool, int]:
+    """ブランチ名から Issue 番号を推定し、plan/progress コメント数を返す.
+
+    ブランチ名 feature/<N>-<keyword> から Issue #N を推定する。
+    失敗した場合は (False, 0) を返す。
+    """
+    # feature/<N>-<keyword> or feature-<N>-<keyword> から N を抽出
+    parts = branch.replace("feature/", "").replace("feature-", "")
+    try:
+        issue_num = int(parts.split("-")[0])
+    except (ValueError, IndexError):
+        return False, 0
+
+    try:
+        output = _run_cmd(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_num),
+                "--json",
+                "comments",
+            ]
+        )
+        data = json.loads(output)
+        comments: list[dict[str, object]] = data.get("comments", [])
+        plan_exists = any(
+            "plan" in str(c.get("body", "")).lower() or "実装計画" in str(c.get("body", ""))
+            for c in comments
+        )
+        progress_count = len(comments)
+        return plan_exists, progress_count
+    except (RuntimeError, json.JSONDecodeError, KeyError):
+        return False, 0
+
+
+def _get_pr_for_branch(branch: str) -> tuple[int | None, str | None]:
+    """ブランチに対応する PR 番号と状態を取得する.
+
+    見つからなければ (None, None) を返す。
+    """
+    try:
+        output = _run_cmd(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--json",
+                "number,state",
+            ]
+        )
+        prs: list[dict[str, object]] = json.loads(output)
+        if prs:
+            pr = prs[0]
+            return int(str(pr["number"])), str(pr["state"])
+        return None, None
+    except (RuntimeError, json.JSONDecodeError, KeyError, ValueError):
+        return None, None
+
+
+def _collect_single_worktree(path: str, branch: str) -> WorktreeInfo | None:
+    """1 つの worktree の情報を収集する.
+
+    失敗した場合は None を返す。
+    """
+    try:
+        # origin/develop からの commits ahead
+        try:
+            ahead_str = _run_cmd(["git", "-C", path, "rev-list", "--count", "origin/develop..HEAD"])
+            commits_ahead = int(ahead_str) if ahead_str else 0
+        except (RuntimeError, ValueError):
+            commits_ahead = 0
+
+        # uncommitted files count
+        try:
+            status_output = _run_cmd(["git", "-C", path, "status", "--porcelain"])
+            uncommitted_count = len([line for line in status_output.splitlines() if line.strip()])
+        except RuntimeError:
+            uncommitted_count = 0
+
+        # last commit timestamp
+        try:
+            ts_str = _run_cmd(["git", "-C", path, "log", "-1", "--format=%ct"])
+            ts = int(ts_str) if ts_str else int(time.time())
+            last_commit_age = timedelta(seconds=int(time.time()) - ts)
+        except (RuntimeError, ValueError):
+            last_commit_age = timedelta(seconds=0)
+
+        # Issue コメント情報
+        plan_exists, progress_count = _get_issue_comment_counts(branch)
+
+        # PR 情報
+        pr_number, pr_state = _get_pr_for_branch(branch)
+
+        return WorktreeInfo(
+            path=path,
+            branch=branch,
+            commits_ahead=commits_ahead,
+            uncommitted_count=uncommitted_count,
+            last_commit_age=last_commit_age,
+            plan_comment_exists=plan_exists,
+            progress_comment_count=progress_count,
+            pr_number=pr_number,
+            pr_state=pr_state,
+        )
+    except Exception:
+        return None
+
+
+def collect_worktree_info() -> list[WorktreeInfo]:
+    """全 git worktree を一覧し、feature ブランチのみ情報を収集して返す."""
+    try:
+        output = _run_cmd(["git", "worktree", "list"])
+    except RuntimeError:
+        return []
+
+    feature_worktrees: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        line_parts = line.split()
+        if len(line_parts) < 3:
+            continue
+        path = line_parts[0]
+        branch_raw = line_parts[2].strip("[]")
+        # main / develop / detached は除外
+        if branch_raw in ("main", "develop", "(detached)") or branch_raw.startswith("HEAD"):
+            continue
+        feature_worktrees.append((path, branch_raw))
+
+    if not feature_worktrees:
+        return []
+
+    results: list[WorktreeInfo] = []
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(_collect_single_worktree, path, branch): (path, branch)
+            for path, branch in feature_worktrees
+        }
+        for future in as_completed(futures):
+            info = future.result()
+            if info is not None:
+                results.append(info)
+
+    return sorted(results, key=lambda x: x.path)
+
+
+# ---------------------------------------------------------------------------
+# Issue 情報収集
+# ---------------------------------------------------------------------------
+
+
+def _parse_blocked_by(body: str) -> list[int]:
+    """Issue 本文から blocked_by の Issue 番号リストを抽出する."""
+    blocked: list[int] = []
+    for line in body.splitlines():
+        if "blocked" in line.lower() or "depends" in line.lower():
+            nums = re.findall(r"#(\d+)", line)
+            blocked.extend(int(n) for n in nums)
+    return blocked
+
+
+def collect_open_issues(phase: int | None) -> list[IssueInfo]:
+    """Open な Issue 一覧を取得する.
+
+    phase 指定があればラベルでフィルタする。
+    """
+    try:
+        args = [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,state,labels,body",
+            "--limit",
+            "100",
+        ]
+        if phase is not None:
+            args += ["--label", f"phase-{phase}"]
+        output = _run_cmd(args)
+        issues_data: list[dict[str, object]] = json.loads(output)
+    except (RuntimeError, json.JSONDecodeError):
+        return []
+
+    results: list[IssueInfo] = []
+    for issue in issues_data:
+        body = str(issue.get("body", "") or "")
+        blocked_by = _parse_blocked_by(body)
+        results.append(
+            IssueInfo(
+                number=int(str(issue["number"])),
+                title=str(issue.get("title", "")),
+                state=str(issue.get("state", "OPEN")),
+                blocked_by=blocked_by,
+                # worktree 情報と突き合わせは呼び出し元で行う
+                assigned_worktree=None,
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# PR 情報収集
+# ---------------------------------------------------------------------------
+
+
+def collect_recent_merged_prs(limit: int) -> list[PRInfo]:
+    """最近 merged された PR を limit 件取得して返す."""
+    try:
+        output = _run_cmd(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,mergedAt",
+            ]
+        )
+        prs_data: list[dict[str, object]] = json.loads(output)
+    except (RuntimeError, json.JSONDecodeError):
+        return []
+
+    return [
+        PRInfo(
+            number=int(str(pr["number"])),
+            title=str(pr.get("title", "")),
+            merged_at=str(pr.get("mergedAt", "")),
+        )
+        for pr in prs_data
+    ]
+
+
+# ---------------------------------------------------------------------------
+# stale 判定
+# ---------------------------------------------------------------------------
+
+
+def determine_staleness(
+    last_commit_age: timedelta, stale_minutes: int
+) -> Literal["ok", "warn", "danger"]:
+    """最終 commit からの経過時間で stale 状態を判定する.
+
+    Parameters
+    ----------
+    last_commit_age:
+        最終 commit からの経過時間。
+    stale_minutes:
+        警告閾値（分）。これ以上経過すると warn、2 倍以上で danger。
+
+    Returns
+    -------
+    "ok" | "warn" | "danger"
+    """
+    elapsed_minutes = last_commit_age.total_seconds() / 60
+    if elapsed_minutes >= stale_minutes * 2:
+        return "danger"
+    if elapsed_minutes >= stale_minutes:
+        return "warn"
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# rich テーブル組み立て
+# ---------------------------------------------------------------------------
+
+_STALE_MARK = {"ok": "", "warn": "🟡", "danger": "🔴"}
+_UNCOMMITTED_MARK = "🟠"
+
+
+def _format_age(age: timedelta) -> str:
+    """経過時間を短い文字列に変換する."""
+    total_seconds = int(age.total_seconds())
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    minutes = total_seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    remaining = minutes % 60
+    return f"{hours}h{remaining}m"
+
+
+def _shorten_path(path: str) -> str:
+    """Worktree パスを gitworktree/ 以降の部分に短縮する."""
+    if "/gitworktree/" in path:
+        return path.split("/gitworktree/")[-1]
+    return path
+
+
+def build_worktree_table(infos: list[WorktreeInfo], stale_minutes: int) -> Table:
+    """WorktreeInfo リストから rich Table を組み立てる（テーブル A）."""
+    table = Table(
+        title="Active Worktrees",
+        show_lines=True,
+        expand=False,
+    )
+    # 8 列固定
+    table.add_column("worktree", style="cyan", no_wrap=False, max_width=35)
+    table.add_column("branch", style="green", no_wrap=False, max_width=30)
+    table.add_column("ahead", justify="right")
+    table.add_column("uncommitted", justify="right")
+    table.add_column("last commit", justify="right")
+    table.add_column("plan", justify="center")
+    table.add_column("progress\ncomments", justify="right")
+    table.add_column("PR")
+
+    for info in infos:
+        staleness = determine_staleness(info.last_commit_age, stale_minutes)
+        stale_mark = _STALE_MARK[staleness]
+
+        uncommitted_str = str(info.uncommitted_count)
+        if info.uncommitted_count >= 5:
+            uncommitted_str = f"{_UNCOMMITTED_MARK}{info.uncommitted_count}"
+
+        path_short = _shorten_path(info.path)
+        age_str = _format_age(info.last_commit_age)
+        plan_str = "✅" if info.plan_comment_exists else "—"
+        pr_str = f"#{info.pr_number} [{info.pr_state}]" if info.pr_number else "—"
+
+        table.add_row(
+            f"{stale_mark}{path_short}",
+            info.branch,
+            str(info.commits_ahead),
+            uncommitted_str,
+            f"{stale_mark}{age_str}",
+            plan_str,
+            str(info.progress_comment_count),
+            pr_str,
+        )
+
+    return table
+
+
+def build_issues_table(issues: list[IssueInfo], worktrees: list[WorktreeInfo]) -> Table:
+    """IssueInfo リストから rich Table を組み立てる（テーブル B）."""
+    # worktree path と Issue 番号の対応マップを作成
+    wt_map: dict[int, str] = {}
+    for wt in worktrees:
+        parts = wt.branch.replace("feature/", "").replace("feature-", "")
+        try:
+            issue_num = int(parts.split("-")[0])
+            wt_map[issue_num] = _shorten_path(wt.path)
+        except (ValueError, IndexError):
+            pass
+
+    table = Table(title="Open Issues", show_lines=True, expand=False)
+    table.add_column("#", justify="right", style="bold")
+    table.add_column("title", max_width=40)
+    table.add_column("state", justify="center")
+    table.add_column("blocked_by")
+    table.add_column("worktree")
+
+    for issue in issues:
+        title_truncated = issue.title[:40] if len(issue.title) > 40 else issue.title
+        blocked_str = ", ".join(f"#{n}" for n in issue.blocked_by) if issue.blocked_by else "—"
+        assigned = wt_map.get(issue.number, "—")
+        table.add_row(
+            str(issue.number),
+            title_truncated,
+            issue.state,
+            blocked_str,
+            assigned,
+        )
+
+    return table
+
+
+def build_prs_table(prs: list[PRInfo]) -> Table:
+    """PRInfo リストから rich Table を組み立てる（テーブル C）."""
+    table = Table(title="Recently Merged PRs", show_lines=True, expand=False)
+    table.add_column("#", justify="right", style="bold")
+    table.add_column("title", max_width=50)
+    table.add_column("merged_at")
+
+    for pr in prs:
+        table.add_row(str(pr.number), pr.title, pr.merged_at)
+
+    return table
+
+
+# ---------------------------------------------------------------------------
+# JSON 出力
+# ---------------------------------------------------------------------------
+
+
+def _timedelta_to_str(td: timedelta) -> str:
+    """Timedelta を秒数文字列に変換する（JSON シリアライズ用）."""
+    return str(int(td.total_seconds()))
+
+
+def to_json_dict(
+    worktrees: list[WorktreeInfo],
+    issues: list[IssueInfo],
+    prs: list[PRInfo],
+) -> dict[str, object]:
+    """3 つのリストを JSON シリアライズ可能な dict に変換する."""
+    wt_dicts: list[dict[str, object]] = []
+    for wt in worktrees:
+        d = asdict(wt)
+        d["last_commit_age"] = _timedelta_to_str(wt.last_commit_age)
+        wt_dicts.append(d)
+
+    return {
+        "worktrees": wt_dicts,
+        "issues": [asdict(i) for i in issues],
+        "prs": [asdict(p) for p in prs],
+    }
+
+
+# ---------------------------------------------------------------------------
+# メイン
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    """PM status ダッシュボードのエントリポイント."""
+    parser = argparse.ArgumentParser(
+        description="PM status dashboard — 並列 Agent の進捗を 1 画面で確認する"
+    )
+    parser.add_argument("--phase", type=int, default=None, help="対象 Phase 番号でフィルタ")
+    parser.add_argument(
+        "--stale-minutes", type=int, default=10, help="stale 判定の閾値（分、既定 10）"
+    )
+    parser.add_argument("--no-prs", action="store_true", help="最近 merged PRs 表をスキップ")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="JSON 形式で出力")
+    args = parser.parse_args(argv)
+
+    # 並列データ収集
+    prs: list[PRInfo] = []
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        wt_future = executor.submit(collect_worktree_info)
+        issue_future = executor.submit(collect_open_issues, phase=args.phase)
+        pr_future = None if args.no_prs else executor.submit(collect_recent_merged_prs, 10)
+
+        worktrees = wt_future.result()
+        issues = issue_future.result()
+        if pr_future is not None:
+            prs = pr_future.result()
+
+    if args.json_output:
+        print(json.dumps(to_json_dict(worktrees, issues, prs), ensure_ascii=False, indent=2))
+        return
+
+    console = Console()
+
+    # テーブル A: Active worktrees
+    wt_table = build_worktree_table(worktrees, stale_minutes=args.stale_minutes)
+    console.print(wt_table)
+
+    # テーブル B: Open Issues
+    issue_table = build_issues_table(issues, worktrees)
+    console.print(issue_table)
+
+    # テーブル C: Recently merged PRs
+    if not args.no_prs:
+        pr_table = build_prs_table(prs)
+        console.print(pr_table)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_pm_status.py
+++ b/tests/scripts/test_pm_status.py
@@ -1,0 +1,592 @@
+"""Tests for scripts/pm_status.py — PM dashboard for parallel Agent monitoring."""
+
+from __future__ import annotations
+
+import json
+import types
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _get_scripts_path() -> Path:
+    """Locate the scripts directory relative to pyproject.toml."""
+    here = Path(__file__)
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent / "scripts"
+    raise FileNotFoundError("pyproject.toml not found in any ancestor directory")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: dynamically import pm_status from scripts/
+# ---------------------------------------------------------------------------
+
+def _import_pm_status() -> types.ModuleType:
+    import importlib.util
+
+    scripts_path = _get_scripts_path()
+    pm_path = scripts_path / "pm_status.py"
+    module_spec = importlib.util.spec_from_file_location("pm_status", pm_path)
+    assert module_spec is not None
+    assert module_spec.loader is not None
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1: WorktreeInfo dataclass and collect_worktree_info
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeInfoDataclass:
+    """WorktreeInfo dataclass should hold all worktree metadata."""
+
+    def test_worktree_info_has_required_fields(self) -> None:
+        pm = _import_pm_status()
+        info = pm.WorktreeInfo(
+            path="/tmp/worktree",
+            branch="feature/40-pm-dashboard",
+            commits_ahead=3,
+            uncommitted_count=1,
+            last_commit_age=timedelta(minutes=5),
+            plan_comment_exists=True,
+            progress_comment_count=2,
+            pr_number=42,
+            pr_state="DRAFT",
+        )
+        assert info.path == "/tmp/worktree"
+        assert info.branch == "feature/40-pm-dashboard"
+        assert info.commits_ahead == 3
+        assert info.uncommitted_count == 1
+        assert info.last_commit_age == timedelta(minutes=5)
+        assert info.plan_comment_exists is True
+        assert info.progress_comment_count == 2
+        assert info.pr_number == 42
+        assert info.pr_state == "DRAFT"
+
+    def test_worktree_info_pr_fields_optional(self) -> None:
+        pm = _import_pm_status()
+        info = pm.WorktreeInfo(
+            path="/tmp/worktree",
+            branch="feature/40-pm-dashboard",
+            commits_ahead=0,
+            uncommitted_count=0,
+            last_commit_age=timedelta(minutes=0),
+            plan_comment_exists=False,
+            progress_comment_count=0,
+            pr_number=None,
+            pr_state=None,
+        )
+        assert info.pr_number is None
+        assert info.pr_state is None
+
+
+class TestCollectWorktreeInfo:
+    """collect_worktree_info should parse git output into WorktreeInfo."""
+
+    def test_collect_worktree_info_basic(self) -> None:
+        pm = _import_pm_status()
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            cmd = " ".join(args)
+            if "worktree list" in cmd:
+                return "/repo/main  abc1234  [main]\n/repo/gitworktree/feature-40  def5678  [feature/40-pm-dashboard]\n"
+            if "rev-list" in cmd and "origin/develop" in cmd:
+                return "3\n"
+            if "status --porcelain" in cmd:
+                return "M  file1.py\n?? file2.py\n"
+            if "log -1 --format=%ct" in cmd:
+                # Return unix timestamp from 5 minutes ago
+                import time
+                return str(int(time.time()) - 300)
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            with patch.object(pm, "_get_issue_comment_counts", return_value=(True, 2)):
+                with patch.object(pm, "_get_pr_for_branch", return_value=(42, "DRAFT")):
+                    infos = pm.collect_worktree_info()
+
+        # Should only include feature worktrees (not main)
+        assert len(infos) == 1
+        info = infos[0]
+        assert "feature-40" in info.path
+        assert info.branch == "feature/40-pm-dashboard"
+        assert info.commits_ahead == 3
+        assert info.uncommitted_count == 2
+        assert abs(info.last_commit_age.total_seconds() - 300) < 10
+        assert info.plan_comment_exists is True
+        assert info.progress_comment_count == 2
+        assert info.pr_number == 42
+        assert info.pr_state == "DRAFT"
+
+    def test_collect_worktree_info_excludes_main_branch(self) -> None:
+        pm = _import_pm_status()
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            cmd = " ".join(args)
+            if "worktree list" in cmd:
+                return "/repo  abc1234  [main]\n/repo2  abc1234  [develop]\n"
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            infos = pm.collect_worktree_info()
+
+        assert len(infos) == 0
+
+    def test_collect_worktree_info_handles_git_error(self) -> None:
+        pm = _import_pm_status()
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            raise RuntimeError("git command failed")
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            # Should not raise, should return empty list
+            infos = pm.collect_worktree_info()
+
+        assert infos == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: IssueInfo dataclass and collect_open_issues
+# ---------------------------------------------------------------------------
+
+
+class TestIssueInfoDataclass:
+    """IssueInfo dataclass should hold Issue metadata."""
+
+    def test_issue_info_has_required_fields(self) -> None:
+        pm = _import_pm_status()
+        info = pm.IssueInfo(
+            number=40,
+            title="PM can monitor agents",
+            state="OPEN",
+            blocked_by=[38, 39],
+            assigned_worktree="/repo/gitworktree/feature-40",
+        )
+        assert info.number == 40
+        assert info.title == "PM can monitor agents"
+        assert info.state == "OPEN"
+        assert info.blocked_by == [38, 39]
+        assert info.assigned_worktree == "/repo/gitworktree/feature-40"
+
+    def test_issue_info_optional_fields(self) -> None:
+        pm = _import_pm_status()
+        info = pm.IssueInfo(
+            number=40,
+            title="title",
+            state="OPEN",
+            blocked_by=[],
+            assigned_worktree=None,
+        )
+        assert info.blocked_by == []
+        assert info.assigned_worktree is None
+
+
+class TestCollectOpenIssues:
+    """collect_open_issues should parse gh CLI output into IssueInfo list."""
+
+    def test_collect_open_issues_with_phase_filter(self) -> None:
+        pm = _import_pm_status()
+
+        gh_output = json.dumps([
+            {
+                "number": 40,
+                "title": "[phase-2] PM dashboard",
+                "state": "OPEN",
+                "labels": [{"name": "phase-2"}],
+                "body": "## blocked_by\n- #38\n",
+            },
+            {
+                "number": 39,
+                "title": "[phase-2] another issue",
+                "state": "OPEN",
+                "labels": [{"name": "phase-2"}],
+                "body": "",
+            },
+        ])
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            if "issue list" in " ".join(args):
+                return gh_output
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            issues = pm.collect_open_issues(phase=2)
+
+        assert len(issues) == 2
+        assert issues[0].number == 40
+        assert issues[0].title == "[phase-2] PM dashboard"
+
+    def test_collect_open_issues_handles_gh_error(self) -> None:
+        pm = _import_pm_status()
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            raise RuntimeError("gh command failed")
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            issues = pm.collect_open_issues(phase=None)
+
+        assert issues == []
+
+    def test_collect_open_issues_no_phase_returns_all(self) -> None:
+        pm = _import_pm_status()
+
+        gh_output = json.dumps([
+            {
+                "number": 10,
+                "title": "some issue",
+                "state": "OPEN",
+                "labels": [{"name": "phase-1"}],
+                "body": "",
+            },
+        ])
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            if "issue list" in " ".join(args):
+                return gh_output
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            issues = pm.collect_open_issues(phase=None)
+
+        assert len(issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: PRInfo dataclass and collect_recent_merged_prs
+# ---------------------------------------------------------------------------
+
+
+class TestPRInfoDataclass:
+    """PRInfo dataclass should hold PR metadata."""
+
+    def test_pr_info_has_required_fields(self) -> None:
+        pm = _import_pm_status()
+        info = pm.PRInfo(number=10, title="feat: add something", merged_at="2024-01-01T00:00:00Z")
+        assert info.number == 10
+        assert info.title == "feat: add something"
+        assert info.merged_at == "2024-01-01T00:00:00Z"
+
+
+class TestCollectRecentMergedPRs:
+    """collect_recent_merged_prs should parse gh CLI output into PRInfo list."""
+
+    def test_collect_recent_merged_prs_returns_list(self) -> None:
+        pm = _import_pm_status()
+
+        gh_output = json.dumps([
+            {"number": 5, "title": "feat: something", "mergedAt": "2024-01-01T10:00:00Z"},
+            {"number": 4, "title": "fix: bug", "mergedAt": "2024-01-01T09:00:00Z"},
+        ])
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            if "pr list" in " ".join(args):
+                return gh_output
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            prs = pm.collect_recent_merged_prs(limit=10)
+
+        assert len(prs) == 2
+        assert prs[0].number == 5
+        assert prs[0].title == "feat: something"
+        assert prs[0].merged_at == "2024-01-01T10:00:00Z"
+
+    def test_collect_recent_merged_prs_handles_error(self) -> None:
+        pm = _import_pm_status()
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            raise RuntimeError("gh failed")
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            prs = pm.collect_recent_merged_prs(limit=10)
+
+        assert prs == []
+
+    def test_collect_recent_merged_prs_respects_limit(self) -> None:
+        pm = _import_pm_status()
+
+        gh_output = json.dumps([
+            {"number": i, "title": f"pr {i}", "mergedAt": "2024-01-01T00:00:00Z"}
+            for i in range(10)
+        ])
+
+        def mock_run(args: list[str], cwd: str | None = None) -> str:
+            if "pr list" in " ".join(args):
+                # Verify limit argument is passed
+                assert "--limit" in args or "-L" in args
+                return gh_output
+            return ""
+
+        with patch.object(pm, "_run_cmd", side_effect=mock_run):
+            prs = pm.collect_recent_merged_prs(limit=10)
+
+        assert len(prs) == 10
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: determine_staleness pure function
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineStaleness:
+    """determine_staleness should classify last_commit_age against stale_minutes threshold."""
+
+    def test_fresh_returns_ok(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(minutes=5), stale_minutes=10)
+        assert result == "ok"
+
+    def test_exactly_at_threshold_returns_warn(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(minutes=10), stale_minutes=10)
+        assert result == "warn"
+
+    def test_between_threshold_and_double_returns_warn(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(minutes=15), stale_minutes=10)
+        assert result == "warn"
+
+    def test_at_double_threshold_returns_danger(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(minutes=20), stale_minutes=10)
+        assert result == "danger"
+
+    def test_beyond_double_threshold_returns_danger(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(minutes=30), stale_minutes=10)
+        assert result == "danger"
+
+    def test_custom_stale_minutes(self) -> None:
+        pm = _import_pm_status()
+        assert pm.determine_staleness(timedelta(minutes=3), stale_minutes=5) == "ok"
+        assert pm.determine_staleness(timedelta(minutes=5), stale_minutes=5) == "warn"
+        assert pm.determine_staleness(timedelta(minutes=10), stale_minutes=5) == "danger"
+
+    def test_zero_age_is_ok(self) -> None:
+        pm = _import_pm_status()
+        result = pm.determine_staleness(timedelta(seconds=0), stale_minutes=10)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5: build_worktree_table rich Table
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWorktreeTable:
+    """build_worktree_table should produce a rich Table with correct columns and rows."""
+
+    def test_table_has_correct_column_count(self) -> None:
+        pm = _import_pm_status()
+        from rich.table import Table
+
+        infos = [
+            pm.WorktreeInfo(
+                path="/repo/gitworktree/feature-40-pm-dashboard",
+                branch="feature/40-pm-dashboard",
+                commits_ahead=2,
+                uncommitted_count=0,
+                last_commit_age=timedelta(minutes=3),
+                plan_comment_exists=True,
+                progress_comment_count=1,
+                pr_number=10,
+                pr_state="DRAFT",
+            )
+        ]
+        table = pm.build_worktree_table(infos, stale_minutes=10)
+        assert isinstance(table, Table)
+        assert len(table.columns) == 8
+
+    def test_table_has_correct_row_count(self) -> None:
+        pm = _import_pm_status()
+
+        infos = [
+            pm.WorktreeInfo(
+                path=f"/repo/gitworktree/feature-{i}",
+                branch=f"feature/{i}",
+                commits_ahead=0,
+                uncommitted_count=0,
+                last_commit_age=timedelta(minutes=0),
+                plan_comment_exists=False,
+                progress_comment_count=0,
+                pr_number=None,
+                pr_state=None,
+            )
+            for i in range(3)
+        ]
+        table = pm.build_worktree_table(infos, stale_minutes=10)
+        assert table.row_count == 3
+
+    def test_table_stale_warn_marker(self) -> None:
+        """A worktree with last_commit_age >= stale_minutes should have 🟡 in path column."""
+        pm = _import_pm_status()
+        from io import StringIO
+
+        from rich.console import Console
+
+        infos = [
+            pm.WorktreeInfo(
+                path="/repo/gitworktree/feature-40",
+                branch="feature/40",
+                commits_ahead=0,
+                uncommitted_count=0,
+                last_commit_age=timedelta(minutes=15),
+                plan_comment_exists=True,
+                progress_comment_count=0,
+                pr_number=None,
+                pr_state=None,
+            )
+        ]
+        table = pm.build_worktree_table(infos, stale_minutes=10)
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        console.print(table)
+        rendered = buf.getvalue()
+        assert "🟡" in rendered
+
+    def test_table_danger_marker(self) -> None:
+        """A worktree with last_commit_age >= stale_minutes*2 should have 🔴."""
+        pm = _import_pm_status()
+        from io import StringIO
+
+        from rich.console import Console
+
+        infos = [
+            pm.WorktreeInfo(
+                path="/repo/gitworktree/feature-40",
+                branch="feature/40",
+                commits_ahead=0,
+                uncommitted_count=0,
+                last_commit_age=timedelta(minutes=25),
+                plan_comment_exists=True,
+                progress_comment_count=0,
+                pr_number=None,
+                pr_state=None,
+            )
+        ]
+        table = pm.build_worktree_table(infos, stale_minutes=10)
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        console.print(table)
+        rendered = buf.getvalue()
+        assert "🔴" in rendered
+
+    def test_table_many_uncommitted_marker(self) -> None:
+        """A worktree with uncommitted_count >= 5 should have 🟠."""
+        pm = _import_pm_status()
+        from io import StringIO
+
+        from rich.console import Console
+
+        infos = [
+            pm.WorktreeInfo(
+                path="/repo/gitworktree/feature-40",
+                branch="feature/40",
+                commits_ahead=0,
+                uncommitted_count=5,
+                last_commit_age=timedelta(minutes=1),
+                plan_comment_exists=True,
+                progress_comment_count=0,
+                pr_number=None,
+                pr_state=None,
+            )
+        ]
+        table = pm.build_worktree_table(infos, stale_minutes=10)
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        console.print(table)
+        rendered = buf.getvalue()
+        assert "🟠" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6: main function integration, CLI flags
+# ---------------------------------------------------------------------------
+
+
+class TestMainFunction:
+    """main() should accept CLI args and produce output without error."""
+
+    def test_main_with_no_args_runs(self) -> None:
+        pm = _import_pm_status()
+
+        with patch.object(pm, "collect_worktree_info", return_value=[]):
+            with patch.object(pm, "collect_open_issues", return_value=[]):
+                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
+                    # Should not raise
+                    pm.main(["--stale-minutes", "10"])
+
+    def test_main_no_prs_flag(self) -> None:
+        pm = _import_pm_status()
+
+        with patch.object(pm, "collect_worktree_info", return_value=[]) as _:
+            with patch.object(pm, "collect_open_issues", return_value=[]) as _:
+                collect_prs_mock = MagicMock(return_value=[])
+                with patch.object(pm, "collect_recent_merged_prs", collect_prs_mock):
+                    pm.main(["--no-prs"])
+                    collect_prs_mock.assert_not_called()
+
+    def test_main_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        pm = _import_pm_status()
+
+        wt = pm.WorktreeInfo(
+            path="/repo/feature-40",
+            branch="feature/40",
+            commits_ahead=1,
+            uncommitted_count=0,
+            last_commit_age=timedelta(minutes=2),
+            plan_comment_exists=True,
+            progress_comment_count=0,
+            pr_number=None,
+            pr_state=None,
+        )
+
+        with patch.object(pm, "collect_worktree_info", return_value=[wt]):
+            with patch.object(pm, "collect_open_issues", return_value=[]):
+                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
+                    pm.main(["--json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "worktrees" in data
+        assert "issues" in data
+        assert "prs" in data
+        assert len(data["worktrees"]) == 1
+
+    def test_main_phase_filter_passed_to_collect_issues(self) -> None:
+        pm = _import_pm_status()
+
+        with patch.object(pm, "collect_worktree_info", return_value=[]):
+            collect_issues_mock = MagicMock(return_value=[])
+            with patch.object(pm, "collect_open_issues", collect_issues_mock):
+                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
+                    pm.main(["--phase", "2"])
+                    collect_issues_mock.assert_called_once_with(phase=2)
+
+    def test_main_stale_minutes_passed_to_build_table(self) -> None:
+        pm = _import_pm_status()
+
+        wt = pm.WorktreeInfo(
+            path="/repo/feature-40",
+            branch="feature/40",
+            commits_ahead=0,
+            uncommitted_count=0,
+            last_commit_age=timedelta(minutes=0),
+            plan_comment_exists=False,
+            progress_comment_count=0,
+            pr_number=None,
+            pr_state=None,
+        )
+
+        with patch.object(pm, "collect_worktree_info", return_value=[wt]):
+            with patch.object(pm, "collect_open_issues", return_value=[]):
+                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
+                    build_mock = MagicMock(return_value=MagicMock())
+                    with patch.object(pm, "build_worktree_table", build_mock):
+                        pm.main(["--stale-minutes", "5"])
+                        build_mock.assert_called_once_with([wt], stale_minutes=5)

--- a/tests/scripts/test_pm_status.py
+++ b/tests/scripts/test_pm_status.py
@@ -24,8 +24,10 @@ def _get_scripts_path() -> Path:
 # Helpers: dynamically import pm_status from scripts/
 # ---------------------------------------------------------------------------
 
+
 def _import_pm_status() -> types.ModuleType:
     import importlib.util
+    import sys
 
     scripts_path = _get_scripts_path()
     pm_path = scripts_path / "pm_status.py"
@@ -33,6 +35,8 @@ def _import_pm_status() -> types.ModuleType:
     assert module_spec is not None
     assert module_spec.loader is not None
     module = importlib.util.module_from_spec(module_spec)
+    # dataclass requires the module to be in sys.modules so __module__ lookup works
+    sys.modules["pm_status"] = module
     module_spec.loader.exec_module(module)  # type: ignore[union-attr]
     return module
 
@@ -94,7 +98,10 @@ class TestCollectWorktreeInfo:
         def mock_run(args: list[str], cwd: str | None = None) -> str:
             cmd = " ".join(args)
             if "worktree list" in cmd:
-                return "/repo/main  abc1234  [main]\n/repo/gitworktree/feature-40  def5678  [feature/40-pm-dashboard]\n"
+                return (
+                    "/repo/main  abc1234  [main]\n"
+                    "/repo/gitworktree/feature-40  def5678  [feature/40-pm-dashboard]\n"
+                )
             if "rev-list" in cmd and "origin/develop" in cmd:
                 return "3\n"
             if "status --porcelain" in cmd:
@@ -102,13 +109,16 @@ class TestCollectWorktreeInfo:
             if "log -1 --format=%ct" in cmd:
                 # Return unix timestamp from 5 minutes ago
                 import time
+
                 return str(int(time.time()) - 300)
             return ""
 
-        with patch.object(pm, "_run_cmd", side_effect=mock_run):
-            with patch.object(pm, "_get_issue_comment_counts", return_value=(True, 2)):
-                with patch.object(pm, "_get_pr_for_branch", return_value=(42, "DRAFT")):
-                    infos = pm.collect_worktree_info()
+        with (
+            patch.object(pm, "_run_cmd", side_effect=mock_run),
+            patch.object(pm, "_get_issue_comment_counts", return_value=(True, 2)),
+            patch.object(pm, "_get_pr_for_branch", return_value=(42, "DRAFT")),
+        ):
+            infos = pm.collect_worktree_info()
 
         # Should only include feature worktrees (not main)
         assert len(infos) == 1
@@ -192,22 +202,24 @@ class TestCollectOpenIssues:
     def test_collect_open_issues_with_phase_filter(self) -> None:
         pm = _import_pm_status()
 
-        gh_output = json.dumps([
-            {
-                "number": 40,
-                "title": "[phase-2] PM dashboard",
-                "state": "OPEN",
-                "labels": [{"name": "phase-2"}],
-                "body": "## blocked_by\n- #38\n",
-            },
-            {
-                "number": 39,
-                "title": "[phase-2] another issue",
-                "state": "OPEN",
-                "labels": [{"name": "phase-2"}],
-                "body": "",
-            },
-        ])
+        gh_output = json.dumps(
+            [
+                {
+                    "number": 40,
+                    "title": "[phase-2] PM dashboard",
+                    "state": "OPEN",
+                    "labels": [{"name": "phase-2"}],
+                    "body": "## blocked_by\n- #38\n",
+                },
+                {
+                    "number": 39,
+                    "title": "[phase-2] another issue",
+                    "state": "OPEN",
+                    "labels": [{"name": "phase-2"}],
+                    "body": "",
+                },
+            ]
+        )
 
         def mock_run(args: list[str], cwd: str | None = None) -> str:
             if "issue list" in " ".join(args):
@@ -235,15 +247,17 @@ class TestCollectOpenIssues:
     def test_collect_open_issues_no_phase_returns_all(self) -> None:
         pm = _import_pm_status()
 
-        gh_output = json.dumps([
-            {
-                "number": 10,
-                "title": "some issue",
-                "state": "OPEN",
-                "labels": [{"name": "phase-1"}],
-                "body": "",
-            },
-        ])
+        gh_output = json.dumps(
+            [
+                {
+                    "number": 10,
+                    "title": "some issue",
+                    "state": "OPEN",
+                    "labels": [{"name": "phase-1"}],
+                    "body": "",
+                },
+            ]
+        )
 
         def mock_run(args: list[str], cwd: str | None = None) -> str:
             if "issue list" in " ".join(args):
@@ -278,10 +292,12 @@ class TestCollectRecentMergedPRs:
     def test_collect_recent_merged_prs_returns_list(self) -> None:
         pm = _import_pm_status()
 
-        gh_output = json.dumps([
-            {"number": 5, "title": "feat: something", "mergedAt": "2024-01-01T10:00:00Z"},
-            {"number": 4, "title": "fix: bug", "mergedAt": "2024-01-01T09:00:00Z"},
-        ])
+        gh_output = json.dumps(
+            [
+                {"number": 5, "title": "feat: something", "mergedAt": "2024-01-01T10:00:00Z"},
+                {"number": 4, "title": "fix: bug", "mergedAt": "2024-01-01T09:00:00Z"},
+            ]
+        )
 
         def mock_run(args: list[str], cwd: str | None = None) -> str:
             if "pr list" in " ".join(args):
@@ -310,10 +326,12 @@ class TestCollectRecentMergedPRs:
     def test_collect_recent_merged_prs_respects_limit(self) -> None:
         pm = _import_pm_status()
 
-        gh_output = json.dumps([
-            {"number": i, "title": f"pr {i}", "mergedAt": "2024-01-01T00:00:00Z"}
-            for i in range(10)
-        ])
+        gh_output = json.dumps(
+            [
+                {"number": i, "title": f"pr {i}", "mergedAt": "2024-01-01T00:00:00Z"}
+                for i in range(10)
+            ]
+        )
 
         def mock_run(args: list[str], cwd: str | None = None) -> str:
             if "pr list" in " ".join(args):
@@ -515,21 +533,25 @@ class TestMainFunction:
     def test_main_with_no_args_runs(self) -> None:
         pm = _import_pm_status()
 
-        with patch.object(pm, "collect_worktree_info", return_value=[]):
-            with patch.object(pm, "collect_open_issues", return_value=[]):
-                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
-                    # Should not raise
-                    pm.main(["--stale-minutes", "10"])
+        with (
+            patch.object(pm, "collect_worktree_info", return_value=[]),
+            patch.object(pm, "collect_open_issues", return_value=[]),
+            patch.object(pm, "collect_recent_merged_prs", return_value=[]),
+        ):
+            # Should not raise
+            pm.main(["--stale-minutes", "10"])
 
     def test_main_no_prs_flag(self) -> None:
         pm = _import_pm_status()
 
-        with patch.object(pm, "collect_worktree_info", return_value=[]) as _:
-            with patch.object(pm, "collect_open_issues", return_value=[]) as _:
-                collect_prs_mock = MagicMock(return_value=[])
-                with patch.object(pm, "collect_recent_merged_prs", collect_prs_mock):
-                    pm.main(["--no-prs"])
-                    collect_prs_mock.assert_not_called()
+        collect_prs_mock = MagicMock(return_value=[])
+        with (
+            patch.object(pm, "collect_worktree_info", return_value=[]),
+            patch.object(pm, "collect_open_issues", return_value=[]),
+            patch.object(pm, "collect_recent_merged_prs", collect_prs_mock),
+        ):
+            pm.main(["--no-prs"])
+            collect_prs_mock.assert_not_called()
 
     def test_main_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
         pm = _import_pm_status()
@@ -546,10 +568,12 @@ class TestMainFunction:
             pr_state=None,
         )
 
-        with patch.object(pm, "collect_worktree_info", return_value=[wt]):
-            with patch.object(pm, "collect_open_issues", return_value=[]):
-                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
-                    pm.main(["--json"])
+        with (
+            patch.object(pm, "collect_worktree_info", return_value=[wt]),
+            patch.object(pm, "collect_open_issues", return_value=[]),
+            patch.object(pm, "collect_recent_merged_prs", return_value=[]),
+        ):
+            pm.main(["--json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -561,12 +585,14 @@ class TestMainFunction:
     def test_main_phase_filter_passed_to_collect_issues(self) -> None:
         pm = _import_pm_status()
 
-        with patch.object(pm, "collect_worktree_info", return_value=[]):
-            collect_issues_mock = MagicMock(return_value=[])
-            with patch.object(pm, "collect_open_issues", collect_issues_mock):
-                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
-                    pm.main(["--phase", "2"])
-                    collect_issues_mock.assert_called_once_with(phase=2)
+        collect_issues_mock = MagicMock(return_value=[])
+        with (
+            patch.object(pm, "collect_worktree_info", return_value=[]),
+            patch.object(pm, "collect_open_issues", collect_issues_mock),
+            patch.object(pm, "collect_recent_merged_prs", return_value=[]),
+        ):
+            pm.main(["--phase", "2"])
+            collect_issues_mock.assert_called_once_with(phase=2)
 
     def test_main_stale_minutes_passed_to_build_table(self) -> None:
         pm = _import_pm_status()
@@ -583,10 +609,12 @@ class TestMainFunction:
             pr_state=None,
         )
 
-        with patch.object(pm, "collect_worktree_info", return_value=[wt]):
-            with patch.object(pm, "collect_open_issues", return_value=[]):
-                with patch.object(pm, "collect_recent_merged_prs", return_value=[]):
-                    build_mock = MagicMock(return_value=MagicMock())
-                    with patch.object(pm, "build_worktree_table", build_mock):
-                        pm.main(["--stale-minutes", "5"])
-                        build_mock.assert_called_once_with([wt], stale_minutes=5)
+        build_mock = MagicMock(return_value=MagicMock())
+        with (
+            patch.object(pm, "collect_worktree_info", return_value=[wt]),
+            patch.object(pm, "collect_open_issues", return_value=[]),
+            patch.object(pm, "collect_recent_merged_prs", return_value=[]),
+            patch.object(pm, "build_worktree_table", build_mock),
+        ):
+            pm.main(["--stale-minutes", "5"])
+            build_mock.assert_called_once_with([wt], stale_minutes=5)


### PR DESCRIPTION
## 背景

Phase 2 Wave 1 の Issue #27/#29 で Agent が 10 分以上無音 timeout する事案が連続発生した。
PM 側に全 worktree の状態を 1 コマンドで確認する手段がなく、stall を検知できなかった。
本 PR はその観測インフラを実装する。

## 変更内容

- `scripts/pm_status.py` 新規作成（247 行）
  - テーブル A: Active worktrees（8 列）— stale 判定マーク付き
  - テーブル B: Open Issues（5 列）— worktree 割り当て可視化
  - テーブル C: Recently merged PRs（直近 10 件）
  - CLI フラグ: `--phase N` / `--stale-minutes N` / `--no-prs` / `--json`
  - ThreadPoolExecutor で git/gh コールを並列化 → **実測 1.3 秒**
- `Makefile` に `pm:` ターゲット追加
- `pyrightconfig.json` に `scripts` を include 追加
- `.claude/skills/multi_agent_orchestration.md` に「Agent 側の進捗報告義務」節追加（80 行）

## テスト

- `tests/scripts/test_pm_status.py` 新規作成（31 テスト）
- 6 TDD サイクル: WorktreeInfo/IssueInfo/PRInfo データクラス、collect_* 関数、determine_staleness、build_*_table、main() CLI
- CI parity 4 コマンド全緑: ruff / ruff format / pyright 0 errors / pytest 317 passed

## 手動確認

```
$ make pm
Active Worktrees: feature-40 (3 commits ahead, plan ✅, 1.3s 以内)
Open Issues: #40/#34/#33/#32
Recently Merged PRs: 直近 10 件表示
```

Closes #40