### PR TITLE
[phase-3.5] rare cell metrics 評価器（closes #61）

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -602,11 +602,13 @@ def evaluate(
     """合成人口の品質を評価し、metrics.json に結果を追記する.
 
     ``generate`` 出力ディレクトリ（``settings.output_dir``）の
-    ``synthetic_persons.csv`` から人口を再構築し、入力統計に対する L1 誤差を
-    統計別 + 合計で計算する。結果は同じ ``output_dir/metrics.json`` に
-    ``aggregate.l1.*`` キーとして追記される。
+    ``synthetic_persons.csv`` から人口を再構築し、以下の評価器を順番に実行する:
 
-    Phase 3.5 (Issue #59) で初版実装。CAP / rare cell / DCR 等は別 Issue で追加。
+    - ``AggregateStatL1Evaluator`` (Issue #59): 統計別 L1 誤差
+    - ``RareCellEvaluator`` (Issue #61): family_type×age cell の rare/unique 率
+
+    結果は ``output_dir/metrics.json`` に ``aggregate.l1.*`` および ``rare_cell.*``
+    キーとして追記される。CAP / DCR 等は後続 Issue で追加。
     """
     import json
     import logging
@@ -615,6 +617,7 @@ def evaluate(
 
     from synthpop_jp.config import Settings
     from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+    from synthpop_jp.evaluate.rare_cell_metrics import RareCellEvaluator
     from synthpop_jp.io.loaders import (
         load_age_diff_couple,
         load_age_diff_parent_child,
@@ -661,12 +664,16 @@ def evaluate(
         settings.input_dir / "demographic_by_age_sex.csv"
     )
 
-    evaluator = AggregateStatL1Evaluator(
+    aggregate_evaluator = AggregateStatL1Evaluator(
         age_diff_parent_child=age_diff_parent_child,
         age_diff_couple=age_diff_couple,
         demographic_by_age_sex=demographic_by_age_sex,
     )
-    metrics = evaluator.evaluate(arrays)
+    rare_cell_evaluator = RareCellEvaluator()
+    metrics: dict[str, float] = {
+        **aggregate_evaluator.evaluate(arrays),
+        **rare_cell_evaluator.evaluate(arrays),
+    }
 
     # metrics.json に追記（既存キーは保持）
     metrics_path = settings.output_dir / "metrics.json"

--- a/src/synthpop_jp/evaluate/__init__.py
+++ b/src/synthpop_jp/evaluate/__init__.py
@@ -4,8 +4,11 @@
 ----------------------------------------
 - :class:`~synthpop_jp.evaluate.aggregate_metrics.AggregateStatL1Evaluator`
   (Issue #59): 統計別 L1 誤差レポータ
+- :class:`~synthpop_jp.evaluate.rare_cell_metrics.RareCellEvaluator`
+  (Issue #61): (family_type, age) cell の rare/unique 率
 """
 
 from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+from synthpop_jp.evaluate.rare_cell_metrics import RareCellEvaluator
 
-__all__ = ["AggregateStatL1Evaluator"]
+__all__ = ["AggregateStatL1Evaluator", "RareCellEvaluator"]

--- a/src/synthpop_jp/evaluate/rare_cell_metrics.py
+++ b/src/synthpop_jp/evaluate/rare_cell_metrics.py
@@ -1,5 +1,101 @@
-"""Rare cell monitoring metrics (Phase 3.5 で実装)."""
+"""Rare cell monitoring metrics (Phase 3.5, Issue #61).
+
+合成人口における ``(family_type, age)`` の組合せを cell とみなし、
+cell サイズ < 5 の割合と unique（== 1）の割合を計算する Evaluator を提供する。
+
+`docs/spec/metrics.md` §6 に基づく実装。`docs/spec/spec.md` §11.5 の
+soft constraint（improve ループでの reject）の前提値となる。
+
+提供するもの
+------------
+- ``RareCellEvaluator``: ``domain/protocols.py::Evaluator`` Protocol を実装
+
+出力キー命名規則
+----------------
+- ``rare_cell.total_cells``: 非空 cell の総数
+- ``rare_cell.fraction_below_5``: cell size < 5 の割合（0.0–1.0）
+- ``rare_cell.fraction_unique``: cell size == 1 の割合
+- ``rare_cell.per_family_type.fraction_below_5.<family_type>``: 属性別
+- ``rare_cell.per_family_type.fraction_unique.<family_type>``: 属性別
+
+空人口（n_persons == 0）では全 fraction = 0、total_cells = 0 を返す（0 除算回避）。
+"""
 
 from __future__ import annotations
 
-# TODO: Phase 3.5 で rare cell / unique person 監視メトリクスを実装する。
+from collections import Counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from synthpop_jp.optimize.state import PopulationArrays
+
+
+# rare cell 判定の閾値（spec §11.5）
+_RARE_THRESHOLD: int = 5
+_UNIQUE_THRESHOLD: int = 1
+
+
+class RareCellEvaluator:
+    """``(family_type, age)`` cell の脅威度メトリクス（``Evaluator`` Protocol 実装）.
+
+    合成人口の各 person を ``(family_type, age)`` で分類し、cell サイズの分布から
+    rare（size < 5）/ unique（size == 1）の割合を計算する。
+
+    Attributes
+    ----------
+    name : str
+        ``"rare_cell"`` 固定。``metrics.json`` のキー prefix として使われる。
+    """
+
+    name: str = "rare_cell"
+
+    def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
+        """合成人口の rare cell メトリクスを計算する.
+
+        Parameters
+        ----------
+        pop : PopulationArrays
+            評価対象の合成人口配列。
+
+        Returns
+        -------
+        dict[str, float]
+            ``rare_cell.*`` キーを含む dict。空人口でも 0 除算しない。
+        """
+        result: dict[str, float] = {}
+
+        n = pop.n_persons
+        if n == 0:
+            result["rare_cell.total_cells"] = 0.0
+            result["rare_cell.fraction_below_5"] = 0.0
+            result["rare_cell.fraction_unique"] = 0.0
+            return result
+
+        # cell = (family_type_id, age). 全体集計
+        family_types = pop.family_type
+        ages = pop.age
+        cells = Counter(zip(family_types.tolist(), ages.tolist(), strict=True))
+        total_cells = len(cells)
+        cells_below_5 = sum(1 for c in cells.values() if c < _RARE_THRESHOLD)
+        cells_unique = sum(1 for c in cells.values() if c == _UNIQUE_THRESHOLD)
+        result["rare_cell.total_cells"] = float(total_cells)
+        result["rare_cell.fraction_below_5"] = (
+            cells_below_5 / total_cells if total_cells > 0 else 0.0
+        )
+        result["rare_cell.fraction_unique"] = cells_unique / total_cells if total_cells > 0 else 0.0
+
+        # per family_type 分解
+        for ft_name in pop.family_reg.all_names():
+            ft_id = pop.family_reg.id_of(ft_name)
+            ft_cells = {(fid, age): cnt for (fid, age), cnt in cells.items() if fid == ft_id}
+            ft_total = len(ft_cells)
+            if ft_total == 0:
+                ft_below_5 = 0.0
+                ft_unique = 0.0
+            else:
+                ft_below_5 = sum(1 for c in ft_cells.values() if c < _RARE_THRESHOLD) / ft_total
+                ft_unique = sum(1 for c in ft_cells.values() if c == _UNIQUE_THRESHOLD) / ft_total
+            result[f"rare_cell.per_family_type.fraction_below_5.{ft_name}"] = ft_below_5
+            result[f"rare_cell.per_family_type.fraction_unique.{ft_name}"] = ft_unique
+
+        return result

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -81,6 +81,21 @@ class TestEvaluateIntegration:
         # 同じ最終人口に対する L1 なので一致する
         assert abs(metrics["aggregate.l1.total"] - metrics["best_score"]) < 1e-3
 
+    def test_evaluate_appends_rare_cell_keys(self, tmp_path: Path) -> None:
+        """evaluate 後の metrics.json に rare_cell.* キーが含まれる（Issue #61）."""
+        config_path = _make_config_yaml(tmp_path)
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0, eval_result.output
+
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert "rare_cell.total_cells" in metrics
+        assert "rare_cell.fraction_below_5" in metrics
+        assert "rare_cell.fraction_unique" in metrics
+        # per_family_type 分解（少なくとも 1 つの family_type について存在）
+        assert any(k.startswith("rare_cell.per_family_type.") for k in metrics)
+
     def test_evaluate_fails_without_synthetic_csv(self, tmp_path: Path) -> None:
         """generate を先に実行していない場合は exit code 1."""
         config_path = _make_config_yaml(tmp_path)

--- a/tests/evaluate/test_rare_cell_metrics.py
+++ b/tests/evaluate/test_rare_cell_metrics.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from synthpop_jp.domain.household import Household
 from synthpop_jp.domain.person import Person
@@ -146,23 +145,11 @@ class TestRareCellEvaluatorMath:
         evaluator = RareCellEvaluator()
         result = evaluator.evaluate(arrays)
         # single: 3 unique cells / 3 = 1.0
-        assert (
-            abs(result["rare_cell.per_family_type.fraction_unique.single"] - 1.0)
-            < 1e-9
-        )
-        assert (
-            abs(result["rare_cell.per_family_type.fraction_below_5.single"] - 1.0)
-            < 1e-9
-        )
+        assert abs(result["rare_cell.per_family_type.fraction_unique.single"] - 1.0) < 1e-9
+        assert abs(result["rare_cell.per_family_type.fraction_below_5.single"] - 1.0) < 1e-9
         # couple: 1 cell, count=5, NOT < 5 → 0.0
-        assert (
-            abs(result["rare_cell.per_family_type.fraction_unique.couple"] - 0.0)
-            < 1e-9
-        )
-        assert (
-            abs(result["rare_cell.per_family_type.fraction_below_5.couple"] - 0.0)
-            < 1e-9
-        )
+        assert abs(result["rare_cell.per_family_type.fraction_unique.couple"] - 0.0) < 1e-9
+        assert abs(result["rare_cell.per_family_type.fraction_below_5.couple"] - 0.0) < 1e-9
 
 
 class TestRareCellEvaluatorEdgeCases:
@@ -182,9 +169,7 @@ class TestRareCellEvaluatorEdgeCases:
 
     def test_finite_values(self) -> None:
         """全 fraction 値が有限（NaN / inf でない）."""
-        arrays = _build_arrays(
-            [("single", "single", "M", 30), ("single", "single", "M", 31)]
-        )
+        arrays = _build_arrays([("single", "single", "M", 30), ("single", "single", "M", 31)])
         evaluator = RareCellEvaluator()
         result = evaluator.evaluate(arrays)
         for k, v in result.items():

--- a/tests/evaluate/test_rare_cell_metrics.py
+++ b/tests/evaluate/test_rare_cell_metrics.py
@@ -1,0 +1,191 @@
+"""Tests for RareCellEvaluator (Phase 3.5, Issue #61).
+
+(family_type, age) cell の脅威度メトリクス:
+- cell size < 5 の割合
+- cell size == 1（unique）の割合
+- per-family_type 分解
+
+`docs/spec/metrics.md` §6 に基づく実装。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.evaluate.rare_cell_metrics import RareCellEvaluator
+from synthpop_jp.optimize.state import PopulationArrays
+
+
+def _build_arrays(persons: list[tuple[str, str, str, int]]) -> PopulationArrays:
+    """テスト用 helper. ``persons = [(family_type, role, sex, age), ...]``.
+
+    各 person は別世帯（household_id を 1 始まりで連番）。家族構造は
+    rare cell では使われない（family_type と age が重要）ため、role / sex は
+    ダミーでも OK。
+    """
+    family_reg = FamilyTypeRegistry()
+    role_reg = RoleRegistry()
+    sex_reg = SexRegistry()
+    seen_ft: set[str] = set()
+    seen_role: set[str] = set()
+    for ft, role, _sex, _age in persons:
+        if ft not in seen_ft:
+            family_reg.register(ft)
+            seen_ft.add(ft)
+        if role not in seen_role:
+            role_reg.register(role)
+            seen_role.add(role)
+    households = [
+        Household(
+            household_id=i + 1,
+            family_type=ft,
+            members=[
+                Person(household_id=i + 1, role=role, sex=sex, age=age)  # type: ignore[arg-type]
+            ],
+        )
+        for i, (ft, role, sex, age) in enumerate(persons)
+    ]
+    return PopulationArrays.from_households(households, family_reg, role_reg, sex_reg)
+
+
+class TestRareCellEvaluatorBasic:
+    """RareCellEvaluator の基本挙動."""
+
+    def test_name_is_rare_cell(self) -> None:
+        """name は 'rare_cell'."""
+        evaluator = RareCellEvaluator()
+        assert evaluator.name == "rare_cell"
+
+    def test_returns_required_keys(self) -> None:
+        """evaluate は最低 4 共通キー + per_family_type 2 キー × N を返す."""
+        arrays = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("single", "single", "F", 28),
+                ("couple", "husband", "M", 40),
+                ("couple", "wife", "F", 38),
+            ]
+        )
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        assert "rare_cell.total_cells" in result
+        assert "rare_cell.fraction_below_5" in result
+        assert "rare_cell.fraction_unique" in result
+        # per_family_type 分解（cells_below_5 と fraction_unique）
+        assert "rare_cell.per_family_type.fraction_below_5.single" in result
+        assert "rare_cell.per_family_type.fraction_below_5.couple" in result
+        assert "rare_cell.per_family_type.fraction_unique.single" in result
+        assert "rare_cell.per_family_type.fraction_unique.couple" in result
+
+
+class TestRareCellEvaluatorMath:
+    """cell カウントの数学的正しさ."""
+
+    def test_all_unique_returns_fraction_unique_one(self) -> None:
+        """全 cell が unique（count == 1）なら fraction_unique = 1.0."""
+        arrays = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("single", "single", "M", 31),
+                ("single", "single", "M", 32),
+                ("single", "single", "M", 33),
+            ]
+        )
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        assert abs(result["rare_cell.fraction_unique"] - 1.0) < 1e-9
+        assert abs(result["rare_cell.fraction_below_5"] - 1.0) < 1e-9
+        assert int(result["rare_cell.total_cells"]) == 4
+
+    def test_single_cell_with_many_returns_zero_unique(self) -> None:
+        """全員同じ cell なら fraction_unique = 0、total_cells = 1."""
+        # 5 人とも (single, age=30) → 1 cell, count=5
+        arrays = _build_arrays([("single", "single", "M", 30) for _ in range(5)])
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        assert abs(result["rare_cell.fraction_unique"] - 0.0) < 1e-9
+        assert abs(result["rare_cell.fraction_below_5"] - 0.0) < 1e-9
+        assert int(result["rare_cell.total_cells"]) == 1
+
+    def test_mixed_cells_compute_correctly(self) -> None:
+        """混在ケース: 2 unique cells + 1 cell-of-5 → fraction = 2/3."""
+        # cell A: (single, 30) × 5 (= cell of 5, NOT < 5)
+        # cell B: (single, 31) × 1 (unique, < 5)
+        # cell C: (couple, 40) × 1 (unique, < 5)
+        persons = [("single", "single", "M", 30) for _ in range(5)]
+        persons.append(("single", "single", "M", 31))
+        persons.append(("couple", "husband", "M", 40))
+        arrays = _build_arrays(persons)
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        # 3 cells total
+        assert int(result["rare_cell.total_cells"]) == 3
+        # 2 cells が < 5: fraction = 2/3
+        assert abs(result["rare_cell.fraction_below_5"] - (2.0 / 3.0)) < 1e-9
+        # 2 cells が unique: fraction = 2/3
+        assert abs(result["rare_cell.fraction_unique"] - (2.0 / 3.0)) < 1e-9
+
+    def test_per_family_type_breakdown(self) -> None:
+        """per family_type 分解: single は全 unique、couple は全 same-cell."""
+        persons = [
+            ("single", "single", "M", 30),
+            ("single", "single", "M", 31),
+            ("single", "single", "M", 32),
+            # couple 5 名: 全員 (couple, age=40) → 1 cell of 5
+            ("couple", "husband", "M", 40),
+            ("couple", "husband", "M", 40),
+            ("couple", "husband", "M", 40),
+            ("couple", "husband", "M", 40),
+            ("couple", "husband", "M", 40),
+        ]
+        arrays = _build_arrays(persons)
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        # single: 3 unique cells / 3 = 1.0
+        assert (
+            abs(result["rare_cell.per_family_type.fraction_unique.single"] - 1.0)
+            < 1e-9
+        )
+        assert (
+            abs(result["rare_cell.per_family_type.fraction_below_5.single"] - 1.0)
+            < 1e-9
+        )
+        # couple: 1 cell, count=5, NOT < 5 → 0.0
+        assert (
+            abs(result["rare_cell.per_family_type.fraction_unique.couple"] - 0.0)
+            < 1e-9
+        )
+        assert (
+            abs(result["rare_cell.per_family_type.fraction_below_5.couple"] - 0.0)
+            < 1e-9
+        )
+
+
+class TestRareCellEvaluatorEdgeCases:
+    """境界条件."""
+
+    def test_empty_population_returns_zero_fractions(self) -> None:
+        """空人口でも 0 除算せず、全 fraction = 0、total_cells = 0."""
+        family_reg = FamilyTypeRegistry()
+        role_reg = RoleRegistry()
+        sex_reg = SexRegistry()
+        empty = PopulationArrays.empty(family_reg, role_reg, sex_reg)
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(empty)
+        assert int(result["rare_cell.total_cells"]) == 0
+        assert abs(result["rare_cell.fraction_below_5"] - 0.0) < 1e-9
+        assert abs(result["rare_cell.fraction_unique"] - 0.0) < 1e-9
+
+    def test_finite_values(self) -> None:
+        """全 fraction 値が有限（NaN / inf でない）."""
+        arrays = _build_arrays(
+            [("single", "single", "M", 30), ("single", "single", "M", 31)]
+        )
+        evaluator = RareCellEvaluator()
+        result = evaluator.evaluate(arrays)
+        for k, v in result.items():
+            assert np.isfinite(v), f"{k} = {v} is not finite"


### PR DESCRIPTION
## 概要

Issue #61。Phase 3.5 の 2 個目の Evaluator として `RareCellEvaluator` を追加し、`evaluate` CLI に組み込んだ。

## 主な変更

- `src/synthpop_jp/evaluate/rare_cell_metrics.py`: `RareCellEvaluator` 実装
  - `(family_type, age)` の cell 集計
  - `rare_cell.total_cells`, `rare_cell.fraction_below_5`, `rare_cell.fraction_unique`
  - per family_type 分解（`rare_cell.per_family_type.*`）
- `src/synthpop_jp/cli.py::evaluate`: AggregateStat と RareCell を両方呼ぶ
- `src/synthpop_jp/evaluate/__init__.py`: RareCellEvaluator を export

## 検証

- 単体テスト 8 件:
  - 全 unique → fraction_unique = 1.0
  - 全同一 cell → fraction_unique = 0.0, total_cells = 1
  - 混在ケースで分子/分母が手計算と一致
  - per family_type 分解が正しく動作
  - 空人口で 0 除算しない
- CLI 統合 1 件: generate→evaluate で rare_cell.* キーが metrics.json に含まれる
- ruff / format / pyright（0 errors）/ pytest 全 450 件 pass

## 非スコープ（後続）

- HTML レポートでの可視化
- improve ループでの soft constraint (Phase 5)
- CAP / TCAP（別 Issue）
- DCR / NNDR / ARD（Phase 4）

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)