### PR TITLE
[#79] 第三者が synthpop-jp の Evaluator を entry_points で外部から差し込めるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -731,6 +731,13 @@ def evaluate(
         **rare_cell_evaluator.evaluate(arrays),
     }
 
+    # entry_points プラグイン (Issue #79). 第三者が `synthpop_jp.evaluators`
+    # group で登録した evaluator を自動検出して呼ぶ。
+    from synthpop_jp.evaluate.plugin import load_evaluator_plugins
+
+    for plugin in load_evaluator_plugins():
+        metrics.update(plugin.evaluate(arrays))
+
     if real_persons_csv is not None:
         if not real_persons_csv.exists():
             err_console.print(

--- a/src/synthpop_jp/evaluate/plugin.py
+++ b/src/synthpop_jp/evaluate/plugin.py
@@ -1,0 +1,80 @@
+"""Evaluator plugin discovery via entry_points (Issue #79).
+
+第三者が別パッケージの ``pyproject.toml`` で
+
+.. code-block:: toml
+
+    [project.entry-points."synthpop_jp.evaluators"]
+    my_evaluator = "my_pkg.evaluators:MyEvaluator"
+
+のように登録した Evaluator factory を、``synthpop-jp evaluate`` が自動検出して
+実行できるようにする。
+
+設計
+----
+- entry_points group: ``synthpop_jp.evaluators``
+- 各 entry point は **無引数 callable**（クラスでも関数でも可）。呼ぶと
+  :class:`~synthpop_jp.domain.protocols.Evaluator` Protocol を満たす instance を返す。
+- Protocol 違反のものは ``UserWarning`` を出してスキップ。
+- 複雑な context（real_persons など）を必要とする evaluator は本機構の対象外
+  （今後の拡張で対応）。
+
+テスト戦略
+----------
+``importlib.metadata.entry_points`` を直接モックするのは難しいため、
+本モジュール内に薄いラッパー ``_discover_entry_points`` を置き、テストでは
+これを ``monkeypatch`` で差し替える。
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from synthpop_jp.domain.protocols import Evaluator
+
+if TYPE_CHECKING:
+    from importlib.metadata import EntryPoint
+
+_GROUP: str = "synthpop_jp.evaluators"
+
+
+def _discover_entry_points(group: str) -> Iterable[EntryPoint]:
+    """``importlib.metadata.entry_points`` の薄いラッパー (テスト差し替え用)."""
+    from importlib.metadata import entry_points
+
+    return entry_points(group=group)
+
+
+def load_evaluator_plugins() -> list[Evaluator]:
+    """``synthpop_jp.evaluators`` group の entry_points から Evaluator を読み込む.
+
+    各 entry point が ``Evaluator`` Protocol を満たさない場合は ``UserWarning``
+    を出してスキップする。
+
+    Returns
+    -------
+    list[Evaluator]
+        Protocol を満たす evaluator instance のリスト。entry_points 未登録時は
+        空リスト。
+    """
+    plugins: list[Evaluator] = []
+    for ep in _discover_entry_points(_GROUP):
+        try:
+            factory: Any = ep.load()
+            instance = factory()
+        except (ImportError, AttributeError, TypeError) as e:
+            warnings.warn(
+                f"Evaluator plugin '{ep.name}' の読み込みに失敗: {e}",
+                stacklevel=2,
+            )
+            continue
+        if not isinstance(instance, Evaluator):
+            warnings.warn(
+                f"Evaluator plugin '{ep.name}' が Evaluator Protocol を満たしません",
+                stacklevel=2,
+            )
+            continue
+        plugins.append(instance)
+    return plugins

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -156,6 +156,35 @@ class TestEvaluateIntegration:
         assert eval_result.exit_code == 1
         assert "real-persons-csv" in eval_result.output
 
+    def test_evaluate_calls_entry_point_plugins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """entry_points 登録された plugin の metric が metrics.json に追記される (Issue #79)."""
+
+        from synthpop_jp.optimize.state import PopulationArrays
+
+        class _DummyPlugin:
+            name: str = "plugin_dummy"
+
+            def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
+                return {"plugin_dummy.score": float(pop.n_persons)}
+
+        monkeypatch.setattr(
+            "synthpop_jp.evaluate.plugin.load_evaluator_plugins",
+            lambda: [_DummyPlugin()],
+        )
+
+        config_path = _make_config_yaml(tmp_path)
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0, eval_result.output
+
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert "plugin_dummy.score" in metrics
+        assert "aggregate.l1.total" in metrics
+        assert "rare_cell.total_cells" in metrics
+
     def test_evaluate_appends_pyramid_per_family_type_keys(self, tmp_path: Path) -> None:
         """use_family_type_pyramid=True の config で evaluate が
         ``aggregate.l1.pyramid_per_family_type.<ft>.<sex>`` キーを出力する (Issue #71)."""

--- a/tests/evaluate/test_plugin.py
+++ b/tests/evaluate/test_plugin.py
@@ -1,0 +1,86 @@
+"""Tests for evaluator plugin discovery via entry_points (Issue #79)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+
+from synthpop_jp.domain.protocols import Evaluator
+from synthpop_jp.evaluate.plugin import load_evaluator_plugins
+from synthpop_jp.optimize.state import PopulationArrays
+
+
+class _DummyEvaluator:
+    """テスト用の最小 Evaluator."""
+
+    name: str = "dummy"
+
+    def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
+        return {"dummy.score": float(pop.n_persons)}
+
+
+class _NotAnEvaluator:
+    """Evaluator Protocol を満たさないもの (name 属性なし、evaluate メソッドなし)."""
+
+    foo: str = "bar"
+
+
+class _FakeEntryPoint:
+    """importlib.metadata.EntryPoint の最小モック."""
+
+    def __init__(self, name: str, factory: Any) -> None:
+        self.name = name
+        self._factory = factory
+
+    def load(self) -> Any:
+        return self._factory
+
+
+class TestLoadEvaluatorPlugins:
+    """load_evaluator_plugins の動作."""
+
+    def test_returns_evaluator_from_entry_point(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """entry_points で登録された factory から Evaluator を取得する."""
+        fake_eps: list[_FakeEntryPoint] = [_FakeEntryPoint("dummy", _DummyEvaluator)]
+
+        def fake_discover(group: str) -> Iterable[_FakeEntryPoint]:
+            del group
+            return fake_eps
+
+        monkeypatch.setattr("synthpop_jp.evaluate.plugin._discover_entry_points", fake_discover)
+
+        plugins = load_evaluator_plugins()
+
+        assert len(plugins) == 1
+        assert isinstance(plugins[0], Evaluator)
+        assert plugins[0].name == "dummy"
+
+    def test_skips_non_evaluator_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, recwarn: pytest.WarningsRecorder
+    ) -> None:
+        """Evaluator Protocol を満たさないものはスキップして warning を出す."""
+        fake_eps: list[_FakeEntryPoint] = [_FakeEntryPoint("bad", _NotAnEvaluator)]
+
+        def fake_discover(group: str) -> Iterable[_FakeEntryPoint]:
+            del group
+            return fake_eps
+
+        monkeypatch.setattr("synthpop_jp.evaluate.plugin._discover_entry_points", fake_discover)
+
+        plugins = load_evaluator_plugins()
+
+        assert plugins == []
+        assert any("bad" in str(w.message) for w in recwarn.list)
+
+    def test_returns_empty_list_when_no_entry_points(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """entry_points が無いときは空リスト (既存挙動と等価)."""
+
+        def fake_discover(group: str) -> Iterable[_FakeEntryPoint]:
+            del group
+            return []
+
+        monkeypatch.setattr("synthpop_jp.evaluate.plugin._discover_entry_points", fake_discover)
+
+        assert load_evaluator_plugins() == []


### PR DESCRIPTION
## 背景

`synthpop-jp evaluate` で評価器を増やすには現状コア改修が必要だった。Phase 3.5 残作業のうち軽量な「entry_points 経由のプラグイン機構の最小実装」を追加し、第三者が独自パッケージから Evaluator を差し込めるようにする。

Closes #79

## この変更で提供する価値

別パッケージの `pyproject.toml` で

```toml
[project.entry-points."synthpop_jp.evaluators"]
my_eval = "my_pkg.evals:MyEvaluator"
```

と書くと、`synthpop-jp evaluate` 実行時に自動検出して呼ぶ。コア改修なしで評価器を拡張できるため、`synthpop-jp` を OSS パッケージとして配布したときに研究者が独自指標を試しやすくなる。

## 変更内容

- `src/synthpop_jp/evaluate/plugin.py` 新規 (~70 行)
  - `load_evaluator_plugins()`: entry_points group `synthpop_jp.evaluators` から無引数 factory を呼んで Evaluator instance のリストを返す
  - Protocol 違反は `UserWarning` でスキップ
  - テスト差し替え用に `_discover_entry_points(group)` ラッパーを切り出し
- `src/synthpop_jp/cli.py::evaluate`: 既存 evaluator + plugin の順で metrics を集計
- `tests/evaluate/test_plugin.py` 新規: 単体 3 件
- `tests/cli/test_evaluate.py`: CLI 統合 1 件追加

## 影響範囲

- 変更モジュール: `evaluate/plugin.py` 新規、`cli.py` evaluate サブコマンド
- 他モジュールへの影響: なし（entry_points 未登録時は既存挙動と完全一致）
- 既存 API の互換性: 維持
- 依存関係の変化: なし（`importlib.metadata` は標準ライブラリ）

## テスト

- 追加テスト: 4 件
- 変更テスト: 0
- カバレッジ: 維持
- 手動確認: なし（CLI 統合テストでカバー）

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest
All checks passed!
112 files already formatted
0 errors, 13 warnings
509 passed, 10 skipped in 9.79s
```

</details>

## レビュー時に確認してほしい点

1. 無引数 factory に絞った設計（複雑な context を要する evaluator は対象外）が適切か
2. `_discover_entry_points` ラッパーで monkeypatch しやすくしている設計
3. `except (ImportError, AttributeError, TypeError)` で例外を限定している判断（generic Exception を避ける）

## 関連

- Issue #79（本 PR）
- 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/79#issuecomment-4341909545
- 自己レビュー: https://github.com/gghatano/synth-pop-harada-2024/issues/79#issuecomment-4341930807
- 関連 PR: #60, #62, #66 (3 評価器揃った前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)