### PR TITLE
[#65] 開発者が CAP/TCAP で属性推論リスクを 1 コマンドで把握できるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -594,6 +594,13 @@ def evaluate(
         Path | None,
         typer.Option("--config", help="設定ファイルのパス。省略時は configs/base.yaml を使う。"),
     ] = None,
+    real_persons_csv: Annotated[
+        Path | None,
+        typer.Option(
+            "--real-persons-csv",
+            help="CAP/TCAP 計算に使う real 個票 CSV。省略時は CAP をスキップ。",
+        ),
+    ] = None,
     log_level: Annotated[
         LogLevel,
         typer.Option("--log-level", help="ログレベル。"),
@@ -606,9 +613,10 @@ def evaluate(
 
     - ``AggregateStatL1Evaluator`` (Issue #59): 統計別 L1 誤差
     - ``RareCellEvaluator`` (Issue #61): family_type×age cell の rare/unique 率
+    - ``CAPEvaluator`` (Issue #65): Generalized CAP / TCAP（``--real-persons-csv`` 指定時のみ）
 
-    結果は ``output_dir/metrics.json`` に ``aggregate.l1.*`` および ``rare_cell.*``
-    キーとして追記される。CAP / DCR 等は後続 Issue で追加。
+    結果は ``output_dir/metrics.json`` に ``aggregate.l1.*`` / ``rare_cell.*`` /
+    ``cap.*`` キーとして追記される。
     """
     import json
     import logging
@@ -617,6 +625,7 @@ def evaluate(
 
     from synthpop_jp.config import Settings
     from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+    from synthpop_jp.evaluate.attribute_inference import CAPEvaluator
     from synthpop_jp.evaluate.rare_cell_metrics import RareCellEvaluator
     from synthpop_jp.io.loaders import (
         load_age_diff_couple,
@@ -674,6 +683,19 @@ def evaluate(
         **aggregate_evaluator.evaluate(arrays),
         **rare_cell_evaluator.evaluate(arrays),
     }
+
+    if real_persons_csv is not None:
+        if not real_persons_csv.exists():
+            err_console.print(
+                f"[red]エラー:[/red] --real-persons-csv が見つかりません: {real_persons_csv}"
+            )
+            raise typer.Exit(code=1)
+        console.print(f"[bold]CAP holdout:[/bold] {real_persons_csv}")
+        holdout = reconstruct_population_arrays_from_persons_csv(real_persons_csv)
+        cap_evaluator = CAPEvaluator()
+        metrics.update(cap_evaluator.evaluate(arrays, holdout))
+    else:
+        console.print("[yellow]--real-persons-csv 未指定のため CAP/TCAP はスキップ[/yellow]")
 
     # metrics.json に追記（既存キーは保持）
     metrics_path = settings.output_dir / "metrics.json"

--- a/src/synthpop_jp/evaluate/__init__.py
+++ b/src/synthpop_jp/evaluate/__init__.py
@@ -6,9 +6,12 @@
   (Issue #59): 統計別 L1 誤差レポータ
 - :class:`~synthpop_jp.evaluate.rare_cell_metrics.RareCellEvaluator`
   (Issue #61): (family_type, age) cell の rare/unique 率
+- :class:`~synthpop_jp.evaluate.attribute_inference.CAPEvaluator`
+  (Issue #65): Generalized CAP / TCAP の attribute inference baseline
 """
 
 from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+from synthpop_jp.evaluate.attribute_inference import CAPEvaluator
 from synthpop_jp.evaluate.rare_cell_metrics import RareCellEvaluator
 
-__all__ = ["AggregateStatL1Evaluator", "RareCellEvaluator"]
+__all__ = ["AggregateStatL1Evaluator", "CAPEvaluator", "RareCellEvaluator"]

--- a/src/synthpop_jp/evaluate/attribute_inference.py
+++ b/src/synthpop_jp/evaluate/attribute_inference.py
@@ -1,5 +1,198 @@
-"""Attribute inference baselines: Generalized CAP / TCAP (Phase 3.5 で実装)."""
+"""Attribute inference baselines: Generalized CAP / TCAP (Phase 3.5, Issue #65).
+
+合成人口に対する **属性推論リスク** の baseline 評価器を提供する。
+quasi-identifier ``Q`` から sensitive attribute ``S`` を推定したときの一致確率を
+``synthetic`` と ``holdout``（real 個票）の比較で測る。
+
+`docs/spec/metrics.md` §5.2 / `docs/spec/spec.md` §13.3 に基づく。
+出典: Taub et al. (2018) "Differential Correct Attribution Probability"。
+
+提供するもの
+------------
+- :class:`CAPEvaluator`: ``domain/protocols.py::PrivacyMetric`` Protocol の実装
+
+出力キー命名規則
+----------------
+- ``cap.generalized``: Generalized CAP（0.0–1.0）
+- ``cap.targeted``: TCAP（0.0–1.0）
+- ``cap.coverage``: holdout のうち synthetic でカバーされた person の割合
+- ``cap.per_family_type.generalized.<family_type>``: 属性別 GCAP
+- ``cap.per_family_type.targeted.<family_type>``: 属性別 TCAP
+
+カバレッジに含まれない person（synthetic に同じ Q を持たない person）は
+GCAP / TCAP の分母から除外し、coverage 値で見えるようにする。
+"""
 
 from __future__ import annotations
 
-# TODO: Phase 3.5 で CAP / TCAP を実装する。
+from collections import Counter, defaultdict
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+
+from synthpop_jp.optimize.state import PopulationArrays
+
+if TYPE_CHECKING:
+    from synthpop_jp.domain.protocols import PrivacyLayer
+
+
+_AttrName = Literal["age", "sex", "role", "family_type", "household_id"]
+
+
+def _column(pop: PopulationArrays, name: str) -> np.ndarray:
+    """``PopulationArrays`` から属性配列を名前で引く."""
+    if name == "age":
+        return pop.age
+    if name == "sex":
+        return pop.sex
+    if name == "role":
+        return pop.role
+    if name == "family_type":
+        return pop.family_type
+    if name == "household_id":
+        return pop.household_id
+    raise ValueError(f"Unknown attribute: {name!r}")
+
+
+def _q_keys(pop: PopulationArrays, attrs: tuple[str, ...]) -> list[tuple[int, ...]]:
+    """各 person の Q-キー（属性値タプル）の列を返す."""
+    cols = [_column(pop, a) for a in attrs]
+    n = pop.n_persons
+    return [tuple(int(c[i]) for c in cols) for i in range(n)]
+
+
+class CAPEvaluator:
+    """Generalized CAP / TCAP の Evaluator（``PrivacyMetric`` Protocol 実装）.
+
+    ``synthetic`` から得られる ``P(S | Q=q)`` と ``holdout`` の真値 ``S`` の
+    一致確率を計算する。属性推論攻撃の成功率を 1 数値で要約した指標。
+
+    Attributes
+    ----------
+    name : str
+        ``"cap"`` 固定。``metrics.json`` のキー prefix。
+    layer : PrivacyLayer
+        ``"attribute_inference"`` 固定。spec §13.3 の中段に対応。
+    quasi_identifiers : tuple[str, ...]
+        Q として使う属性名のタプル。デフォルトは ``("family_type", "sex")``。
+    sensitive : str
+        S として使う属性名。デフォルトは ``"age"``。
+
+    Notes
+    -----
+    Generalized CAP は holdout の各 person について
+    ``synthetic`` 内で同じ Q を持つ部分集合の S 分布から該当 S 値の出現確率を取り、
+    それを holdout 全体で平均する。
+    TCAP は synthetic の同 Q 部分集合の最頻 S が holdout の S と一致する割合
+    （0/1 の平均）。
+
+    holdout に存在するが synthetic には存在しない Q の person は
+    分母から除外し、``cap.coverage`` で見える化する。
+    """
+
+    name: str = "cap"
+    layer: PrivacyLayer = "attribute_inference"
+
+    def __init__(
+        self,
+        quasi_identifiers: tuple[str, ...] = ("family_type", "sex"),
+        sensitive: str = "age",
+    ) -> None:
+        self.quasi_identifiers = quasi_identifiers
+        self.sensitive = sensitive
+
+    def evaluate(
+        self,
+        synthetic: PopulationArrays,
+        holdout: PopulationArrays,
+    ) -> dict[str, float]:
+        """Generalized CAP / TCAP / coverage を計算する.
+
+        Parameters
+        ----------
+        synthetic : PopulationArrays
+            合成人口（攻撃者が観測する公開データ）.
+        holdout : PopulationArrays
+            real 個票（攻撃の正解データ）.
+
+        Returns
+        -------
+        dict[str, float]
+            ``cap.*`` キーを含む dict。空人口でも 0 除算しない。
+        """
+        result: dict[str, float] = {}
+
+        # 全体スコア
+        gcap, tcap, coverage = self._scores(synthetic, holdout)
+        result["cap.generalized"] = gcap
+        result["cap.targeted"] = tcap
+        result["cap.coverage"] = coverage
+
+        # per family_type 分解（holdout に存在する family_type 全てを出す）
+        for ft_name in holdout.family_reg.all_names():
+            ft_id = holdout.family_reg.id_of(ft_name)
+            mask = holdout.family_type == ft_id
+            ft_holdout = self._slice(holdout, mask)
+            ft_gcap, ft_tcap, _coverage = self._scores(synthetic, ft_holdout)
+            result[f"cap.per_family_type.generalized.{ft_name}"] = ft_gcap
+            result[f"cap.per_family_type.targeted.{ft_name}"] = ft_tcap
+
+        return result
+
+    def _scores(
+        self,
+        synthetic: PopulationArrays,
+        holdout: PopulationArrays,
+    ) -> tuple[float, float, float]:
+        """``(gcap, tcap, coverage)`` を返す内部実装."""
+        n_holdout = holdout.n_persons
+        if n_holdout == 0 or synthetic.n_persons == 0:
+            return 0.0, 0.0, 0.0
+
+        # synthetic 内で Q ごとの S 分布を集計
+        q_synth = _q_keys(synthetic, self.quasi_identifiers)
+        s_synth_arr = _column(synthetic, self.sensitive)
+        s_dist: dict[tuple[int, ...], Counter[int]] = defaultdict(Counter)
+        for i, q in enumerate(q_synth):
+            s_dist[q][int(s_synth_arr[i])] += 1
+
+        # synthetic 内 mode のキャッシュ（TCAP 用）
+        s_mode: dict[tuple[int, ...], int] = {
+            q: counter.most_common(1)[0][0] for q, counter in s_dist.items()
+        }
+
+        # holdout 各 person について GCAP / TCAP を集計
+        q_hold = _q_keys(holdout, self.quasi_identifiers)
+        s_hold_arr = _column(holdout, self.sensitive)
+        gcap_sum = 0.0
+        tcap_sum = 0
+        covered = 0
+        for i, q in enumerate(q_hold):
+            counter = s_dist.get(q)
+            if counter is None:
+                continue
+            covered += 1
+            total = sum(counter.values())
+            s_true = int(s_hold_arr[i])
+            gcap_sum += counter.get(s_true, 0) / total
+            if s_mode[q] == s_true:
+                tcap_sum += 1
+
+        coverage = covered / n_holdout
+        if covered == 0:
+            return 0.0, 0.0, coverage
+        return gcap_sum / covered, tcap_sum / covered, coverage
+
+    @staticmethod
+    def _slice(pop: PopulationArrays, mask: np.ndarray) -> PopulationArrays:
+        """``mask`` で絞った部分人口を返す（registry は共有）."""
+        return PopulationArrays(
+            age=pop.age[mask],
+            sex=pop.sex[mask],
+            role=pop.role[mask],
+            household_id=pop.household_id[mask],
+            family_type=pop.family_type[mask],
+            _family_reg=pop.family_reg,
+            _role_reg=pop.role_reg,
+            _sex_reg=pop.sex_reg,
+        )

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -103,3 +103,55 @@ class TestEvaluateIntegration:
         eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
         assert eval_result.exit_code == 1
         assert "synthetic_persons.csv" in eval_result.output
+
+    def test_evaluate_skips_cap_without_real_persons_csv(self, tmp_path: Path) -> None:
+        """``--real-persons-csv`` 未指定時は ``cap.*`` が含まれず、警告が出る（Issue #65）."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert not any(k.startswith("cap.") for k in metrics)
+        assert "CAP" in eval_result.output or "cap" in eval_result.output.lower()
+
+    def test_evaluate_appends_cap_keys_with_real_persons_csv(self, tmp_path: Path) -> None:
+        """``--real-persons-csv`` を指定すると ``cap.*`` キーが追記される（Issue #65）."""
+        config_path = _make_config_yaml(tmp_path)
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+        # synthetic を holdout 代わりに使う（self-eval だが CLI 動作確認には十分）
+        synthetic_csv = tmp_path / "out" / "synthetic_persons.csv"
+        eval_result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                "--config",
+                str(config_path),
+                "--real-persons-csv",
+                str(synthetic_csv),
+            ],
+        )
+        assert eval_result.exit_code == 0, eval_result.output
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert "cap.generalized" in metrics
+        assert "cap.targeted" in metrics
+        assert "cap.coverage" in metrics
+        # holdout = synthetic なので perfect coverage
+        assert abs(metrics["cap.coverage"] - 1.0) < 1e-9
+
+    def test_evaluate_fails_with_missing_real_persons_csv(self, tmp_path: Path) -> None:
+        """``--real-persons-csv`` のパスが無ければ exit code 1（Issue #65）."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        eval_result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                "--config",
+                str(config_path),
+                "--real-persons-csv",
+                str(tmp_path / "does_not_exist.csv"),
+            ],
+        )
+        assert eval_result.exit_code == 1
+        assert "real-persons-csv" in eval_result.output

--- a/tests/evaluate/test_attribute_inference.py
+++ b/tests/evaluate/test_attribute_inference.py
@@ -1,0 +1,249 @@
+"""Tests for CAPEvaluator (Phase 3.5, Issue #65).
+
+Generalized CAP / TCAP の baseline 評価器。
+
+`docs/spec/metrics.md` §5.2 / Taub et al. (2018) に基づく。
+quasi-identifier `Q` から sensitive attribute `S` を推定したときの一致確率を測る。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from synthpop_jp.domain.household import Household
+from synthpop_jp.domain.person import Person
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.evaluate.attribute_inference import CAPEvaluator
+from synthpop_jp.optimize.state import PopulationArrays
+
+
+def _build_arrays(persons: list[tuple[str, str, str, int]]) -> PopulationArrays:
+    """テスト用 helper. ``persons = [(family_type, role, sex, age), ...]``.
+
+    各 person は別世帯（household_id を 1 始まりで連番）。
+    """
+    family_reg = FamilyTypeRegistry()
+    role_reg = RoleRegistry()
+    sex_reg = SexRegistry()
+    seen_ft: set[str] = set()
+    seen_role: set[str] = set()
+    for ft, role, _sex, _age in persons:
+        if ft not in seen_ft:
+            family_reg.register(ft)
+            seen_ft.add(ft)
+        if role not in seen_role:
+            role_reg.register(role)
+            seen_role.add(role)
+    households = [
+        Household(
+            household_id=i + 1,
+            family_type=ft,
+            members=[
+                Person(household_id=i + 1, role=role, sex=sex, age=age)  # type: ignore[arg-type]
+            ],
+        )
+        for i, (ft, role, sex, age) in enumerate(persons)
+    ]
+    return PopulationArrays.from_households(households, family_reg, role_reg, sex_reg)
+
+
+def _empty_arrays() -> PopulationArrays:
+    return PopulationArrays.empty(FamilyTypeRegistry(), RoleRegistry(), SexRegistry())
+
+
+class TestCAPEvaluatorBasic:
+    """CAPEvaluator の基本属性."""
+
+    def test_name_is_cap(self) -> None:
+        """name は 'cap'."""
+        evaluator = CAPEvaluator()
+        assert evaluator.name == "cap"
+
+    def test_layer_is_attribute_inference(self) -> None:
+        """layer は 'attribute_inference'."""
+        evaluator = CAPEvaluator()
+        assert evaluator.layer == "attribute_inference"
+
+    def test_returns_required_keys(self) -> None:
+        """evaluate は generalized / targeted / coverage を返す."""
+        synthetic = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "husband", "M", 40),
+            ]
+        )
+        holdout = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "husband", "M", 40),
+            ]
+        )
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        assert "cap.generalized" in result
+        assert "cap.targeted" in result
+        assert "cap.coverage" in result
+
+
+class TestCAPEvaluatorMath:
+    """CAP / TCAP の数学的正しさ."""
+
+    def test_identical_populations_give_perfect_cap(self) -> None:
+        """holdout = synthetic なら GCAP = TCAP = 1.0、coverage = 1.0."""
+        persons = [
+            ("single", "single", "M", 30),
+            ("single", "single", "F", 25),
+            ("couple", "husband", "M", 40),
+            ("couple", "wife", "F", 38),
+        ]
+        synthetic = _build_arrays(persons)
+        holdout = _build_arrays(persons)
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        # Q = (family_type, sex), S = age. 各 (ft, sex) に対し holdout の age が 1 つ
+        # synthetic 内も同じ 1 つしかないので一致確率 = 1.0
+        assert abs(result["cap.generalized"] - 1.0) < 1e-9
+        assert abs(result["cap.targeted"] - 1.0) < 1e-9
+        assert abs(result["cap.coverage"] - 1.0) < 1e-9
+
+    def test_deterministic_mapping_gives_targeted_one(self) -> None:
+        """Q から S が一意に決まれば TCAP = 1.0."""
+        # Q = (single, M) → S=30 ばかり
+        # Q = (couple, F) → S=40 ばかり
+        synthetic = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("single", "single", "M", 30),
+                ("couple", "wife", "F", 40),
+                ("couple", "wife", "F", 40),
+            ]
+        )
+        holdout = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "wife", "F", 40),
+            ]
+        )
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        assert abs(result["cap.targeted"] - 1.0) < 1e-9
+        assert abs(result["cap.generalized"] - 1.0) < 1e-9
+        assert abs(result["cap.coverage"] - 1.0) < 1e-9
+
+    def test_uniform_sensitive_gives_low_cap(self) -> None:
+        """Q を全員同じ、S を一様に異ならせると GCAP は低い."""
+        # synthetic: Q=(single, M) で age が 4 種
+        synthetic = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("single", "single", "M", 31),
+                ("single", "single", "M", 32),
+                ("single", "single", "M", 33),
+            ]
+        )
+        # holdout: 同じ Q で age=30 のみ
+        holdout = _build_arrays([("single", "single", "M", 30)])
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        # 同 Q 内で age=30 は 1/4 だけ → GCAP = 0.25
+        assert abs(result["cap.generalized"] - 0.25) < 1e-9
+        # TCAP: 最頻値が 30 とは限らない（全部 1 つずつなので最頻値は最初の 30）
+        # 実装に依存するが、この場合 30 が最頻値になりうる→ 1.0、または別なら 0.0
+        # ここでは曖昧さを避けるため検証スキップ
+        assert abs(result["cap.coverage"] - 1.0) < 1e-9
+
+    def test_coverage_when_holdout_q_missing_in_synthetic(self) -> None:
+        """synthetic に無い Q が holdout にあると coverage < 1.0."""
+        synthetic = _build_arrays([("single", "single", "M", 30)])
+        # holdout に couple が含まれるが synthetic には無い
+        holdout = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "wife", "F", 40),
+            ]
+        )
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        # coverage = 1/2
+        assert abs(result["cap.coverage"] - 0.5) < 1e-9
+        # 該当 person は CAP 計算の分母から除外されるので、carry-over は 1.0
+        assert abs(result["cap.generalized"] - 1.0) < 1e-9
+        assert abs(result["cap.targeted"] - 1.0) < 1e-9
+
+    def test_per_family_type_breakdown(self) -> None:
+        """per_family_type 分解キーが揃う."""
+        synthetic = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "wife", "F", 40),
+            ]
+        )
+        holdout = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "wife", "F", 40),
+            ]
+        )
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        assert "cap.per_family_type.generalized.single" in result
+        assert "cap.per_family_type.generalized.couple" in result
+        assert "cap.per_family_type.targeted.single" in result
+        assert "cap.per_family_type.targeted.couple" in result
+        # 同一なので各 1.0
+        assert abs(result["cap.per_family_type.generalized.single"] - 1.0) < 1e-9
+        assert abs(result["cap.per_family_type.targeted.couple"] - 1.0) < 1e-9
+
+
+class TestCAPEvaluatorEdgeCases:
+    """境界条件."""
+
+    def test_empty_holdout_returns_zero(self) -> None:
+        """holdout が空なら全メトリクス 0.0、例外なし."""
+        synthetic = _build_arrays([("single", "single", "M", 30)])
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, _empty_arrays())
+        assert abs(result["cap.generalized"] - 0.0) < 1e-9
+        assert abs(result["cap.targeted"] - 0.0) < 1e-9
+        assert abs(result["cap.coverage"] - 0.0) < 1e-9
+
+    def test_empty_synthetic_returns_zero_coverage(self) -> None:
+        """synthetic が空なら coverage = 0.0、CAP は 0.0（分母なし）."""
+        holdout = _build_arrays([("single", "single", "M", 30)])
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(_empty_arrays(), holdout)
+        assert abs(result["cap.coverage"] - 0.0) < 1e-9
+        assert abs(result["cap.generalized"] - 0.0) < 1e-9
+        assert abs(result["cap.targeted"] - 0.0) < 1e-9
+
+    def test_finite_values(self) -> None:
+        """全 fraction 値が有限."""
+        synthetic = _build_arrays([("single", "single", "M", 30), ("couple", "wife", "F", 40)])
+        holdout = _build_arrays([("single", "single", "M", 30), ("couple", "wife", "F", 41)])
+        evaluator = CAPEvaluator()
+        result = evaluator.evaluate(synthetic, holdout)
+        for k, v in result.items():
+            assert np.isfinite(v), f"{k} = {v} is not finite"
+
+
+class TestCAPEvaluatorCustomQS:
+    """quasi-identifier / sensitive を constructor で変更できる."""
+
+    def test_custom_quasi_identifier_role_only(self) -> None:
+        """Q = (role,) のみで CAP を計算できる."""
+        synthetic = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "husband", "M", 40),
+            ]
+        )
+        holdout = _build_arrays(
+            [
+                ("single", "single", "M", 30),
+                ("couple", "husband", "M", 40),
+            ]
+        )
+        evaluator = CAPEvaluator(quasi_identifiers=("role",), sensitive="age")
+        result = evaluator.evaluate(synthetic, holdout)
+        # 同一なので perfect CAP
+        assert abs(result["cap.generalized"] - 1.0) < 1e-9


### PR DESCRIPTION
## 背景

合成人口の秘匿性は spec §13.3 で 3 層構造（proxy / 属性推論 / shadow MIA）と定義されている。Phase 3.5 までで proxy 寄り（aggregate L1, rare cell）は揃ったが、**属性推論 baseline** が空白だった。Issue #65 はこのギャップを埋める。

Closes #65

## この変更で提供する価値

開発者が `synthpop-jp evaluate --real-persons-csv <real.csv>` を実行すると、合成人口に対する **Generalized CAP / TCAP** が `metrics.json` に書き出される。quasi-identifier から sensitive attribute を推定する攻撃を想定したとき、合成人口がどれくらい本物個票の漏洩源になるかを 1 数値で把握できる。

## 変更内容

- `src/synthpop_jp/evaluate/attribute_inference.py`: `CAPEvaluator` を実装（`PrivacyMetric` Protocol 準拠、`layer="attribute_inference"`）
- `src/synthpop_jp/evaluate/__init__.py`: `CAPEvaluator` を export
- `src/synthpop_jp/cli.py`: `evaluate` サブコマンドに `--real-persons-csv` オプションを追加（指定時のみ CAP 計算、未指定なら警告して既存挙動維持）
- `tests/evaluate/test_attribute_inference.py`: 単体 12 件
- `tests/cli/test_evaluate.py`: CLI 統合 3 件追加

### 出力キー

- `cap.generalized` / `cap.targeted` / `cap.coverage`
- `cap.per_family_type.generalized.<ft>` / `cap.per_family_type.targeted.<ft>`

quasi-identifier デフォルト `("family_type", "sex")`、sensitive デフォルト `"age"`。constructor 引数で差し替え可能。

## 影響範囲

- 変更モジュール: `evaluate/`, `cli.py`
- 他モジュールへの影響: なし（新規 CSV 引数は省略可、既存 evaluate 動作は維持）
- 既存 API の互換性: 維持（`--real-persons-csv` 未指定時は従来通り aggregate + rare_cell のみ）
- 依存関係の変化: なし

## テスト

- 追加テスト: 15 件（単体 12 + CLI 3）
- 変更テスト: 0
- カバレッジ: 維持（`attribute_inference.py` は新規）
- 手動確認: 単体 + CLI 統合で完全カバー

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
107 files already formatted

$ uv run pyright
0 errors, 13 warnings, 0 informations  (warnings は既存の pandas stub のみ)

$ uv run pytest
465 passed, 10 skipped in 18.72s
```

</details>

## レビュー時に確認してほしい点

1. `PrivacyMetric` Protocol を選択した妥当性（`Evaluator` ではなく holdout を取る Protocol を新規実装する形）
2. `--real-persons-csv` 未指定時の警告メッセージで CAP をスキップする UX
3. coverage の解釈（カバレッジ外 person を分母から除外する選択）— Differential CAP との整合性は次 Issue で

## 関連

- Issue #65（本 PR）
- spec §5.2, §13.3
- Issue 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/65#issuecomment-4340903422
- 自己レビューコメント: https://github.com/gghatano/synth-pop-harada-2024/issues/65#issuecomment-4340934217

🤖 Generated with [Claude Code](https://claude.com/claude-code)