### PR TITLE
[#69] 開発者が hybrid 遷移の p_change を SA 進行に応じて変えられるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -338,7 +338,9 @@ def generate(
     from synthpop_jp.optimize.transitions import (
         AgeChangeTransition,
         AgeSwapTransition,
+        ConstantPChange,
         HybridTransition,
+        LinearPChange,
     )
     from synthpop_jp.rng import SeedRegistry
 
@@ -477,10 +479,20 @@ def generate(
             rng=seed_reg.rng("sa_swap"),
             demo_ft_role=demographic_by_family_type_role,
         )
+        schedule: ConstantPChange | LinearPChange
+        if annealing_cfg.p_change_schedule == "linear":
+            # validator が p_change_end != None を保証している
+            assert annealing_cfg.p_change_end is not None
+            schedule = LinearPChange(
+                start=annealing_cfg.p_change,
+                end=annealing_cfg.p_change_end,
+            )
+        else:
+            schedule = ConstantPChange(annealing_cfg.p_change)
         transition = HybridTransition(
             change=change,
             swap=swap,
-            p_change=annealing_cfg.p_change,
+            p_change=schedule,
             rng=seed_reg.rng("sa_hybrid_chooser"),
         )
     else:

--- a/src/synthpop_jp/config.py
+++ b/src/synthpop_jp/config.py
@@ -68,11 +68,19 @@ class AnnealingConfig(BaseModel):
         ``"hybrid"`` は §12.2C（Issue #67、p_change/p_swap で混合）。
         デフォルト ``"age-change"``。
     p_change : float
-        ``transition_kind == "hybrid"`` で AgeChange を選ぶ確率。
-        デフォルト 0.7。``p_change + p_swap == 1.0`` が必要。
+        hybrid 時に AgeChange を選ぶ確率（schedule が constant のとき）または
+        linear schedule の **始端**。デフォルト 0.7。
     p_swap : float
-        ``transition_kind == "hybrid"`` で AgeSwap を選ぶ確率。
-        デフォルト 0.3。
+        constant schedule で AgeSwap を選ぶ確率。デフォルト 0.3。
+        constant 時のみ ``p_change + p_swap == 1.0`` が要求される。
+    p_change_schedule : Literal["constant", "linear"]
+        hybrid の p_change を反復進行に応じてどう変えるか（Issue #69）。
+        ``"constant"`` は ``p_change`` を常に使う（既存挙動）。
+        ``"linear"`` は ``p_change`` から ``p_change_end`` まで線形補間する。
+        デフォルト ``"constant"``。
+    p_change_end : float | None
+        ``p_change_schedule == "linear"`` で終端の p_change を指定する。
+        linear のときは必須。constant では無視。
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -90,6 +98,8 @@ class AnnealingConfig(BaseModel):
     transition_kind: Literal["age-change", "age-swap", "hybrid"] = "age-change"
     p_change: float = 0.7
     p_swap: float = 0.3
+    p_change_schedule: Literal["constant", "linear"] = "constant"
+    p_change_end: float | None = None
 
     @field_validator("T0")
     @classmethod
@@ -111,25 +121,43 @@ class AnnealingConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_hybrid_probabilities(self) -> AnnealingConfig:
-        """``transition_kind == "hybrid"`` のとき p_change/p_swap を検証する.
+        """``transition_kind == "hybrid"`` のとき p_change 関連を検証する.
 
-        - 両者とも ``[0.0, 1.0]`` の範囲
-        - 和が 1.0 (許容誤差 1e-6)
+        - p_change は ``[0.0, 1.0]`` の範囲（schedule に依らず必須）
+        - constant: ``p_change + p_swap == 1.0`` (許容誤差 1e-6)
+        - linear: ``p_change_end`` が指定され ``[0.0, 1.0]`` の範囲
 
         非 hybrid のときは検証しない（デフォルト値が残っても受理）。
         """
-        if self.transition_kind == "hybrid":
-            if not (0.0 <= self.p_change <= 1.0) or not (0.0 <= self.p_swap <= 1.0):
+        if self.transition_kind != "hybrid":
+            return self
+
+        if not (0.0 <= self.p_change <= 1.0):
+            msg = f"hybrid 遷移では p_change を [0.0, 1.0] にしてください (got {self.p_change})"
+            raise ValueError(msg)
+
+        if self.p_change_schedule == "constant":
+            if not (0.0 <= self.p_swap <= 1.0):
                 msg = (
-                    "hybrid 遷移では p_change と p_swap を [0.0, 1.0] にしてください "
-                    f"(p_change={self.p_change}, p_swap={self.p_swap})"
+                    "constant schedule では p_swap を [0.0, 1.0] にしてください "
+                    f"(p_swap={self.p_swap})"
                 )
                 raise ValueError(msg)
             total = self.p_change + self.p_swap
             if abs(total - 1.0) > 1e-6:
                 msg = (
-                    "hybrid 遷移では p_change + p_swap == 1.0 が必要です "
+                    "constant schedule では p_change + p_swap == 1.0 が必要です "
                     f"(p_change={self.p_change}, p_swap={self.p_swap}, sum={total})"
+                )
+                raise ValueError(msg)
+        elif self.p_change_schedule == "linear":
+            if self.p_change_end is None:
+                msg = "linear schedule では p_change_end の指定が必須です"
+                raise ValueError(msg)
+            if not (0.0 <= self.p_change_end <= 1.0):
+                msg = (
+                    "linear schedule では p_change_end を [0.0, 1.0] にしてください "
+                    f"(p_change_end={self.p_change_end})"
                 )
                 raise ValueError(msg)
         return self

--- a/src/synthpop_jp/optimize/annealing.py
+++ b/src/synthpop_jp/optimize/annealing.py
@@ -408,6 +408,13 @@ class SARunner:
         # 最大反復回数
         max_iters = config.max_iters if config.max_iters > 0 else int(1e18)
 
+        # hybrid schedule の進行基準（Issue #69）。
+        # eval_limit > 0 ならそちらが先に止まることが多いので、終端基準としては
+        # min(max_iters, eval_limit) を採用する（0 は無効値として除外）。
+        schedule_total = max_iters
+        if eval_limit > 0:
+            schedule_total = min(schedule_total, eval_limit)
+
         # trace writer の準備
         use_trace = config.trace_enabled and trace_path is not None
         log_every = config.log_every_n_iters if config.log_every_n_iters > 0 else 1
@@ -455,6 +462,11 @@ class SARunner:
 
                     # 温度取得
                     temperature = cooling.get_temperature(iter_n)
+
+                    # hybrid schedule に進行を渡す（Issue #69）。
+                    # constant schedule なら影響なし、linear のときに p_change を更新する。
+                    if isinstance(transition, HybridTransition):
+                        transition.set_progress(iter_n, schedule_total)
 
                     # 遷移提案（ハード制約違反で TransitionError が起きたらスキップ）
                     # isinstance で型ガードし、delta + apply_callback を 1 経路で組み立てる

--- a/src/synthpop_jp/optimize/transitions.py
+++ b/src/synthpop_jp/optimize/transitions.py
@@ -10,6 +10,9 @@
 - ``HybridTransition``: §12.2C. ``AgeChangeTransition`` と ``AgeSwapTransition`` を
   確率 ``p_change`` / ``1 - p_change`` で混合する遷移（Phase 3a, Issue #67）。
   SA loop 側は ``hybrid.choose()`` で内部 transition を取り出し既存ロジックを再利用する。
+- ``ConstantPChange`` / ``LinearPChange``: ``HybridTransition`` の p_change を
+  反復進行に応じて動的に変えるスケジュール（Phase 3a, Issue #69）。
+  SA loop 側は ``hybrid.set_progress(iter, total)`` で進行を渡す。
 
 ハード制約一覧（両遷移で共通）
 ------------------------------
@@ -652,6 +655,62 @@ def _compute_dynamic_constraints(arrays: PopulationArrays) -> tuple[np.ndarray, 
 # ---------------------------------------------------------------------------
 
 
+class ConstantPChange:
+    """``HybridTransition`` 用の固定 p_change スケジュール (Issue #69).
+
+    SA 反復に依らず常に同じ ``p`` を返す。``HybridTransition`` の constructor で
+    float が渡されたとき自動で本クラスに wrap される（後方互換性）。
+    """
+
+    def __init__(self, p: float) -> None:
+        if not (0.0 <= p <= 1.0):
+            msg = f"p は [0.0, 1.0] の範囲でなければなりません (got {p})"
+            raise ValueError(msg)
+        self._p = float(p)
+
+    def p_change_at(self, iter: int, total: int) -> float:
+        """SA 反復 ``iter`` / ``total`` のとき p_change を返す（常に固定値）."""
+        del iter, total  # constant schedule では使わない（共通 API 維持のため受ける）
+        return self._p
+
+
+class LinearPChange:
+    """``HybridTransition`` 用の線形補間 p_change スケジュール (Issue #69).
+
+    SA の進行率 ``iter / total`` に応じて ``start`` から ``end`` まで線形に変化する。
+    spec §12.2C 後半（初期 age-change 厚め → 後半 age-swap 厚め）を表現する。
+
+    Parameters
+    ----------
+    start : float
+        ``iter == 0`` での p_change（[0.0, 1.0]）。
+    end : float
+        ``iter >= total`` での p_change（[0.0, 1.0]）。
+
+    Notes
+    -----
+    ``iter > total`` の場合は ``end`` にクランプする（SA が想定より長く回るときの保護）。
+    ``total <= 0`` のときは ``start`` を返す（割り算回避）。
+    """
+
+    def __init__(self, start: float, end: float) -> None:
+        if not (0.0 <= start <= 1.0):
+            msg = f"start は [0.0, 1.0] の範囲でなければなりません (got {start})"
+            raise ValueError(msg)
+        if not (0.0 <= end <= 1.0):
+            msg = f"end は [0.0, 1.0] の範囲でなければなりません (got {end})"
+            raise ValueError(msg)
+        self._start = float(start)
+        self._end = float(end)
+
+    def p_change_at(self, iter: int, total: int) -> float:
+        """進行率 ``min(iter/total, 1.0)`` で start ↔ end を線形補間する."""
+        if total <= 0:
+            return self._start
+        t = min(iter / total, 1.0)
+        return self._start + (self._end - self._start) * t
+
+
 class HybridTransition:
     """``AgeChangeTransition`` と ``AgeSwapTransition`` の確率混合遷移.
 
@@ -666,36 +725,54 @@ class HybridTransition:
         age-change 遷移インスタンス。
     swap : AgeSwapTransition
         age-swap 遷移インスタンス。
-    p_change : float
-        AgeChange を選ぶ確率 (0.0–1.0)。残りが AgeSwap の確率。
+    p_change : float | ConstantPChange | LinearPChange
+        AgeChange を選ぶ確率。``float`` を渡すと ``ConstantPChange`` に wrap される
+        （後方互換）。schedule オブジェクトを渡すと SA の進行に応じて動的に変化する。
     rng : np.random.Generator
         どちらを選ぶかの乱数源（SeedRegistry の独立 stream を渡す）。
 
     Raises
     ------
     ValueError
-        ``p_change`` が ``[0.0, 1.0]`` の範囲外のとき。
+        ``p_change`` が ``float`` のとき ``[0.0, 1.0]`` の範囲外。
 
     Notes
     -----
-    動的スケジュール（反復に応じた p_change 変化）は spec §12.2C で示唆されているが
-    本実装では固定確率のみ。スケジュール対応は後続 Issue で。
+    動的スケジュールを使うときは SA loop が反復ごとに ``set_progress(iter, total)``
+    を呼ぶ前提（Issue #69）。``set_progress`` を呼ばないと初期値（``iter=0, total=1``）で
+    schedule が評価される。固定確率（``ConstantPChange``）は呼ばれなくても影響なし。
     """
 
     def __init__(
         self,
         change: AgeChangeTransition,
         swap: AgeSwapTransition,
-        p_change: float,
+        p_change: float | ConstantPChange | LinearPChange,
         rng: np.random.Generator,
     ) -> None:
-        if not (0.0 <= p_change <= 1.0):
-            msg = f"p_change は [0.0, 1.0] の範囲でなければなりません (got {p_change})"
-            raise ValueError(msg)
+        if isinstance(p_change, (int, float)):
+            self._schedule: ConstantPChange | LinearPChange = ConstantPChange(float(p_change))
+        else:
+            self._schedule = p_change
         self._change = change
         self._swap = swap
-        self._p_change = float(p_change)
         self._rng = rng
+        # 進行状態（set_progress で更新）。schedule が constant なら影響なし。
+        self._iter = 0
+        self._total = 1
+
+    def set_progress(self, iter: int, total: int) -> None:
+        """SA loop が毎反復呼んで進行状態を更新する.
+
+        Parameters
+        ----------
+        iter : int
+            現在の SA 反復インデックス（0-indexed）。
+        total : int
+            停止条件の最大反復数（schedule の終端基準）。
+        """
+        self._iter = int(iter)
+        self._total = int(total)
 
     def choose(self) -> AgeChangeTransition | AgeSwapTransition:
         """乱数で AgeChange / AgeSwap のどちらか 1 つを返す.
@@ -704,7 +781,9 @@ class HybridTransition:
         -------
         AgeChangeTransition | AgeSwapTransition
             各呼び出し時点で確率的に選ばれる内部 transition。
+            schedule が動的なら ``set_progress`` で渡された ``(iter, total)`` を反映する。
         """
-        if self._rng.uniform() < self._p_change:
+        p = self._schedule.p_change_at(self._iter, self._total)
+        if self._rng.uniform() < p:
             return self._change
         return self._swap

--- a/tests/cli/test_generate.py
+++ b/tests/cli/test_generate.py
@@ -319,3 +319,28 @@ class TestGenerateHybridTransition:
         assert result.exit_code == 0, result.output
         assert (tmp_path / "out" / "synthetic_persons.csv").exists()
         assert (tmp_path / "out" / "metrics.json").exists()
+
+    def test_hybrid_linear_schedule_runs(self, tmp_path: Path) -> None:
+        """linear schedule の hybrid config で generate が exit 0 で完走する (Issue #69)."""
+        config_data: dict[str, object] = {
+            "seed": 42,
+            "input_dir": str(SAMPLE_CASE_DIR),
+            "output_dir": str(tmp_path / "out"),
+            "annealing": {
+                "T0": 100.0,
+                "alpha": 0.99,
+                "max_iters": 200,
+                "evals_per_agent": 0,
+                "target_threshold": 0.0,
+                "patience": 0,
+                "transition_kind": "hybrid",
+                "p_change_schedule": "linear",
+                "p_change": 0.9,
+                "p_change_end": 0.3,
+            },
+        }
+        config_path = tmp_path / "config_hybrid_linear.yaml"
+        config_path.write_text(yaml.dump(config_data))
+        result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert result.exit_code == 0, result.output + str(result.exception or "")
+        assert (tmp_path / "out" / "synthetic_persons.csv").exists()

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -102,3 +102,54 @@ class TestAnnealingConfigHybrid:
         """age-change で p_change + p_swap != 1.0 でも validator は通る."""
         cfg = AnnealingConfig(transition_kind="age-change", p_change=0.1, p_swap=0.1)
         assert cfg.transition_kind == "age-change"
+
+
+class TestAnnealingConfigHybridSchedule:
+    """hybrid の動的 p_change スケジュール validator (Issue #69)."""
+
+    def test_default_schedule_is_constant(self) -> None:
+        """p_change_schedule の default は constant."""
+        cfg = AnnealingConfig(transition_kind="hybrid")
+        assert cfg.p_change_schedule == "constant"
+        assert cfg.p_change_end is None
+
+    def test_linear_with_p_change_end_is_valid(self) -> None:
+        """linear + p_change_end が指定されていれば valid."""
+        cfg = AnnealingConfig(
+            transition_kind="hybrid",
+            p_change_schedule="linear",
+            p_change=0.9,
+            p_change_end=0.3,
+        )
+        assert cfg.p_change_schedule == "linear"
+        assert cfg.p_change_end == 0.3
+
+    def test_linear_without_p_change_end_rejected(self) -> None:
+        """linear で p_change_end が None なら ValidationError."""
+        with pytest.raises(ValidationError):
+            AnnealingConfig(
+                transition_kind="hybrid",
+                p_change_schedule="linear",
+                p_change=0.9,
+                # p_change_end 省略
+            )
+
+    def test_linear_with_p_change_end_out_of_range_rejected(self) -> None:
+        """p_change_end が [0,1] 外ならば ValidationError."""
+        with pytest.raises(ValidationError):
+            AnnealingConfig(
+                transition_kind="hybrid",
+                p_change_schedule="linear",
+                p_change=0.5,
+                p_change_end=1.5,
+            )
+
+    def test_constant_schedule_uses_existing_validator(self) -> None:
+        """constant スケジュールでは既存の sum=1.0 検証が働く."""
+        with pytest.raises(ValidationError):
+            AnnealingConfig(
+                transition_kind="hybrid",
+                p_change_schedule="constant",
+                p_change=0.5,
+                p_swap=0.6,
+            )

--- a/tests/optimize/test_transitions.py
+++ b/tests/optimize/test_transitions.py
@@ -23,7 +23,9 @@ from synthpop_jp.optimize.state import PopulationArrays
 from synthpop_jp.optimize.transitions import (
     AgeChangeTransition,
     AgeSwapTransition,
+    ConstantPChange,
     HybridTransition,
+    LinearPChange,
     TransitionError,
     build_role_age_dist,
 )
@@ -899,3 +901,80 @@ class TestHybridTransitionInvalidProbability:
             HybridTransition(change=change, swap=swap, p_change=1.5, rng=rng)
         with pytest.raises(ValueError):
             HybridTransition(change=change, swap=swap, p_change=-0.1, rng=rng)
+
+
+# ---------------------------------------------------------------------------
+# PChangeSchedule (Issue #69) — 動的 p_change スケジュール
+# ---------------------------------------------------------------------------
+
+
+class TestConstantPChange:
+    """ConstantPChange は iter/total に依らず固定値を返す."""
+
+    def test_constant_returns_p_for_any_iter(self) -> None:
+        sched = ConstantPChange(0.7)
+        for it in [0, 50, 100, 1000]:
+            assert sched.p_change_at(it, 100) == 0.7
+
+
+class TestLinearPChange:
+    """LinearPChange は iter / total の進行率に従って線形補間する."""
+
+    def test_start_at_iter_zero(self) -> None:
+        sched = LinearPChange(start=0.9, end=0.3)
+        assert abs(sched.p_change_at(0, 100) - 0.9) < 1e-9
+
+    def test_end_at_iter_total(self) -> None:
+        sched = LinearPChange(start=0.9, end=0.3)
+        assert abs(sched.p_change_at(100, 100) - 0.3) < 1e-9
+
+    def test_midpoint_linear_interpolation(self) -> None:
+        sched = LinearPChange(start=0.9, end=0.3)
+        # 50% 進行で (0.9 + 0.3) / 2 = 0.6
+        assert abs(sched.p_change_at(50, 100) - 0.6) < 1e-9
+
+    def test_iter_exceeding_total_clamps_to_end(self) -> None:
+        sched = LinearPChange(start=0.9, end=0.3)
+        assert abs(sched.p_change_at(200, 100) - 0.3) < 1e-9
+
+    def test_total_zero_returns_start(self) -> None:
+        """total=0 のとき進行率を計算できないので start を返す."""
+        sched = LinearPChange(start=0.9, end=0.3)
+        assert abs(sched.p_change_at(0, 0) - 0.9) < 1e-9
+
+
+class TestHybridTransitionWithSchedule:
+    """HybridTransition が schedule オブジェクトを受け取って set_progress に応じた選択を行う."""
+
+    def test_accepts_schedule_object(self) -> None:
+        """schedule オブジェクトを p_change として受理できる."""
+        change, swap = _build_hybrid_pair()
+        rng = SeedRegistry(root=42).rng("sa_hybrid_chooser")
+        sched = ConstantPChange(0.7)
+        # ValueError 等を出さずに構築できれば OK
+        HybridTransition(change=change, swap=swap, p_change=sched, rng=rng)
+
+    def test_float_is_wrapped_to_constant(self) -> None:
+        """float を渡すと ConstantPChange に wrap され、既存挙動と一致."""
+        change, swap = _build_hybrid_pair()
+        rng = SeedRegistry(root=42).rng("sa_hybrid_chooser")
+        hybrid = HybridTransition(change=change, swap=swap, p_change=1.0, rng=rng)
+        # set_progress を呼ばなくても constant=1.0 で常に change が返る
+        for _ in range(20):
+            assert hybrid.choose() is change
+
+    def test_set_progress_drives_linear_schedule(self) -> None:
+        """linear schedule で set_progress(iter, total) に従って choose 確率が変わる."""
+        # start=1.0, end=0.0 にすれば iter=0 で必ず change、iter=total で必ず swap
+        change, swap = _build_hybrid_pair()
+        rng = SeedRegistry(root=42).rng("sa_hybrid_chooser")
+        sched = LinearPChange(start=1.0, end=0.0)
+        hybrid = HybridTransition(change=change, swap=swap, p_change=sched, rng=rng)
+
+        hybrid.set_progress(0, 100)
+        for _ in range(20):
+            assert hybrid.choose() is change
+
+        hybrid.set_progress(100, 100)
+        for _ in range(20):
+            assert hybrid.choose() is swap


### PR DESCRIPTION
## 背景

PR #68 (Issue #67) で `HybridTransition` を実装したが、p_change は constructor 固定値のみ。spec §12.2C 後半「初期 age-change 厚め → 後半 age-swap 厚め」を実現する手段が無く、§15.2 の動的 vs 固定の比較実験が組めない状態だった。

Closes #69

## この変更で提供する価値

開発者が `annealing.p_change_schedule: linear`、`p_change: 0.9`、`p_change_end: 0.3` の config で `synthpop-jp generate` を実行すると、SA 進行に応じて p_change が線形に減衰し、初期は AgeChange で大域探索、後半は AgeSwap で局所最適化が走る。spec §12.2C の意図が固定確率と並んで選択肢に入る。

## 変更内容

- `src/synthpop_jp/optimize/transitions.py`:
  - `ConstantPChange` / `LinearPChange` schedule クラス追加
  - `HybridTransition` を schedule オブジェクト受け取り対応に拡張（float は ConstantPChange に wrap で後方互換）
  - `set_progress(iter, total)` を追加
- `src/synthpop_jp/config.py`: `AnnealingConfig` に `p_change_schedule` (constant | linear) と `p_change_end` を追加、validator を hybrid + schedule で分岐
- `src/synthpop_jp/optimize/annealing.py`: SA loop で `schedule_total = min(max_iters, eval_limit)` を計算、毎反復 `transition.set_progress(iter, total)` を呼ぶ
- `src/synthpop_jp/cli.py`: `generate` で schedule オブジェクトを構築
- 単体 14 件 + CLI 統合 1 件追加

## 影響範囲

- 変更モジュール: `optimize/`, `config.py`, `cli.py`
- 他モジュールへの影響: なし（schedule の default は constant、既存挙動と一致）
- 既存 API の互換性: 維持（`HybridTransition(p_change=float, ...)` は ConstantPChange に自動 wrap）
- 依存関係の変化: なし

## テスト

- 追加テスト: 15 件
- 変更テスト: 0
- カバレッジ: 維持
- 手動確認: なし（CLI 統合テストでカバー）

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
109 files already formatted

$ uv run pyright
0 errors, 13 warnings, 0 informations  (warnings は既存の pandas stub のみ)

$ uv run pytest
493 passed, 10 skipped in 9.59s
```

</details>

## レビュー時に確認してほしい点

1. `set_progress` を毎反復呼ぶ overhead（isinstance + 2 attribute set）が SA 性能に影響しないこと
2. `schedule_total = min(max_iters, eval_limit)` の選択（eval_limit が立っているとそちらが先に止まることが多いため、終端基準もそれに合わせる）
3. float を `ConstantPChange` に自動 wrap する後方互換設計

## 関連

- Issue #69（本 PR）
- 前段: PR #68 (固定確率 hybrid, Issue #67)
- spec §12.2C, §15.2
- Issue 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/69#issuecomment-4341224077
- 自己レビューコメント: https://github.com/gghatano/synth-pop-harada-2024/issues/69#issuecomment-4341261479

🤖 Generated with [Claude Code](https://claude.com/claude-code)