### PR TITLE
[phase-2] commit cadence を物理的に強制する check_cadence.py と関連ドキュメント (#46)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,7 @@ pm:
 	uv run python scripts/pm_status.py $(ARGS)
 
 all: lint format type test
+
+.PHONY: cadence
+cadence:
+	uv run python scripts/check_cadence.py $(ARGS)

--- a/docs/rules/tdd.md
+++ b/docs/rules/tdd.md
@@ -200,3 +200,65 @@ _GENERATE_SCRIPT = _REPO_ROOT / "scripts" / "generate_sample_case.py"
 
 - 現行実装例: `tests/regression/test_determinism.py` の `_find_repo_root`
 - 関連: PR #18 で CI 専用の失敗として修正
+
+---
+
+## 11. commit cadence — 実装を小さく刻んで詰まりを防ぐ
+
+TDD の Red/Green/Refactor を守っていても、「テストをたくさん書いてから一気に Green にする」という進め方をすると Agent が無音 stall する。
+本節では commit の粒度を明示し、物理的に強制する仕組みを整える（Issue #46）。
+
+### 基本方針
+
+**1 サイクル = 1 commit（test commit + feat commit）**。まとめて書いてからの commit は禁止。
+
+| タイミング | commit メッセージのプレフィックス |
+|---|---|
+| テストファイル 1 つ書いたら | `test:` |
+| 1 関数 / 1 クラス実装したら | `feat:` |
+| ドキュメント 1 節追加したら | `docs:` |
+| リファクタリングしたら | `refactor:` |
+
+commit は小さいほどよい。「このくらいまとめてからでよい」という判断は stall の入口。
+
+### 警告閾値
+
+uncommitted の変更が以下を超えたら即 commit する：
+
+- **ファイル数 5 超**
+- **追加行数 200 超**
+
+`scripts/check_cadence.py` でその場で確認できる：
+
+```bash
+# make cadence で確認
+make cadence
+# OK: 2 files / 45 lines uncommitted
+
+# カスタム閾値
+make cadence ARGS="--threshold-files 3 --threshold-lines 100"
+
+# 直接呼ぶ場合
+uv run python scripts/check_cadence.py --worktree .
+```
+
+exit 1 + WARNING が出たら、即 `git add <files> && git commit` すること。
+
+### self-stall の定義と対処
+
+最終 commit から **15 分以上** 経過し、かつ進捗コメントも Issue に追加されていない状態を **self-stall** と呼ぶ。
+
+self-stall に陥ったら：
+
+1. 未コミット差分を `wip:` プレフィックスで commit して push
+2. `gh pr create --draft --base develop` で中間 Draft PR を作成
+3. Issue に self-stall 宣言コメントを投稿（詳細フォーマットは `.claude/skills/multi_agent_orchestration.md`）
+4. 完了報告を返す（PM がセッションを引き継ぐ）
+
+PM 側は `make pm` で stale worktree を検知できる（10 分で警告、20 分で危険）。
+
+### 参考
+
+- `scripts/check_cadence.py`: uncommitted 規模の自動確認ツール
+- `tests/scripts/test_check_cadence.py`: 上記のテスト
+- `.claude/skills/multi_agent_orchestration.md` §「commit cadence の強制」: Agent プロンプトへの組み込み方

--- a/scripts/check_cadence.py
+++ b/scripts/check_cadence.py
@@ -1,0 +1,183 @@
+"""scripts/check_cadence.py
+
+uncommitted 変更の規模を確認し、閾値超過なら警告して exit 1 する。
+
+Issue #46: Agent が stall せず commit cadence を守る仕組みの物理的強制
+
+使い方:
+    uv run python scripts/check_cadence.py
+    uv run python scripts/check_cadence.py --worktree /path/to/worktree
+    uv run python scripts/check_cadence.py --threshold-files 3 --threshold-lines 100
+
+`make cadence` からも呼べる。
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+# デフォルト閾値
+DEFAULT_THRESHOLD_FILES = 5
+DEFAULT_THRESHOLD_LINES = 200
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    """git コマンドを実行してstdoutを返す。失敗したら RuntimeError を上げる."""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+    )
+    if result.returncode not in (0, 1):
+        # git status/diff は変更ありの場合に exit 1 を返すことがある
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def count_uncommitted_files(worktree: Path) -> int:
+    """worktree 内の uncommitted ファイル数を返す。
+
+    tracked の変更（M, D, A など）と untracked (??) の両方を数える。
+    """
+    output = _run_git(["status", "--short"], worktree)
+    lines = [line for line in output.splitlines() if line.strip()]
+    return len(lines)
+
+
+def count_uncommitted_lines(worktree: Path) -> int:
+    """worktree 内の uncommitted 追加行数を返す。
+
+    git diff --numstat でステージ済み・未ステージ両方を合計する。
+    untracked ファイルは別途 wc -l で数える。
+    """
+    total_added = 0
+
+    # ステージ済みの差分（--cached）
+    staged_output = _run_git(["diff", "--numstat", "--cached"], worktree)
+    for line in staged_output.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].isdigit():
+            total_added += int(parts[0])
+
+    # 未ステージの差分
+    unstaged_output = _run_git(["diff", "--numstat"], worktree)
+    for line in unstaged_output.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].isdigit():
+            total_added += int(parts[0])
+
+    # untracked ファイルの行数
+    status_output = _run_git(["status", "--short"], worktree)
+    for line in status_output.splitlines():
+        if line.startswith("??"):
+            # untracked ファイル（スペース区切りでファイル名）
+            file_name = line[3:].strip()
+            file_path = worktree / file_name
+            if file_path.is_file():
+                try:
+                    content = file_path.read_text(encoding="utf-8", errors="replace")
+                    total_added += len(content.splitlines())
+                except OSError:
+                    pass
+
+    return total_added
+
+
+def check_cadence(
+    worktree: Path,
+    threshold_files: int = DEFAULT_THRESHOLD_FILES,
+    threshold_lines: int = DEFAULT_THRESHOLD_LINES,
+) -> tuple[bool, str]:
+    """commit cadence の状態を確認する。
+
+    Returns:
+        (ok, message): ok=True なら閾値以内、False なら超過。
+    """
+    n_files = count_uncommitted_files(worktree)
+    n_lines = count_uncommitted_lines(worktree)
+
+    violations: list[str] = []
+    if n_files > threshold_files:
+        violations.append(
+            f"uncommitted files: {n_files} (threshold: {threshold_files})"
+        )
+    if n_lines > threshold_lines:
+        violations.append(
+            f"uncommitted lines: {n_lines} (threshold: {threshold_lines})"
+        )
+
+    if violations:
+        msg_lines = [
+            "WARNING: commit cadence threshold exceeded! Please commit now.",
+            *[f"  - {v}" for v in violations],
+            "",
+            "Hint: Run `git add <files> && git commit` to reset the counter.",
+            f"  Current: {n_files} files / {n_lines} lines uncommitted",
+        ]
+        return False, "\n".join(msg_lines)
+
+    return True, f"OK: {n_files} files / {n_lines} lines uncommitted"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI エントリーポイント。exit code を返す（0=OK, 1=NG）."""
+    parser = argparse.ArgumentParser(
+        description="Check commit cadence: warn if too many uncommitted changes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  uv run python scripts/check_cadence.py
+  uv run python scripts/check_cadence.py --worktree /path/to/worktree
+  uv run python scripts/check_cadence.py --threshold-files 3 --threshold-lines 100
+  make cadence
+""",
+    )
+    parser.add_argument(
+        "--worktree",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the git worktree to check (default: cwd)",
+    )
+    parser.add_argument(
+        "--threshold-files",
+        type=int,
+        default=DEFAULT_THRESHOLD_FILES,
+        help=f"Max uncommitted files before warning (default: {DEFAULT_THRESHOLD_FILES})",
+    )
+    parser.add_argument(
+        "--threshold-lines",
+        type=int,
+        default=DEFAULT_THRESHOLD_LINES,
+        help=f"Max uncommitted lines before warning (default: {DEFAULT_THRESHOLD_LINES})",
+    )
+
+    args = parser.parse_args(argv)
+
+    worktree = args.worktree.resolve()
+    if not worktree.is_dir():
+        print(f"ERROR: worktree path does not exist: {worktree}", file=sys.stderr)
+        return 2
+
+    try:
+        ok, message = check_cadence(
+            worktree=worktree,
+            threshold_files=args.threshold_files,
+            threshold_lines=args.threshold_lines,
+        )
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    print(message)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_cadence.py
+++ b/scripts/check_cadence.py
@@ -1,4 +1,4 @@
-"""scripts/check_cadence.py
+"""scripts/check_cadence.py.
 
 uncommitted 変更の規模を確認し、閾値超過なら警告して exit 1 する。
 
@@ -19,14 +19,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 # デフォルト閾値
 DEFAULT_THRESHOLD_FILES = 5
 DEFAULT_THRESHOLD_LINES = 200
 
 
 def _run_git(args: list[str], cwd: Path) -> str:
-    """git コマンドを実行してstdoutを返す。失敗したら RuntimeError を上げる."""
+    """Git コマンドを実行してstdoutを返す。失敗したら RuntimeError を上げる."""
     result = subprocess.run(
         ["git", *args],
         capture_output=True,
@@ -42,7 +41,7 @@ def _run_git(args: list[str], cwd: Path) -> str:
 
 
 def count_uncommitted_files(worktree: Path) -> int:
-    """worktree 内の uncommitted ファイル数を返す。
+    """Worktree 内の uncommitted ファイル数を返す.
 
     tracked の変更（M, D, A など）と untracked (??) の両方を数える。
     """
@@ -52,7 +51,7 @@ def count_uncommitted_files(worktree: Path) -> int:
 
 
 def count_uncommitted_lines(worktree: Path) -> int:
-    """worktree 内の uncommitted 追加行数を返す。
+    """Worktree 内の uncommitted 追加行数を返す.
 
     git diff --numstat でステージ済み・未ステージ両方を合計する。
     untracked ファイルは別途 wc -l で数える。
@@ -95,9 +94,10 @@ def check_cadence(
     threshold_files: int = DEFAULT_THRESHOLD_FILES,
     threshold_lines: int = DEFAULT_THRESHOLD_LINES,
 ) -> tuple[bool, str]:
-    """commit cadence の状態を確認する。
+    """Commit cadence の状態を確認する.
 
-    Returns:
+    Returns
+    -------
         (ok, message): ok=True なら閾値以内、False なら超過。
     """
     n_files = count_uncommitted_files(worktree)
@@ -105,13 +105,9 @@ def check_cadence(
 
     violations: list[str] = []
     if n_files > threshold_files:
-        violations.append(
-            f"uncommitted files: {n_files} (threshold: {threshold_files})"
-        )
+        violations.append(f"uncommitted files: {n_files} (threshold: {threshold_files})")
     if n_lines > threshold_lines:
-        violations.append(
-            f"uncommitted lines: {n_lines} (threshold: {threshold_lines})"
-        )
+        violations.append(f"uncommitted lines: {n_lines} (threshold: {threshold_lines})")
 
     if violations:
         msg_lines = [

--- a/tests/scripts/test_check_cadence.py
+++ b/tests/scripts/test_check_cadence.py
@@ -1,0 +1,250 @@
+"""tests/scripts/test_check_cadence.py
+
+scripts/check_cadence.py のテスト。
+uncommitted ファイル数・行数の閾値チェックと CLI フラグの動作を確認する。
+
+Issue #46: Agent が stall せず commit cadence を守る仕組みの物理的強制
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _find_repo_root() -> Path:
+    """pyproject.toml を含む最近接の祖先を repo root とみなす."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError(f"pyproject.toml が {here} から辿れない")
+
+
+_REPO_ROOT = _find_repo_root()
+_SCRIPT = _REPO_ROOT / "scripts" / "check_cadence.py"
+
+
+def run_script(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """check_cadence.py を subprocess で実行してCompletedProcessを返す."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+    )
+
+
+class TestCheckCadenceCleanWorktree:
+    """uncommitted 変更なし（クリーンな状態）のテスト."""
+
+    def test_clean_worktree_exits_zero(self, tmp_path: Path) -> None:
+        """git init したクリーンな worktree では exit 0 を返す."""
+        # 空の git リポジトリを作成して初期コミットを作る
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "README.md").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_clean_worktree_prints_ok(self, tmp_path: Path) -> None:
+        """クリーンな状態では 'OK:' を含む出力を返す."""
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "README.md").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        result = run_script("--worktree", str(tmp_path))
+        assert "OK" in result.stdout
+
+
+class TestCheckCadenceFilesThreshold:
+    """ファイル数の閾値チェックのテスト."""
+
+    def _make_git_repo_with_uncommitted_files(
+        self, tmp_path: Path, n_files: int, lines_per_file: int = 1
+    ) -> None:
+        """n_files 個の未コミットファイルを持つ git リポジトリを作る."""
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "README.md").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        # uncommitted files を作成（add しない）
+        for i in range(n_files):
+            content = "\n".join([f"line_{j}" for j in range(lines_per_file)])
+            (tmp_path / f"new_file_{i}.py").write_text(content)
+
+    def test_below_files_threshold_exits_zero(self, tmp_path: Path) -> None:
+        """デフォルト閾値(5ファイル)未満では exit 0."""
+        self._make_git_repo_with_uncommitted_files(tmp_path, n_files=4)
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_at_files_threshold_exits_zero(self, tmp_path: Path) -> None:
+        """デフォルト閾値(5ファイル)ちょうどは exit 0（超過でない）."""
+        self._make_git_repo_with_uncommitted_files(tmp_path, n_files=5)
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_above_files_threshold_exits_one(self, tmp_path: Path) -> None:
+        """デフォルト閾値(5ファイル)超過では exit 1."""
+        self._make_git_repo_with_uncommitted_files(tmp_path, n_files=6)
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_above_files_threshold_prints_warning(self, tmp_path: Path) -> None:
+        """ファイル数超過では警告メッセージを出力する."""
+        self._make_git_repo_with_uncommitted_files(tmp_path, n_files=6)
+        result = run_script("--worktree", str(tmp_path))
+        assert "WARNING" in result.stdout or "WARN" in result.stdout.upper()
+
+    def test_custom_files_threshold(self, tmp_path: Path) -> None:
+        """--threshold-files で閾値変更できる."""
+        self._make_git_repo_with_uncommitted_files(tmp_path, n_files=3)
+        # デフォルト(5)では OK だが、閾値を 2 にすると NG になる
+        result = run_script("--worktree", str(tmp_path), "--threshold-files", "2")
+        assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+class TestCheckCadenceLinesThreshold:
+    """追加行数の閾値チェックのテスト."""
+
+    def _make_git_repo_with_large_file(self, tmp_path: Path, n_lines: int) -> None:
+        """n_lines 行の未コミットファイルを持つ git リポジトリを作る."""
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "README.md").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        content = "\n".join([f"line_{i}" for i in range(n_lines)])
+        (tmp_path / "large_file.py").write_text(content)
+
+    def test_below_lines_threshold_exits_zero(self, tmp_path: Path) -> None:
+        """デフォルト閾値(200行)未満では exit 0."""
+        self._make_git_repo_with_large_file(tmp_path, n_lines=100)
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_above_lines_threshold_exits_one(self, tmp_path: Path) -> None:
+        """デフォルト閾値(200行)超過では exit 1."""
+        self._make_git_repo_with_large_file(tmp_path, n_lines=201)
+        result = run_script("--worktree", str(tmp_path))
+        assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_custom_lines_threshold(self, tmp_path: Path) -> None:
+        """--threshold-lines で閾値変更できる."""
+        self._make_git_repo_with_large_file(tmp_path, n_lines=50)
+        result = run_script("--worktree", str(tmp_path), "--threshold-lines", "30")
+        assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+
+class TestCheckCadenceOutput:
+    """出力フォーマットのテスト."""
+
+    def _make_clean_repo(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "README.md").write_text("initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_ok_output_contains_files_count(self, tmp_path: Path) -> None:
+        """OK 時の出力に files 数が含まれる."""
+        self._make_clean_repo(tmp_path)
+        result = run_script("--worktree", str(tmp_path))
+        assert "files" in result.stdout.lower() or "file" in result.stdout.lower()
+
+    def test_ok_output_contains_lines_count(self, tmp_path: Path) -> None:
+        """OK 時の出力に lines 数が含まれる."""
+        self._make_clean_repo(tmp_path)
+        result = run_script("--worktree", str(tmp_path))
+        assert "line" in result.stdout.lower()

--- a/tests/scripts/test_check_cadence.py
+++ b/tests/scripts/test_check_cadence.py
@@ -10,10 +10,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
-
-import pytest
 
 
 def _find_repo_root() -> Path:


### PR DESCRIPTION
## Summary

- `scripts/check_cadence.py` を新規実装。uncommitted のファイル数（閾値 5）・行数（閾値 200）を `git status --short` と `git diff --numstat` で計測し、超過時に exit 1 + WARNING を出力
- `tests/scripts/test_check_cadence.py` 12 ケース（422 passed）
- `Makefile` に `cadence:` ターゲット追加（`make cadence ARGS="--threshold-files 3"` で閾値変更可）
- `docs/rules/tdd.md` §11 に commit cadence 方針を文書化

## 未実装（権限ブロック）

`.claude/skills/multi_agent_orchestration.md` の commit cadence 節強化は、Claude Code がエージェントセッション中に `.claude/` ディレクトリへの書き込みを拒否するため実施できませんでした。PM がメインセッションで手動適用をお願いします。

強化内容の要旨:
- 「3 コミット毎」→「1 commit ごとに進捗コメント」へ変更
- commit cadence 強制サブ節を新設（make cadence 使い方を記載）
- プロンプト雛形末尾に commit cadence 強制節を追加

## Test plan

- [x] `uv run ruff check .` — all passed
- [x] `uv run ruff format --check .` — 99 files formatted
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -n auto` — 422 passed, 8 skipped

## commit cadence 実演（dog-fooding）

5 commits: test → feat → feat(Makefile) → docs → refactor(lint)
各 commit 後に Issue #46 へ進捗コメント投稿済み

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)