### PR TITLE
[#34] 差分更新 / 遷移 / SA / checkpoint の正しさを hypothesis property test で網羅検証

### DIFF
--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -1,0 +1,184 @@
+"""hypothesis property test 共通設定と fixture — Issue #34.
+
+このモジュールは tests/property/ 配下の 4 テストファイルで共通して使う
+hypothesis 設定・pytest fixture・ヘルパー関数を提供する。
+
+hypothesis 設定方針
+--------------------
+- ``max_examples=50`` : CI での flaky を防ぎつつ十分な探索を行う
+- ``deadline=None``   : SA などの重い処理に時間制限を掛けない
+- ``suppress_health_check`` : function_scoped_fixture および too_slow を抑制
+
+共通 fixture
+-------------
+- ``sample_objective`` : sample_case データから構築した ``ObjectiveState``
+- ``sample_arrays``    : sample_case データから生成した ``PopulationArrays``
+- ``sample_stats``     : sample_case から読んだ ``InitStats``
+- ``objective_input``  : ``ObjectiveState.from_arrays`` に渡す統計テーブル一式
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, settings
+
+from synthpop_jp.init.initial_population import InitStats, generate_initial_population
+from synthpop_jp.io.loaders import (
+    load_age_diff_couple,
+    load_age_diff_parent_child,
+    load_children_count_dist,
+    load_demographic_by_age_sex,
+    load_demographic_by_family_type_role,
+    load_family_type_counts,
+    load_family_type_mapping,
+    load_household_size_by_family_type,
+)
+from synthpop_jp.io.schemas import (
+    AgeDiffCoupleRow,
+    AgeDiffParentChildRow,
+    DemographicByAgeSexRow,
+)
+from synthpop_jp.optimize.objective import ObjectiveState
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.rng import SeedRegistry
+
+# ---------------------------------------------------------------------------
+# hypothesis グローバル設定
+# ---------------------------------------------------------------------------
+
+# property テスト全体で共通のデフォルト設定。
+# 各テスト関数は @settings(max_examples=...) でこれを上書きできる。
+settings.register_profile(
+    "property_default",
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+settings.load_profile("property_default")
+
+
+# ---------------------------------------------------------------------------
+# リポジトリルート解決
+# ---------------------------------------------------------------------------
+
+
+def _find_repo_root() -> Path:
+    """pyproject.toml を含む最近接の祖先を repo root とみなす."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError(f"pyproject.toml が {here} から辿れない階層に見つからない")
+
+
+_REPO_ROOT = _find_repo_root()
+_DATA_DIR = _REPO_ROOT / "data" / "sample_case"
+_CONFIGS_DIR = _REPO_ROOT / "configs"
+
+
+# ---------------------------------------------------------------------------
+# 共通型定義
+# ---------------------------------------------------------------------------
+
+
+class ObjectiveInput:
+    """ObjectiveState 構築に必要な統計テーブルをまとめた型."""
+
+    def __init__(
+        self,
+        age_diff_parent_child: list[AgeDiffParentChildRow],
+        age_diff_couple: list[AgeDiffCoupleRow],
+        demographic_by_age_sex: list[DemographicByAgeSexRow],
+    ) -> None:
+        self.age_diff_parent_child = age_diff_parent_child
+        self.age_diff_couple = age_diff_couple
+        self.demographic_by_age_sex = demographic_by_age_sex
+
+
+# ---------------------------------------------------------------------------
+# 共通 Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def sample_stats() -> InitStats:
+    """sample_case から読み込んだ統計データ（session スコープ）."""
+    return InitStats(
+        family_type_counts=load_family_type_counts(_DATA_DIR / "family_type_counts.csv"),
+        children_count_dist=load_children_count_dist(_DATA_DIR / "children_count_dist.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+        family_type_mapping=load_family_type_mapping(_CONFIGS_DIR / "family_type_mapping.yaml"),
+        household_size_by_family_type=load_household_size_by_family_type(
+            _DATA_DIR / "household_size_by_family_type.csv"
+        ),
+        demographic_by_family_type_role=load_demographic_by_family_type_role(
+            _DATA_DIR / "demographic_by_family_type_role.csv"
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def objective_input(sample_stats: InitStats) -> ObjectiveInput:
+    """ObjectiveState 構築に必要な統計テーブルをまとめた dict（session スコープ）."""
+    return ObjectiveInput(
+        age_diff_parent_child=load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv"),
+        age_diff_couple=load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        demographic_by_age_sex=sample_stats.demographic_by_age_sex,
+    )
+
+
+@pytest.fixture
+def sample_arrays(sample_stats: InitStats) -> PopulationArrays:
+    """sample_case から生成した初期人口（function スコープ、固定 seed）."""
+    rng = SeedRegistry(root=42).rng("init")
+    return generate_initial_population(sample_stats, rng)
+
+
+@pytest.fixture
+def sample_objective(
+    sample_arrays: PopulationArrays, objective_input: ObjectiveInput
+) -> ObjectiveState:
+    """sample_case から構築した ObjectiveState（function スコープ）.
+
+    hypothesis テストで使うときは ``copy.deepcopy`` して fresh なコピーを作ること。
+    """
+    return ObjectiveState.from_arrays(
+        arrays=sample_arrays,
+        age_diff_parent_child=objective_input.age_diff_parent_child,
+        age_diff_couple=objective_input.age_diff_couple,
+        demographic_by_age_sex=objective_input.demographic_by_age_sex,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー: fresh コピー生成
+# ---------------------------------------------------------------------------
+
+
+def fresh_objective(
+    stats: InitStats,
+    inp: ObjectiveInput,
+    seed: int = 42,
+) -> ObjectiveState:
+    """毎回 fresh な ObjectiveState を返すヘルパー.
+
+    hypothesis の各 example で独立した状態を保つために使う。
+    """
+    rng = SeedRegistry(root=seed).rng("init")
+    arrays = generate_initial_population(stats, rng)
+    return ObjectiveState.from_arrays(
+        arrays=arrays,
+        age_diff_parent_child=inp.age_diff_parent_child,
+        age_diff_couple=inp.age_diff_couple,
+        demographic_by_age_sex=inp.demographic_by_age_sex,
+    )
+
+
+def fresh_arrays(stats: InitStats, seed: int = 42) -> PopulationArrays:
+    """毎回 fresh な PopulationArrays を返すヘルパー."""
+    rng = SeedRegistry(root=seed).rng("init")
+    return generate_initial_population(stats, rng)

--- a/tests/property/test_checkpoint_roundtrip.py
+++ b/tests/property/test_checkpoint_roundtrip.py
@@ -1,0 +1,275 @@
+"""Property test: save → load で SAState の全フィールドが一致する — Issue #34.
+
+``save_checkpoint`` / ``load_checkpoint`` の round-trip を hypothesis で検証する。
+Issue #32 の決定論的テストと重複しないよう、本テストでは hypothesis で
+``PopulationArrays`` のサイズ（n_persons）を動的に振る。
+
+なぜ round-trip を検証するか
+------------------------------
+チェックポイントに誤りがあると SA の resume が正しくない状態から再開し、
+再現性（bitwise 一致）が失われる。
+hypothesis で n_persons を振ることで、小さいケース・中程度のケースで
+pickle/gzip の保存・復元が確実に機能することを保証する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.optimize.annealing import SAState
+from synthpop_jp.optimize.checkpoint import load_checkpoint, save_checkpoint
+from synthpop_jp.optimize.objective import ObjectiveState
+from synthpop_jp.optimize.state import PopulationArrays
+
+# ---------------------------------------------------------------------------
+# テスト用ヘルパー
+# ---------------------------------------------------------------------------
+
+ALL_ROLES = ["husband", "wife", "father", "mother", "child", "parent", "single"]
+ALL_FAMILY_TYPES = [
+    "couple",
+    "couple_and_children",
+    "single",
+    "lone_parent_and_children",
+    "couple_and_a_parent",
+]
+
+
+def _make_registries() -> tuple[FamilyTypeRegistry, RoleRegistry, SexRegistry]:
+    """テスト用 Registry を返す."""
+    family_reg = FamilyTypeRegistry()
+    for ft in ALL_FAMILY_TYPES:
+        family_reg.register(ft)
+    role_reg = RoleRegistry()
+    for r in ALL_ROLES:
+        role_reg.register(r)
+    sex_reg = SexRegistry()
+    return family_reg, role_reg, sex_reg
+
+
+def _make_arrays(n_persons: int, seed: int) -> PopulationArrays:
+    """n_persons 人の単身世帯からなる PopulationArrays を生成する.
+
+    seed で age を決定論的に振る。
+    """
+    rng = np.random.default_rng(seed)
+    family_reg, role_reg, sex_reg = _make_registries()
+    households = [
+        Household(
+            household_id=i + 1,
+            family_type="single",
+            members=[
+                Person(
+                    household_id=i + 1,
+                    role="single",  # type: ignore[arg-type]
+                    sex="M" if i % 2 == 0 else "F",  # type: ignore[arg-type]
+                    age=int(rng.integers(18, 80)),
+                )
+            ],
+        )
+        for i in range(n_persons)
+    ]
+    return PopulationArrays.from_households(households, family_reg, role_reg, sex_reg)
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    n_persons=st.integers(min_value=10, max_value=200),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_sastate_roundtrip_with_varying_sizes(
+    n_persons: int,
+    seed: int,
+    tmp_path: Path,
+) -> None:
+    """任意の n_persons で SAState の save/load round-trip が成立する.
+
+    SAState の全フィールド（iter, current_score, best_score, n_accepted, n_total）が
+    load 後に bitwise 一致することを検証する。
+    """
+    rng = np.random.default_rng(seed)
+    arrays = _make_arrays(n_persons, seed)
+    best_arrays = _make_arrays(n_persons, seed + 1)
+    objective = ObjectiveState(arrays=arrays, stats=[], total_score=float(rng.uniform(0, 1000)))
+
+    state = SAState(
+        iter=int(rng.integers(0, 10000)),
+        current_score=float(rng.uniform(0, 500)),
+        best_score=float(rng.uniform(0, 300)),
+        n_accepted=int(rng.integers(0, 5000)),
+        n_total=int(rng.integers(0, 10000)),
+    )
+    rng_state = np.random.default_rng(seed + 2).bit_generator.state
+    ckpt_path = tmp_path / f"checkpoint_n{n_persons}_s{seed}.pkl.gz"
+    save_checkpoint(
+        state=state,
+        arrays=arrays,
+        objective_state=objective,
+        best_arrays=best_arrays,
+        best_score=state.best_score,
+        rng_state=rng_state,
+        path=ckpt_path,
+    )
+
+    (
+        loaded_state,
+        _loaded_arrays,
+        _loaded_objective,
+        _loaded_best_arrays,
+        _loaded_best_score,
+        _loaded_rng_state,
+    ) = load_checkpoint(ckpt_path)
+
+    # SAState の全フィールドが一致する
+    assert loaded_state.iter == state.iter, (
+        f"iter が一致しない: {loaded_state.iter} != {state.iter}"
+    )
+    assert abs(loaded_state.current_score - state.current_score) < 1e-9, (
+        f"current_score が一致しない: {loaded_state.current_score} != {state.current_score}"
+    )
+    assert abs(loaded_state.best_score - state.best_score) < 1e-9, (
+        f"best_score が一致しない: {loaded_state.best_score} != {state.best_score}"
+    )
+    assert loaded_state.n_accepted == state.n_accepted, (
+        f"n_accepted が一致しない: {loaded_state.n_accepted} != {state.n_accepted}"
+    )
+    assert loaded_state.n_total == state.n_total, (
+        f"n_total が一致しない: {loaded_state.n_total} != {state.n_total}"
+    )
+
+
+@given(
+    n_persons=st.integers(min_value=10, max_value=200),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_population_arrays_roundtrip_with_varying_sizes(
+    n_persons: int,
+    seed: int,
+    tmp_path: Path,
+) -> None:
+    """任意の n_persons で PopulationArrays の save/load round-trip が成立する.
+
+    age, sex, role, household_id, family_type の全配列が bitwise 一致することを検証する。
+    """
+    arrays = _make_arrays(n_persons, seed)
+    best_arrays = _make_arrays(n_persons, seed + 1)
+    objective = ObjectiveState(arrays=arrays, stats=[], total_score=0.0)
+    state = SAState()
+    rng_state = np.random.default_rng(seed).bit_generator.state
+    ckpt_path = tmp_path / f"arrays_n{n_persons}_s{seed}.pkl.gz"
+    save_checkpoint(
+        state=state,
+        arrays=arrays,
+        objective_state=objective,
+        best_arrays=best_arrays,
+        best_score=0.0,
+        rng_state=rng_state,
+        path=ckpt_path,
+    )
+
+    _, loaded_arrays, _, loaded_best_arrays, _, _ = load_checkpoint(ckpt_path)
+
+    # 全配列が bitwise 一致する
+    assert np.array_equal(loaded_arrays.age, arrays.age), (
+        f"age が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+    assert np.array_equal(loaded_arrays.sex, arrays.sex), (
+        f"sex が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+    assert np.array_equal(loaded_arrays.role, arrays.role), (
+        f"role が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+    assert np.array_equal(loaded_arrays.household_id, arrays.household_id), (
+        f"household_id が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+    assert np.array_equal(loaded_arrays.family_type, arrays.family_type), (
+        f"family_type が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+
+    # best_arrays の age も一致する
+    assert np.array_equal(loaded_best_arrays.age, best_arrays.age), (
+        f"best_arrays.age が一致しない: n_persons={n_persons}, seed={seed}"
+    )
+
+    # n_persons が保持される
+    assert loaded_arrays.n_persons == n_persons, (
+        f"n_persons が一致しない: {loaded_arrays.n_persons} != {n_persons}"
+    )
+
+
+@given(
+    n_persons=st.integers(min_value=10, max_value=200),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_rng_state_roundtrip_with_varying_sizes(
+    n_persons: int,
+    seed: int,
+    tmp_path: Path,
+) -> None:
+    """任意の n_persons で rng_state の save/load round-trip が成立する.
+
+    rng_state を復元後に生成した乱数が元の rng と bitwise 一致することを検証する。
+    SA の resume 時に乱数列が正確に再開できることの保証である。
+    """
+    rng_orig = np.random.default_rng(seed)
+    # 状態を少し進める
+    for _ in range(100):
+        rng_orig.uniform()
+
+    rng_state_saved = rng_orig.bit_generator.state
+
+    arrays = _make_arrays(n_persons, seed)
+    objective = ObjectiveState(arrays=arrays, stats=[], total_score=0.0)
+    best_arrays = _make_arrays(n_persons, seed + 1)
+    state = SAState(iter=100)
+    ckpt_path = tmp_path / f"rng_n{n_persons}_s{seed}.pkl.gz"
+    save_checkpoint(
+        state=state,
+        arrays=arrays,
+        objective_state=objective,
+        best_arrays=best_arrays,
+        best_score=0.0,
+        rng_state=rng_state_saved,
+        path=ckpt_path,
+    )
+
+    _, _, _, _, _, loaded_rng_state = load_checkpoint(ckpt_path)
+
+    # 復元した状態から rng を再構築して次の 10 サンプルを比較
+    rng_restored = np.random.default_rng()
+    rng_restored.bit_generator.state = loaded_rng_state
+
+    samples_orig = [float(rng_orig.uniform()) for _ in range(10)]
+    samples_restored = [float(rng_restored.uniform()) for _ in range(10)]
+
+    for i, (orig, restored) in enumerate(zip(samples_orig, samples_restored, strict=True)):
+        assert orig == restored, (
+            f"rng sample[{i}] が一致しない: {orig} != {restored}, "
+            f"n_persons={n_persons}, seed={seed}"
+        )

--- a/tests/property/test_objective_delta_vs_full.py
+++ b/tests/property/test_objective_delta_vs_full.py
@@ -1,0 +1,190 @@
+"""Property test: propose_change の差分更新が全再計算と一致する — Issue #34.
+
+最重要テスト。任意の ``(PopulationArrays, person_idx, new_age)`` に対して
+
+    ObjectiveState.propose_change(idx, new_age)
+
+が
+
+    score_after_full_recompute - score_before
+
+と 1e-6 以下の誤差で一致することを hypothesis で網羅的に検証する。
+
+なぜこれが最重要か
+-------------------
+SA の差分更新は全再計算を O(1) に置き換える最適化であり、
+「差分 == 全再計算の差分」が成り立たないと SA が誤った方向に最適化する。
+このテストが落ちた場合、実装にバグがある可能性が高い。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from synthpop_jp.optimize.objective import ObjectiveState
+
+from .conftest import InitStats, ObjectiveInput, fresh_objective
+
+# ---------------------------------------------------------------------------
+# 全再計算ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _full_recompute_score(
+    obj: ObjectiveState,
+    inp: ObjectiveInput,
+) -> float:
+    """obj.arrays の現在状態から全再計算でスコアを求める.
+
+    obj.arrays を直接変更しないこと。
+    呼び出し前に age を変更済みの状態で渡すこと。
+    """
+    fresh = ObjectiveState.from_arrays(
+        arrays=obj.arrays,
+        age_diff_parent_child=inp.age_diff_parent_child,
+        age_diff_couple=inp.age_diff_couple,
+        demographic_by_age_sex=inp.demographic_by_age_sex,
+    )
+    return fresh.total_score
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+    new_age=st.integers(min_value=0, max_value=100),
+)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_propose_change_matches_full_recompute_delta(
+    person_idx_frac: float,
+    new_age: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """任意の (person_idx, new_age) で propose_change が全再計算差分に一致する.
+
+    検証手順:
+    1. fresh な ObjectiveState を生成する（毎 example でリセット）
+    2. propose_change(idx, new_age) で差分スコアを取得する（副作用なし）
+    3. arrays.age[idx] を new_age に書き換えてから全再計算スコアを取得する
+    4. 元の age に戻す
+    5. (全再計算後スコア) - (元スコア) と propose_change の差分を比較する
+    """
+    obj = fresh_objective(sample_stats, objective_input)
+    n_persons = obj.arrays.n_persons
+    idx = max(0, min(int(person_idx_frac * n_persons), n_persons - 1))
+
+    score_before = obj.total_score
+
+    # 差分更新で delta を計算（副作用なし）
+    delta_differential = obj.propose_change(idx, new_age)
+
+    # propose は副作用がないことも確認する
+    assert obj.total_score == score_before, (
+        f"propose_change が total_score を変更した: {score_before} -> {obj.total_score}"
+    )
+    assert int(obj.arrays.age[idx]) == int(obj.arrays.age[idx]), "arrays.age が変更された"
+
+    # 全再計算: age を一時的に書き換えてから from_arrays でスコアを再計算する
+    old_age = int(obj.arrays.age[idx])
+    obj.arrays.age[idx] = np.int16(new_age)
+    score_after_full = _full_recompute_score(obj, objective_input)
+    obj.arrays.age[idx] = np.int16(old_age)  # 元に戻す
+
+    expected_delta = score_after_full - score_before
+
+    assert abs(delta_differential - expected_delta) < 1e-6, (
+        f"差分更新と全再計算の差分が一致しない: "
+        f"idx={idx}, old_age={old_age}, new_age={new_age}, "
+        f"differential={delta_differential:.8f}, full={expected_delta:.8f}, "
+        f"diff={abs(delta_differential - expected_delta):.2e}"
+    )
+
+
+@given(
+    person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+    new_age=st.integers(min_value=0, max_value=100),
+)
+@settings(
+    max_examples=30,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_propose_does_not_modify_state(
+    person_idx_frac: float,
+    new_age: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """propose_change は total_score と arrays.age を変更しない（副作用なし）.
+
+    差分更新の前提となる「propose は副作用なし」を property として検証する。
+    """
+    obj = fresh_objective(sample_stats, objective_input)
+    n_persons = obj.arrays.n_persons
+    idx = max(0, min(int(person_idx_frac * n_persons), n_persons - 1))
+
+    score_before = obj.total_score
+    age_before = int(obj.arrays.age[idx])
+
+    # propose_change を実行（副作用なしのはず）
+    obj.propose_change(idx, new_age)
+
+    # total_score が変化していないことを確認
+    assert obj.total_score == score_before, (
+        f"propose_change が total_score を変更した: "
+        f"before={score_before:.6f}, after={obj.total_score:.6f}"
+    )
+    # arrays.age が変化していないことを確認
+    assert int(obj.arrays.age[idx]) == age_before, (
+        f"propose_change が arrays.age[{idx}] を変更した: "
+        f"before={age_before}, after={int(obj.arrays.age[idx])}"
+    )
+
+
+@given(
+    person_idx_frac=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+    new_age=st.integers(min_value=0, max_value=100),
+)
+@settings(
+    max_examples=30,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_apply_then_revert_restores_score(
+    person_idx_frac: float,
+    new_age: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """apply_change → 元の age に戻す apply_change で total_score が復元される.
+
+    差分更新の可逆性を property として検証する。
+    可逆性が成立しないと SA の反復が誤った状態に陥る。
+    """
+    obj = fresh_objective(sample_stats, objective_input)
+    n_persons = obj.arrays.n_persons
+    idx = max(0, min(int(person_idx_frac * n_persons), n_persons - 1))
+
+    original_score = obj.total_score
+    old_age = int(obj.arrays.age[idx])
+
+    # 変更を適用してから元に戻す
+    obj.apply_change(idx, new_age)
+    obj.apply_change(idx, old_age)
+
+    assert abs(obj.total_score - original_score) < 1e-6, (
+        f"apply → revert 後に total_score が復元されない: "
+        f"idx={idx}, old_age={old_age}, new_age={new_age}, "
+        f"original={original_score:.8f}, restored={obj.total_score:.8f}, "
+        f"diff={abs(obj.total_score - original_score):.2e}"
+    )

--- a/tests/property/test_sa_monotonic_best.py
+++ b/tests/property/test_sa_monotonic_best.py
@@ -1,0 +1,166 @@
+"""Property test: SARunner の best_score は単調非増加 — Issue #34.
+
+SA の設計上、best_score は「これまでに発見した最良スコア」であり、
+一度改善されたら悪化することはない。
+この単調非増加性（monotonic non-increasing）を hypothesis で検証する。
+
+なぜ単調性が重要か
+-------------------
+best_score が増加するということは、「より悪い解を best とみなした」ことを意味する。
+これは SA の実装バグのサインであり、最適化の方向が狂う。
+scores リストは best_score の更新履歴を保持する（SAResult.scores）ため、
+この順序が単調非増加であることをテストする。
+"""
+
+from __future__ import annotations
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from synthpop_jp.config import AnnealingConfig
+from synthpop_jp.optimize.annealing import SAResult, SARunner
+from synthpop_jp.optimize.cooling import ExponentialCooling
+from synthpop_jp.optimize.transitions import AgeChangeTransition
+from synthpop_jp.rng import SeedRegistry
+
+from .conftest import InitStats, ObjectiveInput, fresh_objective
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n_iters=st.integers(min_value=50, max_value=300),
+)
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_best_score_monotonic_non_increasing(
+    seed: int,
+    n_iters: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """SARunner.run の SAResult.scores が単調非増加であることを検証する.
+
+    SAResult.scores は best_score が更新されるたびに追記されるリストであり、
+    初期スコアから始まって改善のみが記録される。
+    したがって隣接要素の差分 (scores[i+1] - scores[i]) は常に <= 0 のはずである。
+
+    検証手順:
+    1. 任意の seed と n_iters で SARunner.run を実行する
+    2. result.scores の隣接差分を計算する
+    3. すべての差分が <= 0 であることを確認する
+    """
+    obj = fresh_objective(sample_stats, objective_input)
+    arrays = obj.arrays
+    demo_rows = objective_input.demographic_by_age_sex
+
+    rng_transition = SeedRegistry(root=seed).rng("sa_transition")
+    rng_runner = SeedRegistry(root=seed).rng("sa_runner")
+
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng_transition,
+    )
+
+    config = AnnealingConfig(
+        T0=100.0,
+        alpha=0.99,
+        max_iters=n_iters,
+        evals_per_agent=0,
+        trace_enabled=False,
+        checkpoint_every_n_iters=0,
+        checkpoint_dir=None,
+    )
+    cooling = ExponentialCooling(T0=config.T0, alpha=config.alpha)
+    runner = SARunner(rng=rng_runner)
+
+    result: SAResult = runner.run(
+        arrays=arrays,
+        objective=obj,
+        transition=transition,
+        cooling=cooling,
+        config=config,
+        progress_enabled=False,
+    )
+
+    scores = result.scores
+    assert len(scores) >= 1, "scores リストが空である（初期スコアが含まれていない）"
+
+    # 隣接差分がすべて <= 0 であることを確認する
+    for i in range(len(scores) - 1):
+        diff = scores[i + 1] - scores[i]
+        assert diff <= 0.0, (
+            f"best_score が増加している: "
+            f"scores[{i}]={scores[i]:.6f} -> scores[{i + 1}]={scores[i + 1]:.6f}, "
+            f"diff={diff:.6f}, seed={seed}, n_iters={n_iters}"
+        )
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n_iters=st.integers(min_value=50, max_value=200),
+)
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_best_score_never_exceeds_initial_score(
+    seed: int,
+    n_iters: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """SA 実行後の best_score が初期スコアを超えないことを検証する.
+
+    best_score は初期スコアからのみ改善方向に進む。
+    initial_score 以上（=悪化）になることはない。
+    """
+    obj = fresh_objective(sample_stats, objective_input)
+    initial_score = obj.total_score
+    arrays = obj.arrays
+    demo_rows = objective_input.demographic_by_age_sex
+
+    rng_transition = SeedRegistry(root=seed).rng("sa_transition")
+    rng_runner = SeedRegistry(root=seed).rng("sa_runner")
+
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng_transition,
+    )
+
+    config = AnnealingConfig(
+        T0=100.0,
+        alpha=0.99,
+        max_iters=n_iters,
+        evals_per_agent=0,
+        trace_enabled=False,
+        checkpoint_every_n_iters=0,
+        checkpoint_dir=None,
+    )
+    cooling = ExponentialCooling(T0=config.T0, alpha=config.alpha)
+    runner = SARunner(rng=rng_runner)
+
+    result: SAResult = runner.run(
+        arrays=arrays,
+        objective=obj,
+        transition=transition,
+        cooling=cooling,
+        config=config,
+        progress_enabled=False,
+    )
+
+    final_best_score = result.final_state.best_score
+
+    assert final_best_score <= initial_score + 1e-9, (
+        f"best_score ({final_best_score:.6f}) が初期スコア ({initial_score:.6f}) を超えた: "
+        f"seed={seed}, n_iters={n_iters}"
+    )

--- a/tests/property/test_transition_preserves_invariants.py
+++ b/tests/property/test_transition_preserves_invariants.py
@@ -1,0 +1,251 @@
+"""Property test: age-change 遷移後も household size・family_type 分布が不変 — Issue #34.
+
+``AgeChangeTransition`` が変えるのは age だけであり、
+世帯の構成（household_id / role / sex / family_type）は変わらない。
+この不変性を hypothesis で網羅的に検証する。
+
+なぜ不変性が重要か
+-------------------
+遷移が誤って household_id や role を変えると、次の差分更新計算が狂う。
+「age しか変えない」という前提は SA の正確性の基盤である。
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.optimize.transitions import AgeChangeTransition
+from synthpop_jp.rng import SeedRegistry
+
+from .conftest import InitStats, ObjectiveInput, fresh_arrays
+
+# ---------------------------------------------------------------------------
+# 不変量の計算ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def compute_household_sizes(arrays: PopulationArrays) -> Counter[int]:
+    """世帯 ID ごとのメンバー数を返す."""
+    return Counter(int(hid) for hid in arrays.household_id)
+
+
+def compute_family_type_dist(arrays: PopulationArrays) -> Counter[int]:
+    """family_type の分布（各世帯の family_type を 1 票とみなす）を返す.
+
+    各世帯の代表メンバー（先頭インデックス）の family_type を集計する。
+    """
+    seen_hids: set[int] = set()
+    dist: Counter[int] = Counter()
+    for i in range(arrays.n_persons):
+        hid = int(arrays.household_id[i])
+        if hid not in seen_hids:
+            seen_hids.add(hid)
+            dist[int(arrays.family_type[i])] += 1
+    return dist
+
+
+def compute_role_dist(arrays: PopulationArrays) -> Counter[int]:
+    """role の分布を返す（全 person の role カウント）."""
+    return Counter(int(r) for r in arrays.role)
+
+
+def compute_sex_dist(arrays: PopulationArrays) -> Counter[int]:
+    """sex の分布を返す（全 person の sex カウント）."""
+    return Counter(int(s) for s in arrays.sex)
+
+
+# ---------------------------------------------------------------------------
+# Property tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    n_iters=st.integers(min_value=1, max_value=100),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_age_change_preserves_household_sizes(
+    n_iters: int,
+    seed: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """age-change 遷移を n_iters 回繰り返しても household size 分布が不変.
+
+    AgeChangeTransition.propose() は (person_idx, new_age) を返すだけであり、
+    呼び出し元が age を更新する。そのため household_id は変化しないはずである。
+    """
+    arrays = fresh_arrays(sample_stats)
+    demo_rows = objective_input.demographic_by_age_sex
+
+    initial_household_sizes = compute_household_sizes(arrays)
+
+    rng = SeedRegistry(root=seed).rng("test_transition")
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng,
+    )
+
+    for _ in range(n_iters):
+        try:
+            idx, new_age = transition.propose()
+        except Exception:
+            # TransitionError など — スキップして次へ
+            continue
+        # age だけを更新する（ObjectiveState 経由ではなく直接更新）
+        arrays.age[idx] = np.int16(new_age)
+
+    after_household_sizes = compute_household_sizes(arrays)
+
+    assert initial_household_sizes == after_household_sizes, (
+        f"household size 分布が変化した: "
+        f"before={dict(initial_household_sizes)}, "
+        f"after={dict(after_household_sizes)}"
+    )
+
+
+@given(
+    n_iters=st.integers(min_value=1, max_value=100),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_age_change_preserves_family_type_distribution(
+    n_iters: int,
+    seed: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """age-change 遷移を n_iters 回繰り返しても family_type 分布が不変.
+
+    family_type は age-change では変更されないため、分布は常に一定のはずである。
+    """
+    arrays = fresh_arrays(sample_stats)
+    demo_rows = objective_input.demographic_by_age_sex
+
+    initial_family_dist = compute_family_type_dist(arrays)
+
+    rng = SeedRegistry(root=seed).rng("test_transition")
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng,
+    )
+
+    for _ in range(n_iters):
+        try:
+            idx, new_age = transition.propose()
+        except Exception:
+            continue
+        arrays.age[idx] = np.int16(new_age)
+
+    after_family_dist = compute_family_type_dist(arrays)
+
+    assert initial_family_dist == after_family_dist, (
+        f"family_type 分布が変化した: "
+        f"before={dict(initial_family_dist)}, "
+        f"after={dict(after_family_dist)}"
+    )
+
+
+@given(
+    n_iters=st.integers(min_value=1, max_value=100),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_age_change_preserves_role_distribution(
+    n_iters: int,
+    seed: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """age-change 遷移を n_iters 回繰り返しても role 分布が不変.
+
+    AgeChangeTransition は age のみを変更するため、role は不変のはずである。
+    """
+    arrays = fresh_arrays(sample_stats)
+    demo_rows = objective_input.demographic_by_age_sex
+
+    initial_role_dist = compute_role_dist(arrays)
+
+    rng = SeedRegistry(root=seed).rng("test_transition")
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng,
+    )
+
+    for _ in range(n_iters):
+        try:
+            idx, new_age = transition.propose()
+        except Exception:
+            continue
+        arrays.age[idx] = np.int16(new_age)
+
+    after_role_dist = compute_role_dist(arrays)
+
+    assert initial_role_dist == after_role_dist, (
+        f"role 分布が変化した: before={dict(initial_role_dist)}, after={dict(after_role_dist)}"
+    )
+
+
+@given(
+    n_iters=st.integers(min_value=1, max_value=100),
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+)
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+def test_age_change_preserves_sex_distribution(
+    n_iters: int,
+    seed: int,
+    sample_stats: InitStats,
+    objective_input: ObjectiveInput,
+) -> None:
+    """age-change 遷移を n_iters 回繰り返しても sex 分布が不変.
+
+    AgeChangeTransition は age のみを変更するため、sex は不変のはずである。
+    """
+    arrays = fresh_arrays(sample_stats)
+    demo_rows = objective_input.demographic_by_age_sex
+
+    initial_sex_dist = compute_sex_dist(arrays)
+
+    rng = SeedRegistry(root=seed).rng("test_transition")
+    transition = AgeChangeTransition(
+        arrays=arrays,
+        demo_by_age_sex=demo_rows,
+        rng=rng,
+    )
+
+    for _ in range(n_iters):
+        try:
+            idx, new_age = transition.propose()
+        except Exception:
+            continue
+        arrays.age[idx] = np.int16(new_age)
+
+    after_sex_dist = compute_sex_dist(arrays)
+
+    assert initial_sex_dist == after_sex_dist, (
+        f"sex 分布が変化した: before={dict(initial_sex_dist)}, after={dict(after_sex_dist)}"
+    )


### PR DESCRIPTION
## 背景

Phase 2 の差分更新（#27）/ age-change 遷移（#29）/ SA runner（#30）/ checkpoint（#32）の正しさを、例単発でなく **hypothesis property test** で網羅検証する。Phase 3a 以降の改修で regression が出たら自動検知できる。

Closes #34

## この変更で提供する価値

- レビュアーが `uv run pytest tests/property/` で Phase 2 コア振る舞いの property 検証が走ることを確信できる
- 「差分更新と全再計算が一致する」「遷移後も world 不変」など、ロジック保存則の宣言が executable な形でリポジトリに残る

## 変更内容

- `tests/property/__init__.py` 新規（空）
- `tests/property/conftest.py` 新規（共通 hypothesis settings）
- `tests/property/test_objective_delta_vs_full.py`: 3 tests
- `tests/property/test_transition_preserves_invariants.py`: 4 tests
- `tests/property/test_sa_monotonic_best.py`: 2 tests
- `tests/property/test_checkpoint_roundtrip.py`: 3 tests

合計 12 property tests, 約 1066 行。

## 影響範囲

- 新規 `tests/property/` のみ。既存テスト・実装に影響なし
- pytest 全体実行時間 +3 秒程度（hypothesis max_examples=50）

## テスト

- 追加: 12 property tests
- 全 410 passed, 2 skipped
- 4 コマンド全緑

## 残課題

- age-swap / hybrid の property test → Phase 3a
- 評価器の property test → Phase 4
- mutation test 的な検証 → 別 Issue 化候補

## レビュアーに見てほしい点

1. hypothesis 戦略の設計（`@settings(max_examples=50)`, `deadline=None`）が flaky にならない範囲か
2. 4 ファイルの property 表現が「Phase 2 のコア振る舞い」を網羅しているか

## 自己点検

- [x] origin/develop 取り込み済み
- [x] 4 コマンド全緑
- [x] Issue #34 成功条件達成
- [x] 非技術者にも 1 段落で説明できる: 「合成人口生成の差分更新が正しいかを 50 通りの入力で自動チェック」
- [x] Closes #34

## 注記

前 Agent stall（24 分無音、commit 0、5 ファイル untracked）の後、PM が引き継いで commit + push + PR 作成。テスト内容は Agent が書いた品質を保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)