### PR TITLE
[#78] 開発者と PM が Harada 2024 Table 13 形式の評価レポートを report.md で読めるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -638,6 +638,13 @@ def evaluate(
             help="CAP/TCAP 計算に使う real 個票 CSV。省略時は CAP をスキップ。",
         ),
     ] = None,
+    no_report: Annotated[
+        bool,
+        typer.Option(
+            "--no-report",
+            help="report.md (Harada 2024 Table 13 形式) の出力を抑止する (Issue #78)。",
+        ),
+    ] = False,
     log_level: Annotated[
         LogLevel,
         typer.Option("--log-level", help="ログレベル。"),
@@ -767,6 +774,20 @@ def evaluate(
     for k, v in metrics.items():
         console.print(f"  {k}: {v:.1f}")
     console.print(f"[bold]metrics.json 更新:[/bold] {metrics_path}")
+
+    # Table 13 形式 Markdown レポート (Issue #78)
+    if not no_report:
+        from synthpop_jp.reports.markdown import render_metrics_table13
+
+        # existing は object 値も含むので、float 化できるものだけ通す
+        report_metrics: dict[str, float] = {}
+        for k, v in existing.items():
+            if isinstance(v, (int, float)):
+                report_metrics[k] = float(v)
+        report_md = render_metrics_table13(report_metrics)
+        report_path = settings.output_dir / "report.md"
+        report_path.write_text(report_md, encoding="utf-8")
+        console.print(f"[bold]report.md 更新:[/bold] {report_path}")
 
 
 @app.command()

--- a/src/synthpop_jp/reports/markdown.py
+++ b/src/synthpop_jp/reports/markdown.py
@@ -1,0 +1,226 @@
+"""Table 13 形式の Markdown renderer (Issue #78).
+
+`synthpop-jp evaluate` が出力する flat な ``metrics.json`` を、
+Harada 2024 Table 13 形式の人間に読みやすい Markdown に整形する。
+
+セクション構成
+--------------
+1. **統計整合性** (``aggregate.l1.*``)
+   - 1.1 minimal 5 統計
+   - 1.2 family_type × sex pyramid (拡張モード時のみ)
+2. **秘匿性**
+   - 2.1 rare cell (proxy 指標)
+   - 2.2 CAP / TCAP (attribute inference、``--real-persons-csv`` 指定時のみ)
+3. **その他** (entry_points プラグイン等の未分類キー)
+
+全セクションが空のときは空の Markdown を返さず、最低限のヘッダだけ出す。
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def _format_value(v: float) -> str:
+    """Metric 値の表示形式を統一する.
+
+    - 0.0–1.0 の比率らしき値: 4 桁
+    - それ以外: 小数 1 桁
+    """
+    if 0.0 <= v <= 1.0 and v != int(v):
+        return f"{v:.4f}"
+    return f"{v:.1f}"
+
+
+def _render_minimal_aggregate(rows: dict[str, float]) -> list[str]:
+    """Minimal 5 統計と total を Markdown table で返す."""
+    lines: list[str] = []
+    if not rows:
+        return lines
+    lines.append("### 1.1 minimal 5 統計")
+    lines.append("")
+    lines.append("| 統計 | L1 誤差 |")
+    lines.append("|---|---:|")
+    # total は最後に
+    items = sorted([(k, v) for k, v in rows.items() if k != "total"])
+    for k, v in items:
+        lines.append(f"| {k} | {_format_value(v)} |")
+    if "total" in rows:
+        lines.append(f"| **total** | **{_format_value(rows['total'])}** |")
+    lines.append("")
+    return lines
+
+
+def _render_family_type_pyramid(rows: dict[str, dict[str, float]]) -> list[str]:
+    """family_type × sex の pyramid L1 を 2 列 table で返す.
+
+    ``rows`` は ``{family_type: {"M": l1, "F": l1}}`` の dict。
+    """
+    lines: list[str] = []
+    if not rows:
+        return lines
+    lines.append("### 1.2 family_type 別 demographic pyramid")
+    lines.append("")
+    lines.append("| family_type | M | F |")
+    lines.append("|---|---:|---:|")
+    for ft in sorted(rows.keys()):
+        m = rows[ft].get("M", 0.0)
+        f = rows[ft].get("F", 0.0)
+        lines.append(f"| {ft} | {_format_value(m)} | {_format_value(f)} |")
+    lines.append("")
+    return lines
+
+
+def _render_rare_cell(
+    global_rows: dict[str, float], per_ft: dict[str, dict[str, float]]
+) -> list[str]:
+    lines: list[str] = []
+    if not global_rows and not per_ft:
+        return lines
+    lines.append("### 2.1 rare cell (proxy)")
+    lines.append("")
+    if global_rows:
+        lines.append("| 指標 | 値 |")
+        lines.append("|---|---:|")
+        for k in sorted(global_rows.keys()):
+            lines.append(f"| {k} | {_format_value(global_rows[k])} |")
+        lines.append("")
+    if per_ft:
+        lines.append("**family_type 別 (fraction_below_5 / fraction_unique):**")
+        lines.append("")
+        lines.append("| family_type | fraction_below_5 | fraction_unique |")
+        lines.append("|---|---:|---:|")
+        for ft in sorted(per_ft.keys()):
+            sub = per_ft[ft]
+            lines.append(
+                f"| {ft} | {_format_value(sub.get('fraction_below_5', 0.0))} | "
+                f"{_format_value(sub.get('fraction_unique', 0.0))} |"
+            )
+        lines.append("")
+    return lines
+
+
+def _render_cap(global_rows: dict[str, float], per_ft: dict[str, dict[str, float]]) -> list[str]:
+    lines: list[str] = []
+    if not global_rows and not per_ft:
+        return lines
+    lines.append("### 2.2 CAP / TCAP (attribute inference)")
+    lines.append("")
+    if global_rows:
+        lines.append("| 指標 | 値 |")
+        lines.append("|---|---:|")
+        for k in sorted(global_rows.keys()):
+            lines.append(f"| {k} | {_format_value(global_rows[k])} |")
+        lines.append("")
+    if per_ft:
+        lines.append("**family_type 別 (generalized / targeted):**")
+        lines.append("")
+        lines.append("| family_type | generalized | targeted |")
+        lines.append("|---|---:|---:|")
+        for ft in sorted(per_ft.keys()):
+            sub = per_ft[ft]
+            lines.append(
+                f"| {ft} | {_format_value(sub.get('generalized', 0.0))} | "
+                f"{_format_value(sub.get('targeted', 0.0))} |"
+            )
+        lines.append("")
+    return lines
+
+
+def _render_others(rows: dict[str, float]) -> list[str]:
+    lines: list[str] = []
+    if not rows:
+        return lines
+    lines.append("## 3. その他 / プラグイン")
+    lines.append("")
+    lines.append("| キー | 値 |")
+    lines.append("|---|---:|")
+    for k in sorted(rows.keys()):
+        lines.append(f"| {k} | {_format_value(rows[k])} |")
+    lines.append("")
+    return lines
+
+
+def render_metrics_table13(metrics: dict[str, float]) -> str:
+    """Metrics dict を Harada 2024 Table 13 形式の Markdown に変換する.
+
+    Parameters
+    ----------
+    metrics : dict[str, float]
+        ``synthpop-jp evaluate`` が ``metrics.json`` に書き出すキー一式。
+
+    Returns
+    -------
+    str
+        Markdown 文字列。空の metrics でも最低限のヘッダを返す。
+    """
+    # キーをグループ分け
+    aggregate_minimal: dict[str, float] = {}
+    pyramid_per_ft: dict[str, dict[str, float]] = defaultdict(dict)
+    rare_cell_global: dict[str, float] = {}
+    rare_cell_per_ft: dict[str, dict[str, float]] = defaultdict(dict)
+    cap_global: dict[str, float] = {}
+    cap_per_ft: dict[str, dict[str, float]] = defaultdict(dict)
+    others: dict[str, float] = {}
+
+    for key, value in metrics.items():
+        if key.startswith("aggregate.l1.pyramid_per_family_type."):
+            # aggregate.l1.pyramid_per_family_type.<ft>.<sex>
+            tail = key.removeprefix("aggregate.l1.pyramid_per_family_type.")
+            parts = tail.rsplit(".", 1)
+            if len(parts) == 2:
+                ft, sex = parts
+                pyramid_per_ft[ft][sex] = float(value)
+            else:
+                others[key] = float(value)
+        elif key.startswith("aggregate.l1."):
+            # minimal 5 + total
+            stat = key.removeprefix("aggregate.l1.")
+            aggregate_minimal[stat] = float(value)
+        elif key.startswith("rare_cell.per_family_type."):
+            # rare_cell.per_family_type.<metric>.<ft>
+            tail = key.removeprefix("rare_cell.per_family_type.")
+            parts = tail.split(".", 1)
+            if len(parts) == 2:
+                metric, ft = parts
+                rare_cell_per_ft[ft][metric] = float(value)
+            else:
+                others[key] = float(value)
+        elif key.startswith("rare_cell."):
+            metric = key.removeprefix("rare_cell.")
+            rare_cell_global[metric] = float(value)
+        elif key.startswith("cap.per_family_type."):
+            tail = key.removeprefix("cap.per_family_type.")
+            parts = tail.split(".", 1)
+            if len(parts) == 2:
+                metric, ft = parts
+                cap_per_ft[ft][metric] = float(value)
+            else:
+                others[key] = float(value)
+        elif key.startswith("cap."):
+            metric = key.removeprefix("cap.")
+            cap_global[metric] = float(value)
+        else:
+            others[key] = float(value)
+
+    lines: list[str] = ["# 評価レポート (Table 13 形式)", ""]
+
+    # 1. 統計整合性
+    if aggregate_minimal or pyramid_per_ft:
+        lines.append("## 1. 統計整合性 (aggregate L1)")
+        lines.append("")
+        lines.extend(_render_minimal_aggregate(aggregate_minimal))
+        lines.extend(_render_family_type_pyramid(pyramid_per_ft))
+
+    # 2. 秘匿性
+    if rare_cell_global or rare_cell_per_ft or cap_global or cap_per_ft:
+        lines.append("## 2. 秘匿性")
+        lines.append("")
+        lines.extend(_render_rare_cell(rare_cell_global, rare_cell_per_ft))
+        lines.extend(_render_cap(cap_global, cap_per_ft))
+
+    # 3. その他
+    if others:
+        lines.extend(_render_others(others))
+
+    return "\n".join(lines) + "\n"

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -156,6 +156,28 @@ class TestEvaluateIntegration:
         assert eval_result.exit_code == 1
         assert "real-persons-csv" in eval_result.output
 
+    def test_evaluate_writes_report_md_by_default(self, tmp_path: Path) -> None:
+        """evaluate 完了で output_dir/report.md が生成される (Issue #78)."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+        report_path = tmp_path / "out" / "report.md"
+        assert report_path.exists()
+        report = report_path.read_text(encoding="utf-8")
+        assert report.startswith("# ")
+        assert "aggregate" in report.lower() or "L1" in report
+
+    def test_evaluate_no_report_flag_skips_report_md(self, tmp_path: Path) -> None:
+        """--no-report 指定で report.md が生成されない (Issue #78)."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        result = runner.invoke(app, ["evaluate", "--config", str(config_path), "--no-report"])
+        assert result.exit_code == 0, result.output
+        report_path = tmp_path / "out" / "report.md"
+        assert not report_path.exists()
+        assert (tmp_path / "out" / "metrics.json").exists()
+
     def test_evaluate_calls_entry_point_plugins(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/reports/test_markdown.py
+++ b/tests/reports/test_markdown.py
@@ -1,0 +1,115 @@
+"""Tests for Table 13 形式 Markdown renderer (Issue #78)."""
+
+from __future__ import annotations
+
+from synthpop_jp.reports.markdown import render_metrics_table13
+
+
+class TestMinimalAggregateSection:
+    """minimal 5 統計の出力."""
+
+    def test_includes_father_child_age_diff(self) -> None:
+        metrics: dict[str, float] = {
+            "aggregate.l1.father_child_age_diff": 12.0,
+            "aggregate.l1.total": 12.0,
+        }
+        md = render_metrics_table13(metrics)
+        assert "father_child_age_diff" in md
+        assert "12.0" in md
+
+    def test_total_row_marked(self) -> None:
+        """total 行が他の行と区別できる形式（太字）で出る."""
+        metrics: dict[str, float] = {
+            "aggregate.l1.father_child_age_diff": 12.0,
+            "aggregate.l1.total": 45.0,
+        }
+        md = render_metrics_table13(metrics)
+        # total は太字で囲まれているか
+        assert "**total**" in md or "**45" in md
+
+
+class TestExtendedFamilyTypePyramidSection:
+    """family_type 別 pyramid を subsection で表示."""
+
+    def test_per_family_type_keys_listed(self) -> None:
+        metrics: dict[str, float] = {
+            "aggregate.l1.pyramid_per_family_type.couple.M": 5.0,
+            "aggregate.l1.pyramid_per_family_type.couple.F": 7.0,
+            "aggregate.l1.pyramid_per_family_type.single.M": 3.0,
+        }
+        md = render_metrics_table13(metrics)
+        assert "couple" in md
+        assert "single" in md
+        # 値も含まれる
+        assert "5.0" in md
+        assert "7.0" in md
+        assert "3.0" in md
+
+
+class TestRareCellSection:
+    """rare cell セクション."""
+
+    def test_global_metrics_present(self) -> None:
+        metrics: dict[str, float] = {
+            "rare_cell.fraction_below_5": 0.45,
+            "rare_cell.fraction_unique": 0.10,
+            "rare_cell.total_cells": 200.0,
+        }
+        md = render_metrics_table13(metrics)
+        assert "rare_cell" in md or "rare cell" in md.lower()
+        assert "0.45" in md or "0.450" in md or "0.4500" in md
+
+    def test_per_family_type_breakdown_listed(self) -> None:
+        metrics: dict[str, float] = {
+            "rare_cell.fraction_below_5": 0.45,
+            "rare_cell.per_family_type.fraction_below_5.couple": 0.30,
+        }
+        md = render_metrics_table13(metrics)
+        assert "couple" in md
+
+
+class TestCAPSection:
+    """CAP セクションは cap.* キーがあるときだけ出す."""
+
+    def test_cap_section_when_cap_keys_present(self) -> None:
+        metrics: dict[str, float] = {
+            "cap.generalized": 0.42,
+            "cap.targeted": 0.50,
+            "cap.coverage": 1.0,
+        }
+        md = render_metrics_table13(metrics)
+        assert "CAP" in md or "cap" in md
+        assert "0.42" in md or "0.420" in md or "0.4200" in md
+
+    def test_no_cap_section_when_absent(self) -> None:
+        metrics: dict[str, float] = {
+            "aggregate.l1.total": 10.0,
+        }
+        md = render_metrics_table13(metrics)
+        # CAP の見出しは出ない（cap キーが無いため）
+        assert "## 2.2" not in md or "CAP" not in md.split("## 2.2")[1] if "## 2.2" in md else True
+
+
+class TestOthersSection:
+    """未知キーは「その他」セクションでも切り捨てない."""
+
+    def test_unknown_keys_listed_in_others(self) -> None:
+        metrics: dict[str, float] = {
+            "aggregate.l1.total": 10.0,
+            "plugin_dummy.score": 99.0,
+        }
+        md = render_metrics_table13(metrics)
+        assert "plugin_dummy" in md or "99.0" in md
+
+
+class TestStructure:
+    """全体構造."""
+
+    def test_returns_string(self) -> None:
+        md = render_metrics_table13({"aggregate.l1.total": 10.0})
+        assert isinstance(md, str)
+        assert len(md) > 0
+
+    def test_starts_with_h1_title(self) -> None:
+        md = render_metrics_table13({"aggregate.l1.total": 10.0})
+        assert md.startswith("# ")


### PR DESCRIPTION
## 背景

`synthpop-jp evaluate` の出力は metrics.json (flat key-value) のみで、人間が読むには扁平すぎた。Phase 3.5 残作業のうち最後の Markdown 自動追記を実装。

`docs/spec/spec.md` §13 / Harada 2024 Table 13 で定義された **統計整合性 / 秘匿性 / 効用** の 3 ブロック構造に沿って、metrics.json を `report.md` に整形して書き出す。

Closes #78

## この変更で提供する価値

`synthpop-jp evaluate` 実行時に `output_dir/report.md` が自動生成され、Table 13 形式の表で読める。実験レポート (`experiments/<日付>-<slug>/report.md`) への貼り込みが 1 ファイルコピーで済む。`--no-report` で抑止可能、metrics.json は常に書く。

## 変更内容

- `src/synthpop_jp/reports/markdown.py` 新規 (~230 行)
  - `render_metrics_table13(metrics)`: flat dict を 3 セクション + subsections に整形
  - `_format_value`: 0–1 比率は 4 桁、それ以外は 1 桁
- `src/synthpop_jp/cli.py::evaluate`: `--no-report` フラグ + report.md 書き出し
- 単体 10 件 + CLI 統合 2 件追加

## 影響範囲

- 変更モジュール: `reports/markdown.py` 新規、`cli.py` evaluate サブコマンド
- 他モジュールへの影響: なし（既存 metrics.json 書き出しは維持）
- 既存 API の互換性: 維持
- 依存関係の変化: なし

## テスト

- 追加テスト: 12 件
- 変更テスト: 0
- カバレッジ: 維持

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest
All checks passed!
114 files already formatted
0 errors, 13 warnings
521 passed, 10 skipped in 9.72s
```

</details>

## レビュー時に確認してほしい点

1. セクション分類のキーマッピング（aggregate.l1.* / rare_cell.* / cap.* / それ以外）が漏れなく拾えているか
2. `--no-report` で skip した時に既存 metrics.json は引き続き書かれること（後方互換）
3. entry_points プラグインの追加キーが「その他」セクションで表示される設計（PR #83 と整合）

## 関連

- Issue #78（本 PR）
- 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/78#issuecomment-4341950548
- 自己レビュー: https://github.com/gghatano/synth-pop-harada-2024/issues/78#issuecomment-4341973781
- 関連 PR: #60, #62, #66, #72 (各評価器), #83 (entry_points プラグイン)

🤖 Generated with [Claude Code](https://claude.com/claude-code)