### PR TITLE
[phase-2] make merge-pr PR=N で PR ready→merge→worktree 削除→develop 同期を 1 コマンド化 (#48)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,8 @@ all: lint format type test
 .PHONY: cadence
 cadence:
 	uv run python scripts/check_cadence.py $(ARGS)
+
+.PHONY: merge-pr
+merge-pr:
+	@if [ -z "$(PR)" ]; then echo "Usage: make merge-pr PR=<number> [DRY_RUN=1]"; exit 1; fi
+	uv run python scripts/merge_pr.py --pr $(PR) $(if $(DRY_RUN),--dry-run,)

--- a/docs/rules/git-worktree.md
+++ b/docs/rules/git-worktree.md
@@ -83,6 +83,29 @@ git worktree prune
 
 ## 3.5. PR merge 時の定型フロー
 
+**通常は `make merge-pr PR=<番号>` 1 コマンドで完結します**（詳細: `scripts/merge_pr.py`）。
+
+```bash
+# リポジトリ直下または worktree 内から実行
+make merge-pr PR=44
+
+# 内容を確認だけしたい場合（コマンドを実際には実行しない）
+make merge-pr PR=44 DRY_RUN=1
+```
+
+`make merge-pr` は以下を自動で実行します:
+
+1. PR の状態確認（state, mergeable, statusCheckRollup）— CI 未通過なら中断
+2. `gh pr ready <PR>` — Draft → Ready に切り替え（Ready 済みなら no-op）
+3. `gh pr merge <PR> --squash --delete-branch` — squash merge
+4. headRefName を取得し worktree path を導出
+5. `git worktree remove gitworktree/feature-N-keyword` — 不在なら warning で続行
+6. `git branch -D feature/N-keyword` — 不在なら warning で続行
+7. `git checkout develop && git pull --ff-only` — develop を最新化
+
+<details>
+<summary>手動で実行する場合（historical reference）</summary>
+
 PR がマージされたら、以下を **この順番で** 実行します（`.claude/skills/4_create_pr.md` §7-8 と整合）。
 
 ```bash
@@ -105,6 +128,8 @@ git checkout develop
 git pull --ff-only
 ```
 
+</details>
+
 ### よくある失敗
 
 | 失敗 | 回避策 |
@@ -113,6 +138,7 @@ git pull --ff-only
 | `cd gitworktree/...` したまま `git worktree remove` して cwd が消失 | 削除前に `cd <repo_root>` で抜ける。`pwd` で確認する習慣 |
 | Draft PR を `gh pr merge` で実行するとエラー | 先に `gh pr ready` を叩く（Draft は自動で Ready にならない） |
 | 片付け忘れた worktree が溜まる | `git worktree list` で定期的に確認。PR merged の worktree は即削除 |
+| `make merge-pr` が CI fail で中断する | CI ログを確認して修正後、再度 push して CI を通す |
 
 ### 並列 PR merge の順序
 

--- a/scripts/merge_pr.py
+++ b/scripts/merge_pr.py
@@ -1,9 +1,10 @@
-"""merge_pr.py — make merge-pr の実体スクリプト。
+"""merge_pr.py — make merge-pr の実体スクリプト.
 
 PM が `make merge-pr PR=N [DRY_RUN=1]` で呼ぶ。
 7 ステップで PR の ready → merge → worktree 削除 → develop 同期を完結させる。
 
-使い方:
+使い方::
+
     uv run python scripts/merge_pr.py --pr 48
     uv run python scripts/merge_pr.py --pr 48 --dry-run
 """
@@ -17,7 +18,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 # ---------------------------------------------------------------------------
 # 内部ヘルパー（patch ポイント）
 # ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ def _run_cmd(
     cwd: str | None = None,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """subprocess.run のラッパー。テストで patch するためのポイント。"""
+    """Subprocess.run のラッパー。テストで patch するためのポイント."""
     return subprocess.run(
         args,
         capture_output=True,
@@ -44,18 +44,23 @@ def _run_cmd(
 
 
 def branch_to_worktree_path(branch_name: str, repo_root: str) -> str | None:
-    """ブランチ名から worktree path を導出する。
+    """ブランチ名から worktree path を導出する.
 
     変換ルール:
       feature/48-merge-pr-helper → <repo_root>/gitworktree/feature-48-merge-pr-helper
 
     feature/ で始まらないブランチは None を返す。
 
-    Args:
-        branch_name: GitHub PR の headRefName（例: feature/48-merge-pr-helper）
-        repo_root: リポジトリルートの絶対パス
+    Parameters
+    ----------
+    branch_name:
+        GitHub PR の headRefName（例: feature/48-merge-pr-helper）
+    repo_root:
+        リポジトリルートの絶対パス
 
-    Returns:
+    Returns
+    -------
+    str | None
         worktree の絶対パス文字列。feature/ ブランチでなければ None。
     """
     if not branch_name.startswith("feature/"):
@@ -73,21 +78,26 @@ def branch_to_worktree_path(branch_name: str, repo_root: str) -> str | None:
 def check_pr_status(
     pr_data: dict[str, Any],
 ) -> tuple[str, str, str]:
-    """PR の JSON データから状態を解析する。
+    """PR の JSON データから状態を解析する.
 
     PR データは gh pr view --json state,mergeable,headRefName,statusCheckRollup
     の出力を想定する。
 
-    Args:
-        pr_data: gh pr view の JSON パース結果
+    Parameters
+    ----------
+    pr_data:
+        gh pr view の JSON パース結果
 
-    Returns:
+    Returns
+    -------
+    tuple[str, str, str]
         (status, state, head_ref) のタプル。
         status は以下のいずれか:
-          - "ok": merge 可能
-          - "already_merged": 既に merge 済み（no-op でよい）
-          - "ci_failed": CI が失敗している
-          - "error": CLOSED など処理不能な状態
+
+        - "ok": merge 可能
+        - "already_merged": 既に merge 済み（no-op でよい）
+        - "ci_failed": CI が失敗している
+        - "error": CLOSED など処理不能な状態
     """
     state: str = pr_data.get("state", "")
     head_ref: str = pr_data.get("headRefName", "")
@@ -118,24 +128,31 @@ def merge_pr(
     dry_run: bool = False,
     repo_root: str | None = None,
 ) -> int:
-    """PR を merge して worktree を片付ける。
+    """PR を merge して worktree を片付ける.
 
     7 ステップで実行:
-      1. PR 状態確認
-      2. gh pr ready（Draft → Ready）
-      3. gh pr merge --squash --delete-branch
-      4. headRefName 取得（ステップ 1 で取得済み）
-      5. branch → worktree path 変換
-      6. git worktree remove
-      7. git branch -D
-      8. git checkout develop && git pull --ff-only
 
-    Args:
-        pr_number: マージ対象の PR 番号
-        dry_run: True のとき実際のコマンドを実行しない（ステップを表示するのみ）
-        repo_root: リポジトリルートのパス。None の場合は git rev-parse で取得
+    1. PR 状態確認
+    2. gh pr ready（Draft → Ready）
+    3. gh pr merge --squash --delete-branch
+    4. headRefName 取得（ステップ 1 で取得済み）
+    5. branch → worktree path 変換
+    6. git worktree remove
+    7. git branch -D
+    8. git checkout develop && git pull --ff-only
 
-    Returns:
+    Parameters
+    ----------
+    pr_number:
+        マージ対象の PR 番号
+    dry_run:
+        True のとき実際のコマンドを実行しない（ステップを表示するのみ）
+    repo_root:
+        リポジトリルートのパス。None の場合は git rev-parse で取得
+
+    Returns
+    -------
+    int
         終了コード。0 = 成功、1 = エラー
     """
     # repo_root を解決
@@ -150,11 +167,21 @@ def merge_pr(
     # -----------------------------------------------------------------------
     print(f"[merge-pr] Step 1: PR #{pr_number} の状態を確認中...")
     view_result = _run_cmd(
-        ["gh", "pr", "view", pr_str, "--json", "state,mergeable,headRefName,statusCheckRollup"],
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_str,
+            "--json",
+            "state,mergeable,headRefName,statusCheckRollup",
+        ],
         cwd=repo_root,
     )
     if view_result.returncode != 0:
-        print(f"[merge-pr] ERROR: gh pr view に失敗しました: {view_result.stderr}", file=sys.stderr)
+        print(
+            f"[merge-pr] ERROR: gh pr view に失敗しました: {view_result.stderr}",
+            file=sys.stderr,
+        )
         return 1
 
     try:
@@ -166,23 +193,27 @@ def merge_pr(
     status, state, head_ref = check_pr_status(pr_data)
 
     if status == "already_merged":
-        print(f"[merge-pr] WARNING: PR #{pr_number} は既に merged です。worktree 片付けのみ実施します。")
+        print(
+            f"[merge-pr] WARNING: PR #{pr_number} は既に merged です。"
+            "worktree 片付けのみ実施します。"
+        )
         # worktree 片付けだけ行う（merge はスキップ）
-        _cleanup_worktree(pr_number, head_ref, repo_root, dry_run)
+        _cleanup_worktree(head_ref, repo_root, dry_run)
         _sync_develop(repo_root, dry_run)
         return 0
 
     if status == "ci_failed":
         print(
-            f"[merge-pr] ERROR: PR #{pr_number} の CI が SUCCESS ではありません（state={state}）。"
-            "強制 merge を防ぐため中断します。",
+            f"[merge-pr] ERROR: PR #{pr_number} の CI が SUCCESS ではありません"
+            f"（state={state}）。強制 merge を防ぐため中断します。",
             file=sys.stderr,
         )
         return 1
 
     if status == "error":
         print(
-            f"[merge-pr] ERROR: PR #{pr_number} の state={state} は処理できません（OPEN or MERGED のみ）。",
+            f"[merge-pr] ERROR: PR #{pr_number} の state={state} は処理できません"
+            "（OPEN or MERGED のみ）。",
             file=sys.stderr,
         )
         return 1
@@ -221,7 +252,7 @@ def merge_pr(
     # -----------------------------------------------------------------------
     # ステップ 4-7: worktree 片付け
     # -----------------------------------------------------------------------
-    _cleanup_worktree(pr_number, head_ref, repo_root, dry_run)
+    _cleanup_worktree(head_ref, repo_root, dry_run)
 
     # -----------------------------------------------------------------------
     # ステップ 8: develop を最新化
@@ -233,17 +264,14 @@ def merge_pr(
 
 
 def _cleanup_worktree(
-    pr_number: int,
     head_ref: str,
     repo_root: str,
     dry_run: bool,
 ) -> None:
-    """worktree と local branch を削除する（ステップ 5-7）。
+    """Worktree と local branch を削除する（ステップ 5-7）.
 
     worktree や branch が存在しない場合は WARNING を出して続行する。
     """
-    pr_str = str(pr_number)
-
     # ステップ 5: branch → worktree path 変換
     worktree_path = branch_to_worktree_path(head_ref, repo_root)
 
@@ -259,11 +287,14 @@ def _cleanup_worktree(
             )
             if rm_result.returncode != 0:
                 print(
-                    f"[merge-pr] WARNING: worktree remove に失敗しました（不在の可能性）: "
+                    "[merge-pr] WARNING: worktree remove に失敗しました（不在の可能性）: "
                     f"{rm_result.stderr}",
                 )
     else:
-        print(f"[merge-pr] Step 6: worktree path を導出できませんでした（branch={head_ref}）。スキップ。")
+        print(
+            f"[merge-pr] Step 6: worktree path を導出できませんでした"
+            f"（branch={head_ref}）。スキップ。"
+        )
 
     # ステップ 7: git branch -D
     print(f"[merge-pr] Step 7: git branch -D {head_ref}...")
@@ -276,13 +307,13 @@ def _cleanup_worktree(
         )
         if branch_result.returncode != 0:
             print(
-                f"[merge-pr] WARNING: branch -D に失敗しました（不在の可能性）: "
+                "[merge-pr] WARNING: branch -D に失敗しました（不在の可能性）: "
                 f"{branch_result.stderr}",
             )
 
 
 def _sync_develop(repo_root: str, dry_run: bool) -> None:
-    """develop ブランチを最新化する（ステップ 8）。"""
+    """Develop ブランチを最新化する（ステップ 8）."""
     print("[merge-pr] Step 8: develop を最新化中...")
     if dry_run:
         print("  [DRY-RUN] git checkout develop")
@@ -298,10 +329,8 @@ def _sync_develop(repo_root: str, dry_run: bool) -> None:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """コマンドライン引数をパースする。"""
-    parser = argparse.ArgumentParser(
-        description="PR を merge して worktree を片付ける。"
-    )
+    """コマンドライン引数をパースする."""
+    parser = argparse.ArgumentParser(description="PR を merge して worktree を片付ける。")
     parser.add_argument(
         "--pr",
         type=int,
@@ -318,7 +347,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> None:
-    """CLI エントリーポイント。"""
+    """CLI エントリーポイント."""
     args = _parse_args(argv)
     exit_code = merge_pr(pr_number=args.pr, dry_run=args.dry_run)
     sys.exit(exit_code)

--- a/scripts/merge_pr.py
+++ b/scripts/merge_pr.py
@@ -1,0 +1,328 @@
+"""merge_pr.py — make merge-pr の実体スクリプト。
+
+PM が `make merge-pr PR=N [DRY_RUN=1]` で呼ぶ。
+7 ステップで PR の ready → merge → worktree 削除 → develop 同期を完結させる。
+
+使い方:
+    uv run python scripts/merge_pr.py --pr 48
+    uv run python scripts/merge_pr.py --pr 48 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# 内部ヘルパー（patch ポイント）
+# ---------------------------------------------------------------------------
+
+
+def _run_cmd(
+    args: list[str],
+    cwd: str | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """subprocess.run のラッパー。テストで patch するためのポイント。"""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        check=check,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 純粋関数: branch → worktree path 変換
+# ---------------------------------------------------------------------------
+
+
+def branch_to_worktree_path(branch_name: str, repo_root: str) -> str | None:
+    """ブランチ名から worktree path を導出する。
+
+    変換ルール:
+      feature/48-merge-pr-helper → <repo_root>/gitworktree/feature-48-merge-pr-helper
+
+    feature/ で始まらないブランチは None を返す。
+
+    Args:
+        branch_name: GitHub PR の headRefName（例: feature/48-merge-pr-helper）
+        repo_root: リポジトリルートの絶対パス
+
+    Returns:
+        worktree の絶対パス文字列。feature/ ブランチでなければ None。
+    """
+    if not branch_name.startswith("feature/"):
+        return None
+    # feature/48-merge-pr-helper → feature-48-merge-pr-helper
+    worktree_dir_name = branch_name.replace("/", "-", 1)
+    return str(Path(repo_root) / "gitworktree" / worktree_dir_name)
+
+
+# ---------------------------------------------------------------------------
+# 純粋関数: PR 状態の解析
+# ---------------------------------------------------------------------------
+
+
+def check_pr_status(
+    pr_data: dict[str, Any],
+) -> tuple[str, str, str]:
+    """PR の JSON データから状態を解析する。
+
+    PR データは gh pr view --json state,mergeable,headRefName,statusCheckRollup
+    の出力を想定する。
+
+    Args:
+        pr_data: gh pr view の JSON パース結果
+
+    Returns:
+        (status, state, head_ref) のタプル。
+        status は以下のいずれか:
+          - "ok": merge 可能
+          - "already_merged": 既に merge 済み（no-op でよい）
+          - "ci_failed": CI が失敗している
+          - "error": CLOSED など処理不能な状態
+    """
+    state: str = pr_data.get("state", "")
+    head_ref: str = pr_data.get("headRefName", "")
+    status_checks: list[dict[str, Any]] = pr_data.get("statusCheckRollup", [])
+
+    if state == "MERGED":
+        return "already_merged", state, head_ref
+
+    if state != "OPEN":
+        return "error", state, head_ref
+
+    # CI チェックが存在する場合、最後の状態が SUCCESS でなければ失敗
+    if status_checks:
+        last_status = status_checks[-1].get("state", "")
+        if last_status != "SUCCESS":
+            return "ci_failed", state, head_ref
+
+    return "ok", state, head_ref
+
+
+# ---------------------------------------------------------------------------
+# メイン処理
+# ---------------------------------------------------------------------------
+
+
+def merge_pr(
+    pr_number: int,
+    dry_run: bool = False,
+    repo_root: str | None = None,
+) -> int:
+    """PR を merge して worktree を片付ける。
+
+    7 ステップで実行:
+      1. PR 状態確認
+      2. gh pr ready（Draft → Ready）
+      3. gh pr merge --squash --delete-branch
+      4. headRefName 取得（ステップ 1 で取得済み）
+      5. branch → worktree path 変換
+      6. git worktree remove
+      7. git branch -D
+      8. git checkout develop && git pull --ff-only
+
+    Args:
+        pr_number: マージ対象の PR 番号
+        dry_run: True のとき実際のコマンドを実行しない（ステップを表示するのみ）
+        repo_root: リポジトリルートのパス。None の場合は git rev-parse で取得
+
+    Returns:
+        終了コード。0 = 成功、1 = エラー
+    """
+    # repo_root を解決
+    if repo_root is None:
+        result = _run_cmd(["git", "rev-parse", "--show-toplevel"])
+        repo_root = result.stdout.strip()
+
+    pr_str = str(pr_number)
+
+    # -----------------------------------------------------------------------
+    # ステップ 1: PR 状態確認
+    # -----------------------------------------------------------------------
+    print(f"[merge-pr] Step 1: PR #{pr_number} の状態を確認中...")
+    view_result = _run_cmd(
+        ["gh", "pr", "view", pr_str, "--json", "state,mergeable,headRefName,statusCheckRollup"],
+        cwd=repo_root,
+    )
+    if view_result.returncode != 0:
+        print(f"[merge-pr] ERROR: gh pr view に失敗しました: {view_result.stderr}", file=sys.stderr)
+        return 1
+
+    try:
+        pr_data: dict[str, Any] = json.loads(view_result.stdout)
+    except json.JSONDecodeError as e:
+        print(f"[merge-pr] ERROR: gh pr view の JSON パースに失敗: {e}", file=sys.stderr)
+        return 1
+
+    status, state, head_ref = check_pr_status(pr_data)
+
+    if status == "already_merged":
+        print(f"[merge-pr] WARNING: PR #{pr_number} は既に merged です。worktree 片付けのみ実施します。")
+        # worktree 片付けだけ行う（merge はスキップ）
+        _cleanup_worktree(pr_number, head_ref, repo_root, dry_run)
+        _sync_develop(repo_root, dry_run)
+        return 0
+
+    if status == "ci_failed":
+        print(
+            f"[merge-pr] ERROR: PR #{pr_number} の CI が SUCCESS ではありません（state={state}）。"
+            "強制 merge を防ぐため中断します。",
+            file=sys.stderr,
+        )
+        return 1
+
+    if status == "error":
+        print(
+            f"[merge-pr] ERROR: PR #{pr_number} の state={state} は処理できません（OPEN or MERGED のみ）。",
+            file=sys.stderr,
+        )
+        return 1
+
+    # status == "ok"
+    print(f"[merge-pr] PR #{pr_number} は state={state}, CI=OK。merge を実行します。")
+
+    # -----------------------------------------------------------------------
+    # ステップ 2: gh pr ready（Draft → Ready）
+    # -----------------------------------------------------------------------
+    print(f"[merge-pr] Step 2: gh pr ready #{pr_number}...")
+    if dry_run:
+        print(f"  [DRY-RUN] gh pr ready {pr_str}")
+    else:
+        # Draft でない場合は no-op でエラーになることがあるが無視
+        _run_cmd(["gh", "pr", "ready", pr_str], cwd=repo_root)
+
+    # -----------------------------------------------------------------------
+    # ステップ 3: gh pr merge --squash --delete-branch
+    # -----------------------------------------------------------------------
+    print(f"[merge-pr] Step 3: gh pr merge #{pr_number} --squash --delete-branch...")
+    if dry_run:
+        print(f"  [DRY-RUN] gh pr merge {pr_str} --squash --delete-branch")
+    else:
+        merge_result = _run_cmd(
+            ["gh", "pr", "merge", pr_str, "--squash", "--delete-branch"],
+            cwd=repo_root,
+        )
+        if merge_result.returncode != 0:
+            print(
+                f"[merge-pr] ERROR: gh pr merge に失敗しました: {merge_result.stderr}",
+                file=sys.stderr,
+            )
+            return 1
+
+    # -----------------------------------------------------------------------
+    # ステップ 4-7: worktree 片付け
+    # -----------------------------------------------------------------------
+    _cleanup_worktree(pr_number, head_ref, repo_root, dry_run)
+
+    # -----------------------------------------------------------------------
+    # ステップ 8: develop を最新化
+    # -----------------------------------------------------------------------
+    _sync_develop(repo_root, dry_run)
+
+    print(f"[merge-pr] 完了: PR #{pr_number} を merge し、worktree を片付けました。")
+    return 0
+
+
+def _cleanup_worktree(
+    pr_number: int,
+    head_ref: str,
+    repo_root: str,
+    dry_run: bool,
+) -> None:
+    """worktree と local branch を削除する（ステップ 5-7）。
+
+    worktree や branch が存在しない場合は WARNING を出して続行する。
+    """
+    pr_str = str(pr_number)
+
+    # ステップ 5: branch → worktree path 変換
+    worktree_path = branch_to_worktree_path(head_ref, repo_root)
+
+    # ステップ 6: git worktree remove
+    if worktree_path:
+        print(f"[merge-pr] Step 6: git worktree remove {worktree_path}...")
+        if dry_run:
+            print(f"  [DRY-RUN] git worktree remove {worktree_path}")
+        else:
+            rm_result = _run_cmd(
+                ["git", "worktree", "remove", worktree_path],
+                cwd=repo_root,
+            )
+            if rm_result.returncode != 0:
+                print(
+                    f"[merge-pr] WARNING: worktree remove に失敗しました（不在の可能性）: "
+                    f"{rm_result.stderr}",
+                )
+    else:
+        print(f"[merge-pr] Step 6: worktree path を導出できませんでした（branch={head_ref}）。スキップ。")
+
+    # ステップ 7: git branch -D
+    print(f"[merge-pr] Step 7: git branch -D {head_ref}...")
+    if dry_run:
+        print(f"  [DRY-RUN] git branch -D {head_ref}")
+    else:
+        branch_result = _run_cmd(
+            ["git", "branch", "-D", head_ref],
+            cwd=repo_root,
+        )
+        if branch_result.returncode != 0:
+            print(
+                f"[merge-pr] WARNING: branch -D に失敗しました（不在の可能性）: "
+                f"{branch_result.stderr}",
+            )
+
+
+def _sync_develop(repo_root: str, dry_run: bool) -> None:
+    """develop ブランチを最新化する（ステップ 8）。"""
+    print("[merge-pr] Step 8: develop を最新化中...")
+    if dry_run:
+        print("  [DRY-RUN] git checkout develop")
+        print("  [DRY-RUN] git pull --ff-only")
+    else:
+        _run_cmd(["git", "checkout", "develop"], cwd=repo_root)
+        _run_cmd(["git", "pull", "--ff-only"], cwd=repo_root)
+
+
+# ---------------------------------------------------------------------------
+# CLI エントリーポイント
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """コマンドライン引数をパースする。"""
+    parser = argparse.ArgumentParser(
+        description="PR を merge して worktree を片付ける。"
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        required=True,
+        help="merge 対象の PR 番号",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="コマンドを実行せず手順を表示するだけ",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI エントリーポイント。"""
+    args = _parse_args(argv)
+    exit_code = merge_pr(pr_number=args.pr, dry_run=args.dry_run)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_merge_pr.py
+++ b/tests/scripts/test_merge_pr.py
@@ -1,0 +1,645 @@
+"""Tests for scripts/merge_pr.py — merge-pr helper script.
+
+このテストファイルは TDD の原則に従い、実装前に書かれている。
+各テストケースは scripts/merge_pr.py の振る舞いを規定する。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+def _get_scripts_path() -> Path:
+    """Locate the scripts directory relative to pyproject.toml."""
+    here = Path(__file__)
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent / "scripts"
+    raise FileNotFoundError("pyproject.toml not found in any ancestor directory")
+
+
+def _import_merge_pr() -> types.ModuleType:
+    """Dynamically import merge_pr from scripts/ directory."""
+    scripts_path = _get_scripts_path()
+    merge_pr_path = scripts_path / "merge_pr.py"
+    module_spec = importlib.util.spec_from_file_location("merge_pr", merge_pr_path)
+    assert module_spec is not None
+    assert module_spec.loader is not None
+    module = importlib.util.module_from_spec(module_spec)
+    sys.modules["merge_pr"] = module
+    module_spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1: 正常系 — PR open + CI green → 7 ステップ順次実行
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrNormalFlow:
+    """PR open + CI green のとき、7 ステップが順序通り実行される。"""
+
+    def _make_pr_view_response(
+        self,
+        state: str = "OPEN",
+        mergeable: str = "MERGEABLE",
+        ci_status: str = "SUCCESS",
+        head_ref: str = "feature/48-merge-pr-helper",
+    ) -> str:
+        """gh pr view の JSON レスポンスを生成するヘルパー。"""
+        return json.dumps(
+            {
+                "state": state,
+                "mergeable": mergeable,
+                "headRefName": head_ref,
+                "statusCheckRollup": [
+                    {"state": ci_status, "context": "ci/test"},
+                ],
+            }
+        )
+
+    def test_normal_flow_calls_all_steps_in_order(self) -> None:
+        """正常系: 7 ステップが正しい順序で実行される。"""
+        m = _import_merge_pr()
+
+        pr_view_response = self._make_pr_view_response()
+        run_mock = MagicMock()
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            # gh pr view の呼び出しには JSON を返す
+            if "pr" in args and "view" in args:
+                result.stdout = pr_view_response
+            return result
+
+        run_mock.side_effect = side_effect
+
+        with patch.object(m, "_run_cmd", run_mock):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 0
+
+        # 呼び出し引数リストを確認
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+
+        # ステップ 1: PR 状態確認
+        assert any("pr" in args and "view" in args for args in call_args_list)
+        # ステップ 2: gh pr ready
+        assert any("pr" in args and "ready" in args for args in call_args_list)
+        # ステップ 3: gh pr merge
+        assert any(
+            "pr" in args and "merge" in args and "--squash" in args
+            for args in call_args_list
+        )
+        # ステップ 6: git worktree remove
+        assert any("worktree" in args and "remove" in args for args in call_args_list)
+        # ステップ 7: git branch -D
+        assert any("branch" in args and "-D" in args for args in call_args_list)
+        # ステップ 8: git checkout develop
+        assert any("checkout" in args and "develop" in args for args in call_args_list)
+        # ステップ 8: git pull --ff-only
+        assert any("pull" in args and "--ff-only" in args for args in call_args_list)
+
+    def test_normal_flow_exit_code_zero(self) -> None:
+        """正常系: exit code が 0 であること。"""
+        m = _import_merge_pr()
+
+        pr_view_response = self._make_pr_view_response()
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 0
+
+    def test_normal_flow_worktree_path_derived_from_branch(self) -> None:
+        """branch 名から worktree path が正しく導出される。
+
+        feature/48-merge-pr-helper → gitworktree/feature-48-merge-pr-helper
+        """
+        m = _import_merge_pr()
+
+        pr_view_response = self._make_pr_view_response(
+            head_ref="feature/48-merge-pr-helper"
+        )
+
+        captured_worktree_remove_args: list[list[str]] = []
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            if "worktree" in args and "remove" in args:
+                captured_worktree_remove_args.append(args)
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert len(captured_worktree_remove_args) == 1
+        remove_args = captured_worktree_remove_args[0]
+        # worktree path が feature/N-keyword → gitworktree/feature-N-keyword に変換されている
+        assert any("gitworktree/feature-48-merge-pr-helper" in arg for arg in remove_args)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2: CI fail 系 — statusCheckRollup が FAILURE → exit 1
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrCIFail:
+    """CI が失敗している場合、早期 exit 1 で merge しない。"""
+
+    def test_ci_failure_returns_exit_1(self) -> None:
+        """CI が FAILURE なら exit 1 を返す。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [
+                    {"state": "FAILURE", "context": "ci/test"},
+                ],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 1
+
+    def test_ci_failure_does_not_call_merge(self) -> None:
+        """CI が FAILURE なら gh pr merge は呼ばれない。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [
+                    {"state": "FAILURE", "context": "ci/test"},
+                ],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        # gh pr merge は呼ばれていないこと
+        assert not any(
+            "pr" in args and "merge" in args for args in call_args_list
+        )
+
+    def test_pending_ci_returns_exit_1(self) -> None:
+        """CI が PENDING なら exit 1 を返す（SUCCESS 以外はすべて拒否）。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [
+                    {"state": "PENDING", "context": "ci/test"},
+                ],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 1
+
+    def test_empty_status_check_rollup_allows_merge(self) -> None:
+        """statusCheckRollup が空の場合（CI なし）は merge を許可する。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3: 既 merged 系 — state == MERGED → no-op + warning
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrAlreadyMerged:
+    """PR が既に merged の場合、merge を試みずに警告を出して exit 0。"""
+
+    def test_already_merged_returns_exit_0(self) -> None:
+        """既 merged PR は no-op で exit 0 を返す。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "MERGED",
+                "mergeable": "UNKNOWN",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 0
+
+    def test_already_merged_does_not_call_gh_pr_merge(self) -> None:
+        """既 merged PR は gh pr merge を呼ばない。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "MERGED",
+                "mergeable": "UNKNOWN",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        assert not any(
+            "pr" in args and "merge" in args for args in call_args_list
+        )
+
+    def test_closed_pr_returns_exit_1(self) -> None:
+        """CLOSED（close された PR）は exit 1 を返す。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "CLOSED",
+                "mergeable": "UNKNOWN",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4: worktree 不在系 — worktree remove 失敗 → warning で続行
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrWorktreeAbsent:
+    """worktree が存在しない場合、警告を出して branch -D まで続行する。"""
+
+    def test_worktree_remove_failure_continues_to_branch_delete(self) -> None:
+        """worktree remove が失敗しても、branch -D が呼ばれる。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            # worktree remove は失敗させる
+            if "worktree" in args and "remove" in args:
+                result.returncode = 1
+                result.stderr = "error: worktree not found"
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        # exit code は 0（worktree 不在は warning のみ）
+        assert exit_code == 0
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        # branch -D は呼ばれる
+        assert any("branch" in args and "-D" in args for args in call_args_list)
+        # git pull --ff-only も呼ばれる
+        assert any("pull" in args and "--ff-only" in args for args in call_args_list)
+
+    def test_branch_delete_failure_continues_to_pull(self) -> None:
+        """branch -D が失敗しても、git pull --ff-only が呼ばれる。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            # branch -D は失敗させる
+            if "branch" in args and "-D" in args:
+                result.returncode = 1
+                result.stderr = "error: branch not found"
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            exit_code = m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
+
+        assert exit_code == 0
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        assert any("pull" in args and "--ff-only" in args for args in call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5: dry-run 系 — コマンドを実行せず echo のみ
+# ---------------------------------------------------------------------------
+
+
+class TestMergePrDryRun:
+    """--dry-run フラグ時はコマンドを実行せず、手順を表示して exit 0。"""
+
+    def test_dry_run_does_not_call_gh_pr_merge(self) -> None:
+        """dry-run 時は gh pr merge が呼ばれない。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            exit_code = m.merge_pr(pr_number=48, dry_run=True, repo_root="/repo")
+
+        assert exit_code == 0
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        # dry-run 時は gh pr merge を呼ばない
+        assert not any(
+            "pr" in args and "merge" in args for args in call_args_list
+        )
+
+    def test_dry_run_does_not_call_git_worktree_remove(self) -> None:
+        """dry-run 時は git worktree remove が呼ばれない。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        run_mock = MagicMock(side_effect=side_effect)
+        with patch.object(m, "_run_cmd", run_mock):
+            m.merge_pr(pr_number=48, dry_run=True, repo_root="/repo")
+
+        call_args_list = [c[0][0] for c in run_mock.call_args_list]
+        assert not any(
+            "worktree" in args and "remove" in args for args in call_args_list
+        )
+
+    def test_dry_run_returns_exit_0(self) -> None:
+        """dry-run は必ず exit 0。"""
+        m = _import_merge_pr()
+
+        pr_view_response = json.dumps(
+            {
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "headRefName": "feature/48-merge-pr-helper",
+                "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+            }
+        )
+
+        def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = pr_view_response if ("pr" in args and "view" in args) else ""
+            return result
+
+        with patch.object(m, "_run_cmd", MagicMock(side_effect=side_effect)):
+            exit_code = m.merge_pr(pr_number=48, dry_run=True, repo_root="/repo")
+
+        assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6: branch_to_worktree_path 変換関数
+# ---------------------------------------------------------------------------
+
+
+class TestBranchToWorktreePath:
+    """branch 名 → worktree path の変換ロジックを単体で検証。"""
+
+    def test_feature_branch_to_worktree_path(self) -> None:
+        """feature/48-merge-pr-helper → gitworktree/feature-48-merge-pr-helper"""
+        m = _import_merge_pr()
+        result = m.branch_to_worktree_path("feature/48-merge-pr-helper", repo_root="/repo")
+        assert result == "/repo/gitworktree/feature-48-merge-pr-helper"
+
+    def test_feature_branch_with_numbers(self) -> None:
+        """feature/42-add-sa-core → gitworktree/feature-42-add-sa-core"""
+        m = _import_merge_pr()
+        result = m.branch_to_worktree_path("feature/42-add-sa-core", repo_root="/repo")
+        assert result == "/repo/gitworktree/feature-42-add-sa-core"
+
+    def test_non_feature_branch_returns_none(self) -> None:
+        """feature/ で始まらないブランチは None を返す。"""
+        m = _import_merge_pr()
+        result = m.branch_to_worktree_path("main", repo_root="/repo")
+        assert result is None
+
+    def test_develop_branch_returns_none(self) -> None:
+        """develop ブランチは None を返す。"""
+        m = _import_merge_pr()
+        result = m.branch_to_worktree_path("develop", repo_root="/repo")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7: check_pr_status 関数
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPRStatus:
+    """check_pr_status が PR の状態を正しく解析する。"""
+
+    def test_open_ci_success_returns_ok(self) -> None:
+        """OPEN + CI SUCCESS → ('ok', state, head_ref)"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/48-merge-pr-helper",
+            "statusCheckRollup": [{"state": "SUCCESS", "context": "ci/test"}],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "ok"
+        assert state == "OPEN"
+        assert head_ref == "feature/48-merge-pr-helper"
+
+    def test_merged_returns_already_merged(self) -> None:
+        """MERGED → ('already_merged', state, head_ref)"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "MERGED",
+            "mergeable": "UNKNOWN",
+            "headRefName": "feature/48-merge-pr-helper",
+            "statusCheckRollup": [],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "already_merged"
+        assert state == "MERGED"
+
+    def test_closed_returns_error(self) -> None:
+        """CLOSED → ('error', state, head_ref)"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "CLOSED",
+            "mergeable": "UNKNOWN",
+            "headRefName": "feature/48-merge-pr-helper",
+            "statusCheckRollup": [],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "error"
+
+    def test_ci_failure_returns_ci_failed(self) -> None:
+        """OPEN + CI FAILURE → ('ci_failed', state, head_ref)"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/48-merge-pr-helper",
+            "statusCheckRollup": [{"state": "FAILURE", "context": "ci/test"}],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "ci_failed"
+
+    def test_multiple_checks_last_one_wins(self) -> None:
+        """複数の CI チェックがある場合、最後の state が判定に使われる。"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/48-merge-pr-helper",
+            "statusCheckRollup": [
+                {"state": "SUCCESS", "context": "ci/lint"},
+                {"state": "FAILURE", "context": "ci/test"},
+            ],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "ci_failed"

--- a/tests/scripts/test_merge_pr.py
+++ b/tests/scripts/test_merge_pr.py
@@ -11,9 +11,7 @@ import json
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 
 def _get_scripts_path() -> Path:
@@ -97,8 +95,7 @@ class TestMergePrNormalFlow:
         assert any("pr" in args and "ready" in args for args in call_args_list)
         # ステップ 3: gh pr merge
         assert any(
-            "pr" in args and "merge" in args and "--squash" in args
-            for args in call_args_list
+            "pr" in args and "merge" in args and "--squash" in args for args in call_args_list
         )
         # ステップ 6: git worktree remove
         assert any("worktree" in args and "remove" in args for args in call_args_list)
@@ -133,9 +130,7 @@ class TestMergePrNormalFlow:
         """
         m = _import_merge_pr()
 
-        pr_view_response = self._make_pr_view_response(
-            head_ref="feature/48-merge-pr-helper"
-        )
+        pr_view_response = self._make_pr_view_response(head_ref="feature/48-merge-pr-helper")
 
         captured_worktree_remove_args: list[list[str]] = []
 
@@ -218,9 +213,7 @@ class TestMergePrCIFail:
 
         call_args_list = [c[0][0] for c in run_mock.call_args_list]
         # gh pr merge は呼ばれていないこと
-        assert not any(
-            "pr" in args and "merge" in args for args in call_args_list
-        )
+        assert not any("pr" in args and "merge" in args for args in call_args_list)
 
     def test_pending_ci_returns_exit_1(self) -> None:
         """CI が PENDING なら exit 1 を返す（SUCCESS 以外はすべて拒否）。"""
@@ -329,9 +322,7 @@ class TestMergePrAlreadyMerged:
             m.merge_pr(pr_number=48, dry_run=False, repo_root="/repo")
 
         call_args_list = [c[0][0] for c in run_mock.call_args_list]
-        assert not any(
-            "pr" in args and "merge" in args for args in call_args_list
-        )
+        assert not any("pr" in args and "merge" in args for args in call_args_list)
 
     def test_closed_pr_returns_exit_1(self) -> None:
         """CLOSED（close された PR）は exit 1 を返す。"""
@@ -470,9 +461,7 @@ class TestMergePrDryRun:
 
         call_args_list = [c[0][0] for c in run_mock.call_args_list]
         # dry-run 時は gh pr merge を呼ばない
-        assert not any(
-            "pr" in args and "merge" in args for args in call_args_list
-        )
+        assert not any("pr" in args and "merge" in args for args in call_args_list)
 
     def test_dry_run_does_not_call_git_worktree_remove(self) -> None:
         """dry-run 時は git worktree remove が呼ばれない。"""
@@ -498,9 +487,7 @@ class TestMergePrDryRun:
             m.merge_pr(pr_number=48, dry_run=True, repo_root="/repo")
 
         call_args_list = [c[0][0] for c in run_mock.call_args_list]
-        assert not any(
-            "worktree" in args and "remove" in args for args in call_args_list
-        )
+        assert not any("worktree" in args and "remove" in args for args in call_args_list)
 
     def test_dry_run_returns_exit_0(self) -> None:
         """dry-run は必ず exit 0。"""
@@ -595,7 +582,7 @@ class TestCheckPRStatus:
             "statusCheckRollup": [],
         }
 
-        status, state, head_ref = m.check_pr_status(pr_data)
+        status, state, _head_ref = m.check_pr_status(pr_data)
         assert status == "already_merged"
         assert state == "MERGED"
 
@@ -610,7 +597,7 @@ class TestCheckPRStatus:
             "statusCheckRollup": [],
         }
 
-        status, state, head_ref = m.check_pr_status(pr_data)
+        status, _state, _head_ref = m.check_pr_status(pr_data)
         assert status == "error"
 
     def test_ci_failure_returns_ci_failed(self) -> None:
@@ -624,7 +611,7 @@ class TestCheckPRStatus:
             "statusCheckRollup": [{"state": "FAILURE", "context": "ci/test"}],
         }
 
-        status, state, head_ref = m.check_pr_status(pr_data)
+        status, _state, _head_ref = m.check_pr_status(pr_data)
         assert status == "ci_failed"
 
     def test_multiple_checks_last_one_wins(self) -> None:
@@ -641,5 +628,5 @@ class TestCheckPRStatus:
             ],
         }
 
-        status, state, head_ref = m.check_pr_status(pr_data)
+        status, _state, _head_ref = m.check_pr_status(pr_data)
         assert status == "ci_failed"

--- a/tests/scripts/test_merge_pr.py
+++ b/tests/scripts/test_merge_pr.py
@@ -11,6 +11,7 @@ import json
 import sys
 import types
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 
@@ -575,7 +576,7 @@ class TestCheckPRStatus:
         """MERGED → ('already_merged', state, head_ref)"""
         m = _import_merge_pr()
 
-        pr_data = {
+        pr_data: dict[str, Any] = {
             "state": "MERGED",
             "mergeable": "UNKNOWN",
             "headRefName": "feature/48-merge-pr-helper",
@@ -590,7 +591,7 @@ class TestCheckPRStatus:
         """CLOSED → ('error', state, head_ref)"""
         m = _import_merge_pr()
 
-        pr_data = {
+        pr_data: dict[str, Any] = {
             "state": "CLOSED",
             "mergeable": "UNKNOWN",
             "headRefName": "feature/48-merge-pr-helper",


### PR DESCRIPTION
## Summary

- `scripts/merge_pr.py` を新規実装。7 ステップ（PR 状態確認 → ready → squash merge → worktree 削除 → branch 削除 → develop 同期）を 1 スクリプトで完結
- `Makefile` に `merge-pr` ターゲットを追加（`make merge-pr PR=N [DRY_RUN=1]`）
- `docs/rules/git-worktree.md` §3.5 を改訂し、旧 5 ステップ手順を `<details>` 内 historical reference に移動
- `tests/scripts/test_merge_pr.py` 24 ケース（正常系・CI fail 系・既 merged 系・worktree 不在系・dry-run 系）を TDD で実装

Closes #48

## Test plan

- [ ] `make merge-pr` （PR 番号なし）→ ヘルプを表示して exit 1
- [ ] `make merge-pr PR=N DRY_RUN=1` → コマンドを表示するだけで何も実行しない
- [ ] `uv run pytest tests/scripts/test_merge_pr.py` → 24 passed
- [ ] `uv run ruff check .` → All checks passed
- [ ] `uv run pyright` → 0 errors
- [ ] `uv run pytest -n auto` → 434 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)