### PR TITLE
[#71] 開発者が family_type 別 demographic pyramid を含む extended objective で SA を回せるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -447,6 +447,8 @@ def generate(
         age_diff_parent_child=age_diff_parent_child,
         age_diff_couple=age_diff_couple,
         demographic_by_age_sex=demographic_by_age_sex,
+        demo_ft_role=demographic_by_family_type_role,
+        use_family_type_pyramid=settings.objective.use_family_type_pyramid,
     )
     initial_score = objective.total_score
     console.print(f"[green]初期スコア:[/green] {initial_score:.1f}")
@@ -666,7 +668,9 @@ def evaluate(
         load_age_diff_couple,
         load_age_diff_parent_child,
         load_demographic_by_age_sex,
+        load_demographic_by_family_type_role,
     )
+    from synthpop_jp.io.schemas import DemographicByFamilyTypeRoleRow
     from synthpop_jp.io.synthesized import reconstruct_population_arrays_from_persons_csv
 
     logging.basicConfig(level=getattr(logging, log_level.value))
@@ -708,10 +712,18 @@ def evaluate(
         settings.input_dir / "demographic_by_age_sex.csv"
     )
 
+    # family_type 別 demographic pyramid (Issue #71)。任意入力。
+    demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None
+    demo_ft_role_path = settings.input_dir / "demographic_by_family_type_role.csv"
+    if demo_ft_role_path.exists():
+        demo_ft_role = load_demographic_by_family_type_role(demo_ft_role_path)
+
     aggregate_evaluator = AggregateStatL1Evaluator(
         age_diff_parent_child=age_diff_parent_child,
         age_diff_couple=age_diff_couple,
         demographic_by_age_sex=demographic_by_age_sex,
+        demo_ft_role=demo_ft_role,
+        use_family_type_pyramid=settings.objective.use_family_type_pyramid,
     )
     rare_cell_evaluator = RareCellEvaluator()
     metrics: dict[str, float] = {

--- a/src/synthpop_jp/config.py
+++ b/src/synthpop_jp/config.py
@@ -163,6 +163,22 @@ class AnnealingConfig(BaseModel):
         return self
 
 
+class ObjectiveConfig(BaseModel):
+    """目的関数のオプション設定 (Issue #71).
+
+    Attributes
+    ----------
+    use_family_type_pyramid : bool
+        True で family_type × sex demographic pyramid を minimal 5 統計に追加し、
+        合計 5 + 2N 統計の目的関数で SA を回す。`docs/spec/spec.md` §11.3。
+        デフォルト False（既存挙動維持）。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    use_family_type_pyramid: bool = False
+
+
 class Settings(BaseModel):
     """CLI 全体の実行設定をまとめる pydantic モデル.
 
@@ -177,6 +193,10 @@ class Settings(BaseModel):
     family_type_mapping : Path | None
         ``family_type_mapping.yaml`` のパス。省略時は ``configs/family_type_mapping.yaml``
         を自動検索する。
+    annealing : AnnealingConfig
+        SA 実行パラメータ。
+    objective : ObjectiveConfig
+        目的関数のオプション（Issue #71）。
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -186,6 +206,7 @@ class Settings(BaseModel):
     output_dir: Path
     family_type_mapping: Path | None = None
     annealing: AnnealingConfig = AnnealingConfig()
+    objective: ObjectiveConfig = ObjectiveConfig()
 
     @classmethod
     def from_yaml(cls, path: Path) -> Settings:

--- a/src/synthpop_jp/evaluate/aggregate_metrics.py
+++ b/src/synthpop_jp/evaluate/aggregate_metrics.py
@@ -1,8 +1,8 @@
-"""Aggregate 21-statistic L1 error reporter (Phase 3.5, Issue #59).
+"""Aggregate L1 error reporter (Phase 3.5, Issue #59 / #71).
 
-Phase 2 実装済みの 5 統計（``ObjectiveState.stats`` と同型）に対し、observed と
-target の L1 誤差を統計別 + 合計で返す Evaluator を提供する。21 統計拡張は
-Phase 3a の別 Issue で対応する。
+minimal 5 統計（Issue #59）と、optional の family_type × sex pyramid 統計
+（Issue #71、5 + 2N 統計）に対し、observed と target の L1 誤差を統計別 + 合計で
+返す Evaluator を提供する。
 
 提供するもの
 ------------
@@ -15,6 +15,8 @@ Phase 3a の別 Issue で対応する。
 - ``aggregate.l1.couple_age_diff``
 - ``aggregate.l1.pyramid_male``
 - ``aggregate.l1.pyramid_female``
+- ``aggregate.l1.pyramid_per_family_type.<family_type>.<sex>``
+  （``use_family_type_pyramid=True`` のときのみ）
 - ``aggregate.l1.total``
 """
 
@@ -29,11 +31,12 @@ if TYPE_CHECKING:
         AgeDiffCoupleRow,
         AgeDiffParentChildRow,
         DemographicByAgeSexRow,
+        DemographicByFamilyTypeRoleRow,
     )
     from synthpop_jp.optimize.state import PopulationArrays
 
 
-# 5 統計の出力キー名（``build_objective_stats`` のインデックス順）
+# minimal 5 統計の出力キー名（``build_objective_stats`` のインデックス順）
 _STAT_NAMES: tuple[str, ...] = (
     "father_child_age_diff",
     "mother_child_age_diff",
@@ -57,6 +60,11 @@ class AggregateStatL1Evaluator:
         ``age_diff_couple.csv`` から読んだ全行。
     demographic_by_age_sex : list[DemographicByAgeSexRow]
         ``demographic_by_age_sex.csv`` から読んだ全行。
+    demo_ft_role : list[DemographicByFamilyTypeRoleRow] | None
+        ``demographic_by_family_type_role.csv`` の全行。
+        ``use_family_type_pyramid=True`` のとき必須（Issue #71）。
+    use_family_type_pyramid : bool
+        True で family_type × sex pyramid 統計の L1 を追加する（Issue #71）。
 
     Attributes
     ----------
@@ -71,13 +79,18 @@ class AggregateStatL1Evaluator:
         age_diff_parent_child: list[AgeDiffParentChildRow],
         age_diff_couple: list[AgeDiffCoupleRow],
         demographic_by_age_sex: list[DemographicByAgeSexRow],
+        *,
+        demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
+        use_family_type_pyramid: bool = False,
     ) -> None:
         self._age_diff_parent_child = age_diff_parent_child
         self._age_diff_couple = age_diff_couple
         self._demographic_by_age_sex = demographic_by_age_sex
+        self._demo_ft_role = demo_ft_role
+        self._use_family_type_pyramid = use_family_type_pyramid
 
     def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
-        """合成人口の 5 統計 L1 誤差を計算して dict で返す.
+        """合成人口の統計別 L1 誤差を計算して dict で返す.
 
         Parameters
         ----------
@@ -87,20 +100,35 @@ class AggregateStatL1Evaluator:
         Returns
         -------
         dict[str, float]
-            ``aggregate.l1.<stat_name>`` × 5 + ``aggregate.l1.total`` を含む
-            6 キーの dict。
+            minimal 5 統計の ``aggregate.l1.<stat_name>`` + ``aggregate.l1.total``。
+            ``use_family_type_pyramid=True`` のときは
+            ``aggregate.l1.pyramid_per_family_type.<ft>.<sex>`` も追加。
         """
         stats = build_objective_stats(
             arrays=pop,
             age_diff_parent_child=self._age_diff_parent_child,
             age_diff_couple=self._age_diff_couple,
             demographic_by_age_sex=self._demographic_by_age_sex,
+            demo_ft_role=self._demo_ft_role,
+            use_family_type_pyramid=self._use_family_type_pyramid,
         )
         result: dict[str, float] = {}
         total = 0.0
-        for i, stat in enumerate(stats):
-            l1 = stat.l1_score()
+        for i in range(5):
+            l1 = stats[i].l1_score()
             result[f"{self.name}.l1.{_STAT_NAMES[i]}"] = l1
             total += l1
+
+        if self._use_family_type_pyramid:
+            n_ft = len(pop.family_reg)
+            for ft_id in range(n_ft):
+                ft_name = pop.family_reg.name_of(ft_id)
+                for s_idx, sex in enumerate(("M", "F")):
+                    stat_idx = 5 + ft_id * 2 + s_idx
+                    l1 = stats[stat_idx].l1_score()
+                    key = f"{self.name}.l1.pyramid_per_family_type.{ft_name}.{sex}"
+                    result[key] = l1
+                    total += l1
+
         result[f"{self.name}.l1.total"] = total
         return result

--- a/src/synthpop_jp/optimize/objective.py
+++ b/src/synthpop_jp/optimize/objective.py
@@ -34,6 +34,7 @@ from synthpop_jp.io.schemas import (
     AgeDiffCoupleRow,
     AgeDiffParentChildRow,
     DemographicByAgeSexRow,
+    DemographicByFamilyTypeRoleRow,
 )
 
 if TYPE_CHECKING:
@@ -450,7 +451,82 @@ def _compute_pyramid_observed(
 
 
 # ---------------------------------------------------------------------------
-# build_objective_stats: 5 統計の構築
+# family_type 別 demographic pyramid (Issue #71)
+# ---------------------------------------------------------------------------
+
+
+def _build_family_type_pyramid_stat(
+    rows: list[DemographicByFamilyTypeRoleRow],
+    family_type: str,
+    sex_label: str,
+    arrays: PopulationArrays,
+) -> StatTable:
+    """family_type × sex 別の demographic pyramid 統計を構築する.
+
+    target は ``demographic_by_family_type_role.csv`` を ``(family_type, sex, age)``
+    で集計（role を集約）した値。observed は合成集団の (family_type, sex) 別 age 分布。
+
+    Parameters
+    ----------
+    rows : list[DemographicByFamilyTypeRoleRow]
+        ``demographic_by_family_type_role.csv`` から読んだ全行。
+    family_type : str
+        対象の family_type 名。
+    sex_label : str
+        ``"M"`` または ``"F"``。
+    arrays : PopulationArrays
+        合成集団の人口配列。
+
+    Returns
+    -------
+    StatTable
+        observed と target が初期化された統計テーブル。target に該当 age が無い
+        family_type/sex でも空の StatTable（target 全 0、bin_edges は age 0..100）を返す。
+    """
+    # 該当 family_type × sex の rows を age 別に集約（role を sum）
+    matched = [r for r in rows if r.family_type == family_type and r.sex == sex_label]
+    age_to_count: dict[int, int] = {}
+    for r in matched:
+        age_to_count[r.age] = age_to_count.get(r.age, 0) + r.count
+
+    # bin_edges は age 0..100 の固定 (101 bins)。target に無い age は 0 として扱う。
+    # observed が target 範囲外で捨てられないように 0..100 を網羅する。
+    bin_edges = np.arange(0, 102, dtype=np.float64)
+    target = np.zeros(101, dtype=np.int64)
+    for age, count in age_to_count.items():
+        if 0 <= age <= 100:
+            target[age] = count
+
+    family_type_id = arrays.family_reg.id_of(family_type)
+    sex_id = arrays.sex_reg.id_of(sex_label)
+    n_bins = len(bin_edges) - 1
+    observed = _compute_family_type_pyramid_observed(
+        arrays, family_type_id, sex_id, bin_edges, n_bins
+    )
+    return StatTable(observed=observed, target=target, bin_edges=bin_edges)
+
+
+def _compute_family_type_pyramid_observed(
+    arrays: PopulationArrays,
+    family_type_id: int,
+    sex_id: int,
+    bin_edges: np.ndarray,
+    n_bins: int,
+) -> np.ndarray:
+    """family_type × sex の observed pyramid を計算する."""
+    mask = (arrays.family_type == family_type_id) & (arrays.sex == sex_id)
+    ages = arrays.age[mask].astype(np.int64)
+    observed, _ = np.histogram(ages, bins=bin_edges)
+    return observed.astype(np.int64)
+
+
+def family_type_pyramid_index(offset: int, family_type_id: int, sex_id: int, n_sex: int = 2) -> int:
+    """family_type × sex から ``stats`` リストのインデックスを計算する."""
+    return offset + family_type_id * n_sex + sex_id
+
+
+# ---------------------------------------------------------------------------
+# build_objective_stats: 5 統計 (+ optional family_type pyramid) の構築
 # ---------------------------------------------------------------------------
 
 
@@ -459,8 +535,11 @@ def build_objective_stats(
     age_diff_parent_child: list[AgeDiffParentChildRow],
     age_diff_couple: list[AgeDiffCoupleRow],
     demographic_by_age_sex: list[DemographicByAgeSexRow],
+    *,
+    demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
+    use_family_type_pyramid: bool = False,
 ) -> list[StatTable]:
-    """5 統計を構築して StatTable のリストを返す.
+    """5 統計（+ optional family_type × sex pyramid）を構築する.
 
     返り値のインデックス:
     - 0: father-child 年齢差
@@ -468,6 +547,8 @@ def build_objective_stats(
     - 2: couple 年齢差（husband - wife）
     - 3: male demographic pyramid
     - 4: female demographic pyramid
+    - 5..5 + 2N - 1: ``use_family_type_pyramid=True`` のとき
+      ``family_type_id * 2 + sex_id`` 順で family_type × sex pyramid
 
     Parameters
     ----------
@@ -479,19 +560,40 @@ def build_objective_stats(
         age_diff_couple.csv から読んだ全行。
     demographic_by_age_sex : list[DemographicByAgeSexRow]
         demographic_by_age_sex.csv から読んだ全行。
+    demo_ft_role : list[DemographicByFamilyTypeRoleRow] | None
+        ``demographic_by_family_type_role.csv`` の全行。
+        ``use_family_type_pyramid=True`` のとき必須。
+    use_family_type_pyramid : bool
+        True で family_type × sex pyramid 統計を末尾に追加する（Issue #71）。
 
     Returns
     -------
     list[StatTable]
-        長さ 5 の StatTable リスト。
+        長さ 5（拡張オフ時）または 5 + 2N（拡張オン時）。
     """
-    return [
+    base = [
         _build_parent_child_stat(age_diff_parent_child, "father", arrays),
         _build_parent_child_stat(age_diff_parent_child, "mother", arrays),
         _build_couple_stat(age_diff_couple, arrays),
         _build_pyramid_stat(demographic_by_age_sex, "M", arrays),
         _build_pyramid_stat(demographic_by_age_sex, "F", arrays),
     ]
+    if not use_family_type_pyramid:
+        return base
+
+    if demo_ft_role is None:
+        msg = "use_family_type_pyramid=True のとき demo_ft_role を渡す必要があります"
+        raise ValueError(msg)
+
+    # family_type は登録 ID 順で列挙する。stats[offset + ft_id*2 + sex_id] で
+    # 正しいインデックスを引けるよう、set ベースの順序非決定性を避ける（Issue #71）。
+    n_ft = len(arrays.family_reg)
+    extended: list[StatTable] = []
+    for ft_id in range(n_ft):
+        ft = arrays.family_reg.name_of(ft_id)
+        for sex in ("M", "F"):
+            extended.append(_build_family_type_pyramid_stat(demo_ft_role, ft, sex, arrays))
+    return base + extended
 
 
 # ---------------------------------------------------------------------------
@@ -504,21 +606,30 @@ class ObjectiveState:
     """差分更新版目的関数の状態コンテナ.
 
     SA の内部ループで 1 人の age が変わるとき、
-    5 統計のヒストグラムを O(1) で差分更新しながら total_score を維持する。
+    5 統計（+ optional family_type × sex pyramid）のヒストグラムを O(1) で
+    差分更新しながら total_score を維持する。
 
     Attributes
     ----------
     arrays : PopulationArrays
         人口配列への参照（コピーしない）。
     stats : list[StatTable]
-        5 統計分の StatTable リスト（インデックスの意味は build_objective_stats 参照）。
+        StatTable リスト。インデックスの意味は ``build_objective_stats`` 参照。
+        family_type pyramid 拡張オンのとき長さは 5 + 2N。
     total_score : float
         現在の目的スコア = Σ_s L1(stats[s])。
+    family_type_pyramid_offset : int | None
+        ``stats`` における family_type × sex pyramid の開始インデックス。
+        拡張オフ時は ``None``（Issue #71）。
+    n_family_types : int
+        family_type pyramid の対象 family_type 数（拡張オフ時は 0）。
     """
 
     arrays: PopulationArrays
     stats: list[StatTable]
     total_score: float
+    family_type_pyramid_offset: int | None = None
+    n_family_types: int = 0
 
     @classmethod
     def from_arrays(
@@ -527,6 +638,9 @@ class ObjectiveState:
         age_diff_parent_child: list[AgeDiffParentChildRow],
         age_diff_couple: list[AgeDiffCoupleRow],
         demographic_by_age_sex: list[DemographicByAgeSexRow],
+        *,
+        demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
+        use_family_type_pyramid: bool = False,
     ) -> ObjectiveState:
         """PopulationArrays と統計テーブルから ObjectiveState を構築する.
 
@@ -540,23 +654,38 @@ class ObjectiveState:
             age_diff_couple.csv から読んだ全行。
         demographic_by_age_sex : list[DemographicByAgeSexRow]
             demographic_by_age_sex.csv から読んだ全行。
+        demo_ft_role : list[DemographicByFamilyTypeRoleRow] | None
+            ``demographic_by_family_type_role.csv`` の全行。
+            ``use_family_type_pyramid=True`` のとき必須。
+        use_family_type_pyramid : bool
+            True で family_type × sex pyramid を追加する（Issue #71）。
 
         Returns
         -------
         ObjectiveState
-            初期化済みの ObjectiveState。total_score は 5 統計の L1 合計。
+            初期化済みの ObjectiveState。total_score は全統計の L1 合計。
         """
         stats = build_objective_stats(
             arrays=arrays,
             age_diff_parent_child=age_diff_parent_child,
             age_diff_couple=age_diff_couple,
             demographic_by_age_sex=demographic_by_age_sex,
+            demo_ft_role=demo_ft_role,
+            use_family_type_pyramid=use_family_type_pyramid,
         )
         total_score = sum(s.l1_score() for s in stats)
+        if use_family_type_pyramid:
+            offset: int | None = 5
+            n_ft = len(arrays.family_reg)
+        else:
+            offset = None
+            n_ft = 0
         return cls(
             arrays=arrays,
             stats=stats,
             total_score=total_score,
+            family_type_pyramid_offset=offset,
+            n_family_types=n_ft,
         )
 
     # -----------------------------------------------------------------------
@@ -593,6 +722,15 @@ class ObjectiveState:
         pyramid_idx = 3 + sex_id
         pyramid_stat = self.stats[pyramid_idx]
         delta += _delta_pyramid(pyramid_stat, old_age, new_age)
+
+        # --- family_type × sex pyramid (Issue #71、拡張オン時のみ) ---
+        if self.family_type_pyramid_offset is not None:
+            ft_id = int(self.arrays.family_type[person_idx])
+            ft_pyramid_idx = family_type_pyramid_index(
+                self.family_type_pyramid_offset, ft_id, sex_id
+            )
+            ft_pyramid_stat = self.stats[ft_pyramid_idx]
+            delta += _delta_pyramid(ft_pyramid_stat, old_age, new_age)
 
         # --- stats[0]: father-child, stats[1]: mother-child ---
         role_id = int(self.arrays.role[person_idx])
@@ -786,6 +924,14 @@ class ObjectiveState:
         pyramid_idx = 3 + sex_id
         pyramid_stat = self.stats[pyramid_idx]
         _apply_pyramid_update(pyramid_stat, old_age, new_age)
+
+        # family_type × sex pyramid (Issue #71)
+        if self.family_type_pyramid_offset is not None:
+            ft_id = int(self.arrays.family_type[person_idx])
+            ft_pyramid_idx = family_type_pyramid_index(
+                self.family_type_pyramid_offset, ft_id, sex_id
+            )
+            _apply_pyramid_update(self.stats[ft_pyramid_idx], old_age, new_age)
 
         role_id = int(self.arrays.role[person_idx])
         role_name = self.arrays.role_reg.name_of(role_id)

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -155,3 +155,32 @@ class TestEvaluateIntegration:
         )
         assert eval_result.exit_code == 1
         assert "real-persons-csv" in eval_result.output
+
+    def test_evaluate_appends_pyramid_per_family_type_keys(self, tmp_path: Path) -> None:
+        """use_family_type_pyramid=True の config で evaluate が
+        ``aggregate.l1.pyramid_per_family_type.<ft>.<sex>`` キーを出力する (Issue #71)."""
+        config_data: dict[str, object] = {
+            "seed": 42,
+            "input_dir": str(SAMPLE_CASE_DIR),
+            "output_dir": str(tmp_path / "out"),
+            "annealing": {
+                "T0": 100.0,
+                "alpha": 0.99,
+                "max_iters": 200,
+                "evals_per_agent": 0,
+                "target_threshold": 0.0,
+                "patience": 0,
+            },
+            "objective": {"use_family_type_pyramid": True},
+        }
+        config_path = tmp_path / "config_extended.yaml"
+        config_path.write_text(yaml.dump(config_data))
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0, eval_result.output
+
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert any(k.startswith("aggregate.l1.pyramid_per_family_type.") for k in metrics), (
+            f"pyramid_per_family_type キーが含まれない: keys={list(metrics)[:20]}"
+        )

--- a/tests/cli/test_generate.py
+++ b/tests/cli/test_generate.py
@@ -344,3 +344,37 @@ class TestGenerateHybridTransition:
         result = runner.invoke(app, ["generate", "--config", str(config_path)])
         assert result.exit_code == 0, result.output + str(result.exception or "")
         assert (tmp_path / "out" / "synthetic_persons.csv").exists()
+
+
+@pytest.mark.slow
+class TestGenerateExtendedObjective:
+    """family_type 別 pyramid 拡張モードの統合テスト (Issue #71)."""
+
+    def _make_extended_config(self, tmp_path: Path) -> Path:
+        config_data: dict[str, object] = {
+            "seed": 42,
+            "input_dir": str(SAMPLE_CASE_DIR),
+            "output_dir": str(tmp_path / "out"),
+            "annealing": {
+                "T0": 100.0,
+                "alpha": 0.99,
+                "max_iters": 200,
+                "evals_per_agent": 0,
+                "target_threshold": 0.0,
+                "patience": 0,
+            },
+            "objective": {
+                "use_family_type_pyramid": True,
+            },
+        }
+        config_path = tmp_path / "config_extended.yaml"
+        config_path.write_text(yaml.dump(config_data))
+        return config_path
+
+    def test_extended_generate_exits_0(self, tmp_path: Path) -> None:
+        """use_family_type_pyramid=True の config で generate が完走する."""
+        config_path = self._make_extended_config(tmp_path)
+        result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert result.exit_code == 0, result.output + str(result.exception or "")
+        assert (tmp_path / "out" / "synthetic_persons.csv").exists()
+        assert (tmp_path / "out" / "metrics.json").exists()

--- a/tests/optimize/test_objective_extended.py
+++ b/tests/optimize/test_objective_extended.py
@@ -1,0 +1,261 @@
+"""Tests for extended objective with family_type × sex pyramid (Issue #71).
+
+minimal 5 統計に加えて family_type 別 demographic pyramid を追加する拡張モード:
+- `use_family_type_pyramid=True` で 5 + 2N 個の StatTable を構築
+- 差分更新ロジックが family_type 別 pyramid も O(1) で更新
+- AggregateStatL1Evaluator が新キーを出力
+
+`docs/spec/spec.md` §11.3 / §11.4.1 (式(3)) に基づく段階的実装。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+import numpy as np
+import pytest
+
+from synthpop_jp.init.initial_population import InitStats, generate_initial_population
+from synthpop_jp.io.loaders import (
+    load_age_diff_couple,
+    load_age_diff_parent_child,
+    load_children_count_dist,
+    load_demographic_by_age_sex,
+    load_demographic_by_family_type_role,
+    load_family_type_counts,
+    load_family_type_mapping,
+    load_household_size_by_family_type,
+)
+from synthpop_jp.io.schemas import (
+    AgeDiffCoupleRow,
+    AgeDiffParentChildRow,
+    DemographicByAgeSexRow,
+    DemographicByFamilyTypeRoleRow,
+)
+from synthpop_jp.optimize.objective import (
+    ObjectiveState,
+    build_objective_stats,
+)
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.rng import SeedRegistry
+
+
+class ExtendedObjectiveInput(TypedDict):
+    age_diff_parent_child: list[AgeDiffParentChildRow]
+    age_diff_couple: list[AgeDiffCoupleRow]
+    demographic_by_age_sex: list[DemographicByAgeSexRow]
+    demo_ft_role: list[DemographicByFamilyTypeRoleRow]
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("pyproject.toml not found")
+
+
+_REPO_ROOT = _find_repo_root()
+_DATA_DIR = _REPO_ROOT / "data" / "sample_case"
+_CONFIGS_DIR = _REPO_ROOT / "configs"
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    return SeedRegistry(root=42).rng("init")
+
+
+@pytest.fixture
+def sample_stats() -> InitStats:
+    return InitStats(
+        family_type_counts=load_family_type_counts(_DATA_DIR / "family_type_counts.csv"),
+        children_count_dist=load_children_count_dist(_DATA_DIR / "children_count_dist.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+        family_type_mapping=load_family_type_mapping(_CONFIGS_DIR / "family_type_mapping.yaml"),
+        household_size_by_family_type=load_household_size_by_family_type(
+            _DATA_DIR / "household_size_by_family_type.csv"
+        ),
+        demographic_by_family_type_role=load_demographic_by_family_type_role(
+            _DATA_DIR / "demographic_by_family_type_role.csv"
+        ),
+    )
+
+
+@pytest.fixture
+def sample_arrays(sample_stats: InitStats, rng: np.random.Generator) -> PopulationArrays:
+    return generate_initial_population(sample_stats, rng)
+
+
+@pytest.fixture
+def extended_input(sample_stats: InitStats) -> ExtendedObjectiveInput:
+    return ExtendedObjectiveInput(
+        age_diff_parent_child=load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv"),
+        age_diff_couple=load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        demographic_by_age_sex=sample_stats.demographic_by_age_sex,
+        demo_ft_role=sample_stats.demographic_by_family_type_role or [],
+    )
+
+
+class TestBuildObjectiveStatsExtended:
+    """build_objective_stats の use_family_type_pyramid フラグ."""
+
+    def test_default_returns_five_stats(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """フラグ未指定では既存 5 統計のみ返す."""
+        stats = build_objective_stats(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+        )
+        assert len(stats) == 5
+
+    def test_extended_returns_more_stats(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """use_family_type_pyramid=True で 5 + 2N 個（N >= 1）."""
+        stats = build_objective_stats(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        # 5 + (n_family_types * 2)
+        n_ft = len(sample_arrays.family_reg.all_names())
+        assert len(stats) == 5 + n_ft * 2
+
+    def test_extended_each_pyramid_observed_sum_matches_population(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """全 family_type × sex pyramid の observed 合計が人口に一致."""
+        stats = build_objective_stats(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        n_ft = len(sample_arrays.family_reg.all_names())
+        offset = 5
+        ft_stats = stats[offset : offset + n_ft * 2]
+        total_observed = sum(int(s.observed.sum()) for s in ft_stats)
+        assert total_observed == sample_arrays.n_persons
+
+
+class TestObjectiveStateExtended:
+    """ObjectiveState の拡張モード."""
+
+    def test_from_arrays_with_extended_flag(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """from_arrays に use_family_type_pyramid=True を渡せて、attribute が立つ."""
+        obj = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        assert obj.family_type_pyramid_offset == 5
+        n_ft = len(sample_arrays.family_reg.all_names())
+        assert len(obj.stats) == 5 + n_ft * 2
+
+    def test_total_score_includes_extended_stats(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """拡張モードの total_score は 拡張なしより大きい（追加統計の L1 が加算）."""
+        obj_minimal = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+        )
+        # 同じ arrays で再度（in-place 変更がないと仮定）
+        obj_extended = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        # 5 統計部分の L1 は同じ。追加分は >= 0
+        assert obj_extended.total_score >= obj_minimal.total_score
+
+    def test_apply_change_keeps_score_consistent(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """拡張モードで apply_change 後の total_score が再計算と一致 (差分更新の正しさ)."""
+        obj = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        # 5 人について age を ±1 動かして差分更新後のスコアと再計算スコアが一致するか
+        rng = SeedRegistry(root=999).rng("test")
+        for _ in range(5):
+            idx = int(rng.integers(0, sample_arrays.n_persons))
+            old_age = int(sample_arrays.age[idx])
+            new_age = max(18, min(80, old_age + int(rng.choice([-1, 1]))))
+            if new_age == old_age:
+                continue
+            obj.apply_change(idx, new_age)
+
+        # 再構築して比較
+        obj_recomputed = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        assert abs(obj.total_score - obj_recomputed.total_score) < 1e-9
+
+    def test_apply_change_updates_only_target_family_type_pyramid(
+        self, sample_arrays: PopulationArrays, extended_input: ExtendedObjectiveInput
+    ) -> None:
+        """age-change で対象 person の (ft, sex) pyramid だけ変化、他 ft pyramid は不変."""
+        obj = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=extended_input["age_diff_parent_child"],
+            age_diff_couple=extended_input["age_diff_couple"],
+            demographic_by_age_sex=extended_input["demographic_by_age_sex"],
+            demo_ft_role=extended_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+        )
+        # snapshot of all extended stats observed arrays
+        n_ft = len(sample_arrays.family_reg.all_names())
+        offset = 5
+        before = [obj.stats[offset + i].observed.copy() for i in range(n_ft * 2)]
+
+        # 1 person を動かす
+        idx = 0
+        old_age = int(sample_arrays.age[idx])
+        new_age = old_age + 1 if old_age < 80 else old_age - 1
+        target_ft_id = int(sample_arrays.family_type[idx])
+        target_sex_id = int(sample_arrays.sex[idx])
+        target_pyramid_idx = target_ft_id * 2 + target_sex_id
+
+        obj.apply_change(idx, new_age)
+
+        for i in range(n_ft * 2):
+            after = obj.stats[offset + i].observed
+            if i == target_pyramid_idx:
+                # 対象 pyramid は old_age で -1, new_age で +1 のはず
+                assert not np.array_equal(after, before[i])
+            else:
+                assert np.array_equal(after, before[i]), (
+                    f"family_type pyramid index {i} が変化（対象 {target_pyramid_idx} 以外なのに）"
+                )


### PR DESCRIPTION
## 背景

`docs/spec/spec.md` §11.3 の extended objective（Murata 2017 21 統計対応）の段階的実装。現状は minimal 5 統計のみで、§15.2 比較実験 (extended vs minimal) を回す前提が欠けていた。

このスコープでは **family_type × sex pyramid (10 統計)** を minimal に追加し、合計 5 + 2N 統計に拡張する。残り 6 統計 (family_type × role × sex の詳細) は後続 Issue で。

Closes #71

## この変更で提供する価値

開発者が config で `objective.use_family_type_pyramid: true` と書くと、minimal 5 統計に **family_type 別 demographic pyramid 10 統計** が追加され、合計 15 統計ベースの目的関数で SA を最適化できる。Evaluator 側にも対応キー (`aggregate.l1.pyramid_per_family_type.<ft>.<sex>`) が追加される。

これにより spec §11.3 の段階的実装が前進し、Murata 2017 21 統計の足固めが完了する。

## 変更内容

- `src/synthpop_jp/optimize/objective.py`:
  - `_build_family_type_pyramid_stat` / `_compute_family_type_pyramid_observed` / `family_type_pyramid_index` を追加（共通 0..100 全 bin）
  - `build_objective_stats` に `*, demo_ft_role, use_family_type_pyramid` を追加（後方互換）
  - `ObjectiveState` に `family_type_pyramid_offset` / `n_family_types` attribute、`from_arrays` を拡張
  - 差分更新 (`_compute_delta_for_change`, `_update_histograms`) に family_type pyramid 更新を追加（既存 `_delta_pyramid` / `_apply_pyramid_update` を再利用）
- `src/synthpop_jp/config.py`: `ObjectiveConfig` 新規 + `Settings.objective` フィールド
- `src/synthpop_jp/cli.py`: generate / evaluate で `use_family_type_pyramid` を渡す
- `src/synthpop_jp/evaluate/aggregate_metrics.py`: `AggregateStatL1Evaluator` に `*, demo_ft_role, use_family_type_pyramid` を追加し、対応キーを出力
- 単体 7 件 + CLI 統合 2 件追加

## 影響範囲

- 変更モジュール: `optimize/objective.py`, `config.py`, `cli.py`, `evaluate/aggregate_metrics.py`
- 他モジュールへの影響: なし（拡張は default False で既存挙動と一致）
- 既存 API の互換性: 維持（`build_objective_stats`, `ObjectiveState.from_arrays`, `AggregateStatL1Evaluator.__init__` の新規引数はすべて keyword-only）
- 依存関係の変化: なし

## 実装中に発見・修正したバグ

- `family_reg.all_names()` が `set[str]` を返すため、`for ft in all_names()` の順序が非決定的だった。`stats[offset + ft_id*2 + sex_id]` でアクセスする差分更新と矛盾し、再計算 vs 差分更新で 6.0 のずれが出た。`for ft_id in range(len(family_reg))` + `name_of(ft_id)` に修正して登録 ID 順を強制。

## テスト

- 追加テスト: 9 件
- 変更テスト: 0
- カバレッジ: 維持
- 手動確認: なし（CLI 統合テストでカバー）

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
110 files already formatted

$ uv run pyright
0 errors, 13 warnings, 0 informations  (warnings は既存の pandas stub のみ)

$ uv run pytest
502 passed, 10 skipped in 9.51s
```

</details>

## レビュー時に確認してほしい点

1. `_build_family_type_pyramid_stat` で bin_edges を 0..100 固定 (101 bins) にした選択（target に登場しない age を observed から漏らさないため）
2. `family_reg.all_names()` の set 順非決定性回避（registry id 順での列挙）
3. ObjectiveConfig 新規追加と Settings.objective フィールドの構造
4. 差分更新の overhead が約 +20% 増の見込み（実測は §15.2 実験で）

## 関連

- Issue #71（本 PR）
- spec §11.3, §11.4.1, §11.6, §15.2
- Issue 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/71#issuecomment-4341442591
- 自己レビューコメント: https://github.com/gghatano/synth-pop-harada-2024/issues/71#issuecomment-4341495982
- 既存パターン: PR #60 (AggregateStatL1Evaluator), PR #58 (AgeSwap)
- 後続: 残り 6 統計 (別 Issue)、初期生成の 21 統計誤差 0 化 (Priv S2、別 Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)