### PR TITLE
[phase-3.5] aggregate L1 評価器 + evaluate CLI（closes #59）

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -589,16 +589,101 @@ def generate(
 
 
 @app.command()
-def evaluate(run_dir: str) -> None:
-    """Evaluate the synthetic population in ``run_dir`` (Phase 3.5 onward).
+def evaluate(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", help="設定ファイルのパス。省略時は configs/base.yaml を使う。"),
+    ] = None,
+    log_level: Annotated[
+        LogLevel,
+        typer.Option("--log-level", help="ログレベル。"),
+    ] = LogLevel.INFO,
+) -> None:
+    """合成人口の品質を評価し、metrics.json に結果を追記する.
 
-    Parameters
-    ----------
-    run_dir : str
-        Directory produced by a previous ``generate`` invocation.
+    ``generate`` 出力ディレクトリ（``settings.output_dir``）の
+    ``synthetic_persons.csv`` から人口を再構築し、入力統計に対する L1 誤差を
+    統計別 + 合計で計算する。結果は同じ ``output_dir/metrics.json`` に
+    ``aggregate.l1.*`` キーとして追記される。
+
+    Phase 3.5 (Issue #59) で初版実装。CAP / rare cell / DCR 等は別 Issue で追加。
     """
-    del run_dir
-    _not_yet("evaluate", "Phase 3.5")
+    import json
+    import logging
+
+    from pydantic import ValidationError
+
+    from synthpop_jp.config import Settings
+    from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+    from synthpop_jp.io.loaders import (
+        load_age_diff_couple,
+        load_age_diff_parent_child,
+        load_demographic_by_age_sex,
+    )
+    from synthpop_jp.io.synthesized import reconstruct_population_arrays_from_persons_csv
+
+    logging.basicConfig(level=getattr(logging, log_level.value))
+
+    if config is None:
+        config = _find_default_config()
+
+    console.print(f"[bold]設定ファイル:[/bold] {config}")
+
+    try:
+        settings = Settings.from_yaml(config)
+    except FileNotFoundError:
+        err_console.print(f"[red]エラー:[/red] 設定ファイルが見つかりません: {config}")
+        raise typer.Exit(code=1) from None
+    except ValidationError as e:
+        err_console.print(f"[red]設定の検証に失敗:[/red] {e}")
+        raise typer.Exit(code=1) from None
+
+    persons_csv = settings.output_dir / "synthetic_persons.csv"
+    if not persons_csv.exists():
+        err_console.print(
+            f"[red]エラー:[/red] synthetic_persons.csv が見つかりません: {persons_csv}"
+        )
+        err_console.print("先に `synthpop-jp generate` を実行してください。")
+        raise typer.Exit(code=1)
+
+    console.print(f"[bold]評価対象:[/bold] {persons_csv}")
+    arrays = reconstruct_population_arrays_from_persons_csv(persons_csv)
+    console.print(
+        f"[green]人口再構築完了:[/green] {len(set(int(h) for h in arrays.household_id))} 世帯 / "
+        f"{arrays.n_persons} 人"
+    )
+
+    age_diff_parent_child = load_age_diff_parent_child(
+        settings.input_dir / "age_diff_parent_child.csv"
+    )
+    age_diff_couple = load_age_diff_couple(settings.input_dir / "age_diff_couple.csv")
+    demographic_by_age_sex = load_demographic_by_age_sex(
+        settings.input_dir / "demographic_by_age_sex.csv"
+    )
+
+    evaluator = AggregateStatL1Evaluator(
+        age_diff_parent_child=age_diff_parent_child,
+        age_diff_couple=age_diff_couple,
+        demographic_by_age_sex=demographic_by_age_sex,
+    )
+    metrics = evaluator.evaluate(arrays)
+
+    # metrics.json に追記（既存キーは保持）
+    metrics_path = settings.output_dir / "metrics.json"
+    if metrics_path.exists():
+        existing: dict[str, object] = json.loads(metrics_path.read_text(encoding="utf-8"))
+    else:
+        existing = {}
+    existing.update(metrics)
+    metrics_path.write_text(
+        json.dumps(existing, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    console.print("[green]評価完了:[/green]")
+    for k, v in metrics.items():
+        console.print(f"  {k}: {v:.1f}")
+    console.print(f"[bold]metrics.json 更新:[/bold] {metrics_path}")
 
 
 @app.command()

--- a/src/synthpop_jp/evaluate/__init__.py
+++ b/src/synthpop_jp/evaluate/__init__.py
@@ -1,1 +1,11 @@
-"""Evaluator suite (Phase 3.5 / Phase 4 で実体)."""
+"""Evaluator suite (Phase 3.5 / Phase 4 で実体).
+
+提供する Evaluator 一覧（Phase 3.5 時点）
+----------------------------------------
+- :class:`~synthpop_jp.evaluate.aggregate_metrics.AggregateStatL1Evaluator`
+  (Issue #59): 統計別 L1 誤差レポータ
+"""
+
+from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+
+__all__ = ["AggregateStatL1Evaluator"]

--- a/src/synthpop_jp/evaluate/aggregate_metrics.py
+++ b/src/synthpop_jp/evaluate/aggregate_metrics.py
@@ -1,5 +1,106 @@
-"""Aggregate 21-statistic L1 error reporter (Phase 3.5 で実装)."""
+"""Aggregate 21-statistic L1 error reporter (Phase 3.5, Issue #59).
+
+Phase 2 実装済みの 5 統計（``ObjectiveState.stats`` と同型）に対し、observed と
+target の L1 誤差を統計別 + 合計で返す Evaluator を提供する。21 統計拡張は
+Phase 3a の別 Issue で対応する。
+
+提供するもの
+------------
+- ``AggregateStatL1Evaluator``: ``domain/protocols.py::Evaluator`` Protocol を実装
+
+出力キー命名規則
+----------------
+- ``aggregate.l1.father_child_age_diff``
+- ``aggregate.l1.mother_child_age_diff``
+- ``aggregate.l1.couple_age_diff``
+- ``aggregate.l1.pyramid_male``
+- ``aggregate.l1.pyramid_female``
+- ``aggregate.l1.total``
+"""
 
 from __future__ import annotations
 
-# TODO: Phase 3.5 で Table 13 形式の統計別誤差レポータを実装する。
+from typing import TYPE_CHECKING
+
+from synthpop_jp.optimize.objective import build_objective_stats
+
+if TYPE_CHECKING:
+    from synthpop_jp.io.schemas import (
+        AgeDiffCoupleRow,
+        AgeDiffParentChildRow,
+        DemographicByAgeSexRow,
+    )
+    from synthpop_jp.optimize.state import PopulationArrays
+
+
+# 5 統計の出力キー名（``build_objective_stats`` のインデックス順）
+_STAT_NAMES: tuple[str, ...] = (
+    "father_child_age_diff",
+    "mother_child_age_diff",
+    "couple_age_diff",
+    "pyramid_male",
+    "pyramid_female",
+)
+
+
+class AggregateStatL1Evaluator:
+    """統計別 L1 誤差レポータ（``Evaluator`` Protocol 実装）.
+
+    入力 CSV から target 統計を保持し、``evaluate(pop)`` で合成人口に対する
+    observed を都度計算して L1 誤差を返す。
+
+    Parameters
+    ----------
+    age_diff_parent_child : list[AgeDiffParentChildRow]
+        ``age_diff_parent_child.csv`` から読んだ全行。
+    age_diff_couple : list[AgeDiffCoupleRow]
+        ``age_diff_couple.csv`` から読んだ全行。
+    demographic_by_age_sex : list[DemographicByAgeSexRow]
+        ``demographic_by_age_sex.csv`` から読んだ全行。
+
+    Attributes
+    ----------
+    name : str
+        ``"aggregate"`` 固定。``metrics.json`` のキー prefix として使われる。
+    """
+
+    name: str = "aggregate"
+
+    def __init__(
+        self,
+        age_diff_parent_child: list[AgeDiffParentChildRow],
+        age_diff_couple: list[AgeDiffCoupleRow],
+        demographic_by_age_sex: list[DemographicByAgeSexRow],
+    ) -> None:
+        self._age_diff_parent_child = age_diff_parent_child
+        self._age_diff_couple = age_diff_couple
+        self._demographic_by_age_sex = demographic_by_age_sex
+
+    def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
+        """合成人口の 5 統計 L1 誤差を計算して dict で返す.
+
+        Parameters
+        ----------
+        pop : PopulationArrays
+            評価対象の合成人口配列。``observed`` ヒストグラムの算出元。
+
+        Returns
+        -------
+        dict[str, float]
+            ``aggregate.l1.<stat_name>`` × 5 + ``aggregate.l1.total`` を含む
+            6 キーの dict。
+        """
+        stats = build_objective_stats(
+            arrays=pop,
+            age_diff_parent_child=self._age_diff_parent_child,
+            age_diff_couple=self._age_diff_couple,
+            demographic_by_age_sex=self._demographic_by_age_sex,
+        )
+        result: dict[str, float] = {}
+        total = 0.0
+        for i, stat in enumerate(stats):
+            l1 = stat.l1_score()
+            result[f"{self.name}.l1.{_STAT_NAMES[i]}"] = l1
+            total += l1
+        result[f"{self.name}.l1.total"] = total
+        return result

--- a/src/synthpop_jp/io/synthesized.py
+++ b/src/synthpop_jp/io/synthesized.py
@@ -1,0 +1,96 @@
+"""Reader for ``synthetic_persons.csv`` to reconstruct PopulationArrays — Issue #59.
+
+``generate`` の出力 CSV から ``PopulationArrays`` を再構築する関数を提供する。
+``synthpop-jp evaluate`` が合成人口の品質を評価するときに使う（generate を再実行
+せず、ファイルから読み戻す）。
+
+提供するもの
+------------
+- ``reconstruct_population_arrays_from_persons_csv(persons_csv)``
+  → :class:`~synthpop_jp.optimize.state.PopulationArrays`
+"""
+
+from __future__ import annotations
+
+import csv
+from typing import TYPE_CHECKING, cast
+
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.optimize.state import PopulationArrays
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_HH_ID_PREFIX = "HH_"
+
+
+def reconstruct_population_arrays_from_persons_csv(
+    persons_csv: Path,
+) -> PopulationArrays:
+    """``synthetic_persons.csv`` から ``PopulationArrays`` を再構築する.
+
+    ``generate`` が書き出した CSV の各行を 1 person として解釈し、
+    ``household_id`` でグルーピングして ``Household`` のリストに戻し、
+    ``PopulationArrays.from_households`` で並列配列化する。
+
+    必要な CSV 列: ``household_id`` (``"HH_NNNNNN"`` 形式)、``family_type``、
+    ``role``、``sex`` (``"M"`` / ``"F"``)、``age``。
+
+    Parameters
+    ----------
+    persons_csv : Path
+        ``synthetic_persons.csv`` のパス。
+
+    Returns
+    -------
+    PopulationArrays
+        再構築された人口配列。Registry は CSV 内の登場順で登録される。
+
+    Raises
+    ------
+    FileNotFoundError
+        指定された CSV が存在しない場合。
+    """
+    family_reg = FamilyTypeRegistry()
+    role_reg = RoleRegistry()
+    sex_reg = SexRegistry()
+
+    households_dict: dict[int, dict[str, object]] = {}
+    seen_family_types: set[str] = set()
+    seen_roles: set[str] = set()
+
+    with persons_csv.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            hh_id_str = row["household_id"]
+            hh_id = int(str(hh_id_str).removeprefix(_HH_ID_PREFIX))
+            family_type = row["family_type"]
+            role = row["role"]
+            sex = row["sex"]
+            age = int(row["age"])
+
+            # 登場した family_type / role を Registry に登録
+            if family_type not in seen_family_types:
+                family_reg.register(family_type)
+                seen_family_types.add(family_type)
+            if role not in seen_roles:
+                role_reg.register(role)
+                seen_roles.add(role)
+
+            if hh_id not in households_dict:
+                households_dict[hh_id] = {"family_type": family_type, "members": []}
+            members = cast("list[Person]", households_dict[hh_id]["members"])
+            members.append(Person(household_id=hh_id, role=role, sex=sex, age=age))  # type: ignore[arg-type]
+
+    households = [
+        Household(
+            household_id=hid,
+            family_type=cast("str", info["family_type"]),
+            members=cast("list[Person]", info["members"]),
+        )
+        for hid, info in sorted(households_dict.items())
+    ]
+    return PopulationArrays.from_households(households, family_reg, role_reg, sex_reg)

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -1,0 +1,90 @@
+"""Tests for the ``evaluate`` CLI subcommand (Phase 3.5, Issue #59).
+
+generate → evaluate を tmp_path 上で順番実行し、metrics.json に
+``aggregate.l1.*`` キーが追記されることを検証する。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from synthpop_jp.cli import app
+
+runner = CliRunner()
+
+SAMPLE_CASE_DIR = Path(__file__).parent.parent.parent / "data" / "sample_case"
+
+
+def _make_config_yaml(tmp_path: Path) -> Path:
+    """generate + evaluate 共通の小さい config を作る."""
+    config_data: dict[str, object] = {
+        "seed": 42,
+        "input_dir": str(SAMPLE_CASE_DIR),
+        "output_dir": str(tmp_path / "out"),
+        "annealing": {
+            "T0": 100.0,
+            "alpha": 0.99,
+            "max_iters": 200,
+            "evals_per_agent": 0,
+            "target_threshold": 0.0,
+            "patience": 0,
+        },
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+@pytest.mark.slow
+class TestEvaluateIntegration:
+    """end-to-end: generate → evaluate を順番に実行する."""
+
+    def test_evaluate_appends_aggregate_keys(self, tmp_path: Path) -> None:
+        """evaluate 後の metrics.json に aggregate.l1.* キーが含まれる."""
+        config_path = _make_config_yaml(tmp_path)
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0, eval_result.output
+
+        metrics_path = tmp_path / "out" / "metrics.json"
+        assert metrics_path.exists()
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+
+        # aggregate.l1.* が 5 stat + total = 6 キー含まれる
+        assert "aggregate.l1.father_child_age_diff" in metrics
+        assert "aggregate.l1.mother_child_age_diff" in metrics
+        assert "aggregate.l1.couple_age_diff" in metrics
+        assert "aggregate.l1.pyramid_male" in metrics
+        assert "aggregate.l1.pyramid_female" in metrics
+        assert "aggregate.l1.total" in metrics
+
+        # 既存 generate キーが保持される
+        assert "total_households" in metrics
+        assert "best_score" in metrics
+
+    def test_evaluate_aggregate_total_matches_best_score(self, tmp_path: Path) -> None:
+        """evaluate の aggregate.l1.total は generate の best_score と一致."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        runner.invoke(app, ["evaluate", "--config", str(config_path)])
+
+        metrics_path = tmp_path / "out" / "metrics.json"
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+        # best_score は generate が書いた値、aggregate.l1.total は evaluate が計算
+        # 同じ最終人口に対する L1 なので一致する
+        assert abs(metrics["aggregate.l1.total"] - metrics["best_score"]) < 1e-3
+
+    def test_evaluate_fails_without_synthetic_csv(self, tmp_path: Path) -> None:
+        """generate を先に実行していない場合は exit code 1."""
+        config_path = _make_config_yaml(tmp_path)
+        # generate せずに evaluate
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 1
+        assert "synthetic_persons.csv" in eval_result.output

--- a/tests/evaluate/test_aggregate_metrics.py
+++ b/tests/evaluate/test_aggregate_metrics.py
@@ -1,0 +1,132 @@
+"""Tests for AggregateStatL1Evaluator (Phase 3.5, Issue #59).
+
+統計別 L1 誤差レポータの単体テスト。Phase 2 の ObjectiveState.stats と同型の
+5 統計に対し、L1 誤差を統計別 + 合計で返すことを検証する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+from synthpop_jp.init.initial_population import InitStats, generate_initial_population
+from synthpop_jp.io.loaders import (
+    load_age_diff_couple,
+    load_age_diff_parent_child,
+    load_children_count_dist,
+    load_demographic_by_age_sex,
+    load_demographic_by_family_type_role,
+    load_family_type_counts,
+    load_family_type_mapping,
+    load_household_size_by_family_type,
+)
+from synthpop_jp.optimize.objective import ObjectiveState
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.rng import SeedRegistry
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("pyproject.toml not found")
+
+
+_DATA_DIR = _find_repo_root() / "data" / "sample_case"
+_CONFIGS_DIR = _find_repo_root() / "configs"
+
+
+@pytest.fixture
+def sample_arrays() -> PopulationArrays:
+    """sample_case から生成した初期人口."""
+    stats = InitStats(
+        family_type_counts=load_family_type_counts(_DATA_DIR / "family_type_counts.csv"),
+        children_count_dist=load_children_count_dist(_DATA_DIR / "children_count_dist.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+        family_type_mapping=load_family_type_mapping(_CONFIGS_DIR / "family_type_mapping.yaml"),
+        household_size_by_family_type=load_household_size_by_family_type(
+            _DATA_DIR / "household_size_by_family_type.csv"
+        ),
+        demographic_by_family_type_role=load_demographic_by_family_type_role(
+            _DATA_DIR / "demographic_by_family_type_role.csv"
+        ),
+    )
+    rng = SeedRegistry(root=42).rng("init")
+    return generate_initial_population(stats, rng)
+
+
+@pytest.fixture
+def evaluator() -> AggregateStatL1Evaluator:
+    """sample_case の入力 CSV から構築した evaluator."""
+    return AggregateStatL1Evaluator(
+        age_diff_parent_child=load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv"),
+        age_diff_couple=load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+    )
+
+
+class TestAggregateStatL1Evaluator:
+    """AggregateStatL1Evaluator は domain/protocols.py::Evaluator Protocol を実装する."""
+
+    def test_name_is_aggregate(self, evaluator: AggregateStatL1Evaluator) -> None:
+        """`name` 属性は metrics.json でのキー prefix として 'aggregate'."""
+        assert evaluator.name == "aggregate"
+
+    def test_evaluate_returns_six_keys(
+        self, evaluator: AggregateStatL1Evaluator, sample_arrays: PopulationArrays
+    ) -> None:
+        """5 統計分の L1 + total = 6 キー."""
+        result = evaluator.evaluate(sample_arrays)
+        expected_keys = {
+            "aggregate.l1.father_child_age_diff",
+            "aggregate.l1.mother_child_age_diff",
+            "aggregate.l1.couple_age_diff",
+            "aggregate.l1.pyramid_male",
+            "aggregate.l1.pyramid_female",
+            "aggregate.l1.total",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_total_equals_sum_of_individual(
+        self, evaluator: AggregateStatL1Evaluator, sample_arrays: PopulationArrays
+    ) -> None:
+        """total は個別 5 統計 L1 の合計に一致."""
+        result = evaluator.evaluate(sample_arrays)
+        individual_sum = (
+            result["aggregate.l1.father_child_age_diff"]
+            + result["aggregate.l1.mother_child_age_diff"]
+            + result["aggregate.l1.couple_age_diff"]
+            + result["aggregate.l1.pyramid_male"]
+            + result["aggregate.l1.pyramid_female"]
+        )
+        assert abs(result["aggregate.l1.total"] - individual_sum) < 1e-9
+
+    def test_all_values_nonnegative(
+        self, evaluator: AggregateStatL1Evaluator, sample_arrays: PopulationArrays
+    ) -> None:
+        """L1 誤差はすべて非負."""
+        result = evaluator.evaluate(sample_arrays)
+        for k, v in result.items():
+            assert v >= 0.0, f"{k} = {v} should be >= 0"
+            assert np.isfinite(v), f"{k} = {v} should be finite"
+
+    def test_total_matches_objective_state_score(
+        self, evaluator: AggregateStatL1Evaluator, sample_arrays: PopulationArrays
+    ) -> None:
+        """total は ObjectiveState.total_score と一致する（同 inputs / 同 arrays）."""
+        objective = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=evaluator._age_diff_parent_child,
+            age_diff_couple=evaluator._age_diff_couple,
+            demographic_by_age_sex=evaluator._demographic_by_age_sex,
+        )
+        result = evaluator.evaluate(sample_arrays)
+        assert abs(result["aggregate.l1.total"] - objective.total_score) < 1e-6

--- a/tests/evaluate/test_aggregate_metrics.py
+++ b/tests/evaluate/test_aggregate_metrics.py
@@ -118,15 +118,23 @@ class TestAggregateStatL1Evaluator:
             assert v >= 0.0, f"{k} = {v} should be >= 0"
             assert np.isfinite(v), f"{k} = {v} should be finite"
 
-    def test_total_matches_objective_state_score(
-        self, evaluator: AggregateStatL1Evaluator, sample_arrays: PopulationArrays
-    ) -> None:
+    def test_total_matches_objective_state_score(self, sample_arrays: PopulationArrays) -> None:
         """total は ObjectiveState.total_score と一致する（同 inputs / 同 arrays）."""
+        age_diff_parent_child = load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv")
+        age_diff_couple = load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv")
+        demographic_by_age_sex = load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        )
+        evaluator = AggregateStatL1Evaluator(
+            age_diff_parent_child=age_diff_parent_child,
+            age_diff_couple=age_diff_couple,
+            demographic_by_age_sex=demographic_by_age_sex,
+        )
         objective = ObjectiveState.from_arrays(
             arrays=sample_arrays,
-            age_diff_parent_child=evaluator._age_diff_parent_child,
-            age_diff_couple=evaluator._age_diff_couple,
-            demographic_by_age_sex=evaluator._demographic_by_age_sex,
+            age_diff_parent_child=age_diff_parent_child,
+            age_diff_couple=age_diff_couple,
+            demographic_by_age_sex=demographic_by_age_sex,
         )
         result = evaluator.evaluate(sample_arrays)
         assert abs(result["aggregate.l1.total"] - objective.total_score) < 1e-6

--- a/tests/io/test_synthesized.py
+++ b/tests/io/test_synthesized.py
@@ -1,0 +1,126 @@
+"""Tests for io/synthesized.py — synthetic CSV reconstruction (Issue #59)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from synthpop_jp.io.synthesized import reconstruct_population_arrays_from_persons_csv
+
+
+def _write_persons_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    """Write a small persons CSV at ``path`` for tests."""
+    fieldnames = ["person_id", "household_id", "family_type", "role", "sex", "age"]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+
+class TestReconstructPopulationArrays:
+    """reconstruct_population_arrays_from_persons_csv の単体テスト."""
+
+    def test_reconstructs_basic_household(self, tmp_path: Path) -> None:
+        """1 世帯 3 人の CSV を再構築し、属性が一致する."""
+        csv_path = tmp_path / "synthetic_persons.csv"
+        _write_persons_csv(
+            csv_path,
+            [
+                {
+                    "person_id": "P_000001",
+                    "household_id": "HH_000001",
+                    "family_type": "couple_and_children",
+                    "role": "father",
+                    "sex": "M",
+                    "age": 40,
+                },
+                {
+                    "person_id": "P_000002",
+                    "household_id": "HH_000001",
+                    "family_type": "couple_and_children",
+                    "role": "mother",
+                    "sex": "F",
+                    "age": 38,
+                },
+                {
+                    "person_id": "P_000003",
+                    "household_id": "HH_000001",
+                    "family_type": "couple_and_children",
+                    "role": "child",
+                    "sex": "M",
+                    "age": 10,
+                },
+            ],
+        )
+        arrays = reconstruct_population_arrays_from_persons_csv(csv_path)
+        assert arrays.n_persons == 3
+        # ages 40, 38, 10 が含まれる
+        assert sorted(int(a) for a in arrays.age) == [10, 38, 40]
+        # all in household 1
+        assert all(int(h) == 1 for h in arrays.household_id)
+
+    def test_multi_household_count(self, tmp_path: Path) -> None:
+        """複数世帯を再構築すると人数と世帯数が CSV と一致する."""
+        csv_path = tmp_path / "synthetic_persons.csv"
+        rows = []
+        person_id = 1
+        for hh in range(1, 4):
+            for role, sex, age in [("husband", "M", 35), ("wife", "F", 33)]:
+                rows.append(
+                    {
+                        "person_id": f"P_{person_id:06d}",
+                        "household_id": f"HH_{hh:06d}",
+                        "family_type": "couple",
+                        "role": role,
+                        "sex": sex,
+                        "age": age,
+                    }
+                )
+                person_id += 1
+        _write_persons_csv(csv_path, rows)
+        arrays = reconstruct_population_arrays_from_persons_csv(csv_path)
+        assert arrays.n_persons == 6
+        # 3 世帯
+        assert len(set(int(h) for h in arrays.household_id)) == 3
+
+    def test_registers_unique_family_types_and_roles(self, tmp_path: Path) -> None:
+        """family_type / role は CSV 内の出現名がすべて Registry に登録される."""
+        csv_path = tmp_path / "synthetic_persons.csv"
+        _write_persons_csv(
+            csv_path,
+            [
+                {
+                    "person_id": "P_000001",
+                    "household_id": "HH_000001",
+                    "family_type": "single",
+                    "role": "single",
+                    "sex": "M",
+                    "age": 30,
+                },
+                {
+                    "person_id": "P_000002",
+                    "household_id": "HH_000002",
+                    "family_type": "couple",
+                    "role": "husband",
+                    "sex": "M",
+                    "age": 35,
+                },
+                {
+                    "person_id": "P_000003",
+                    "household_id": "HH_000002",
+                    "family_type": "couple",
+                    "role": "wife",
+                    "sex": "F",
+                    "age": 33,
+                },
+            ],
+        )
+        arrays = reconstruct_population_arrays_from_persons_csv(csv_path)
+        # FamilyTypeRegistry has both "single" and "couple"
+        assert arrays.family_reg.id_of("single") >= 0
+        assert arrays.family_reg.id_of("couple") >= 0
+        # RoleRegistry has all 3
+        assert arrays.role_reg.id_of("single") >= 0
+        assert arrays.role_reg.id_of("husband") >= 0
+        assert arrays.role_reg.id_of("wife") >= 0

--- a/tests/io/test_synthesized.py
+++ b/tests/io/test_synthesized.py
@@ -63,7 +63,7 @@ class TestReconstructPopulationArrays:
     def test_multi_household_count(self, tmp_path: Path) -> None:
         """複数世帯を再構築すると人数と世帯数が CSV と一致する."""
         csv_path = tmp_path / "synthetic_persons.csv"
-        rows = []
+        rows: list[dict[str, object]] = []
         person_id = 1
         for hh in range(1, 4):
             for role, sex, age in [("husband", "M", 35), ("wife", "F", 33)]:


### PR DESCRIPTION
## 概要

Phase 3.5 の最初の Issue。`synthpop-jp evaluate` CLI を実装し、合成人口の品質を 1 コマンドで把握できるようにした。

## 主な変更

- `src/synthpop_jp/evaluate/aggregate_metrics.py`: `AggregateStatL1Evaluator` 実装
  - 5 統計（father-child, mother-child, couple, pyramid M/F）の L1 誤差を計算
  - 出力キー: `aggregate.l1.<stat_name>` × 5 + `aggregate.l1.total`
- `src/synthpop_jp/io/synthesized.py`: 新規モジュール
  - `reconstruct_population_arrays_from_persons_csv()` で synthetic_persons.csv から PopulationArrays を再構築
- `src/synthpop_jp/cli.py`: evaluate stub を実装に置換
  - `--config` で settings をロード、`output_dir/synthetic_persons.csv` から再構築
  - `metrics.json` に `aggregate.l1.*` を追記（既存キー保持）
- `src/synthpop_jp/evaluate/__init__.py`: export 追加

## 実機 smoke

```
$ synthpop-jp generate --config tmp.yaml
SA 完了: best_score=401.0 (initial=454.0, improvement=11.7%)

$ synthpop-jp evaluate --config tmp.yaml
評価完了:
  aggregate.l1.father_child_age_diff: 77.0
  aggregate.l1.mother_child_age_diff: 62.0
  aggregate.l1.couple_age_diff: 56.0
  aggregate.l1.pyramid_male: 117.0
  aggregate.l1.pyramid_female: 89.0
  aggregate.l1.total: 401.0  ← best_score と一致
```

## 検証

- ruff / format / pyright（0 errors）/ pytest 全 pass
- 既存 430 件 + 新規 11 件（5 evaluator + 3 io + 3 CLI integration）
- 5 commits（Red→Green→io helper→CLI wiring→__init__ export）

## 非スコープ（後続）

- 21 統計拡張（Phase 3a の extended objective が入れば evaluator も追従）
- Table 13 形式の `report.md` 自動追記（HTML レポート再構築と別 Issue）
- CAP / TCAP / rare cell metrics（Phase 3.5 別 Issue）
- DCR / NNDR / ARD / utility metrics（Phase 4）
- evaluate plugin entry_points テスト（評価器 ≥ 2 個揃ってから）

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)