### PR TITLE
[#76] 開発者が Murata 式(3) 準拠の strict_extended モード (D, E 除外) で SA を回せるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -449,6 +449,7 @@ def generate(
         demographic_by_age_sex=demographic_by_age_sex,
         demo_ft_role=demographic_by_family_type_role,
         use_family_type_pyramid=settings.objective.use_family_type_pyramid,
+        exclude_male_female_pyramid=settings.objective.exclude_male_female_pyramid,
     )
     initial_score = objective.total_score
     console.print(f"[green]初期スコア:[/green] {initial_score:.1f}")
@@ -731,6 +732,7 @@ def evaluate(
         demographic_by_age_sex=demographic_by_age_sex,
         demo_ft_role=demo_ft_role,
         use_family_type_pyramid=settings.objective.use_family_type_pyramid,
+        exclude_male_female_pyramid=settings.objective.exclude_male_female_pyramid,
     )
     rare_cell_evaluator = RareCellEvaluator()
     metrics: dict[str, float] = {

--- a/src/synthpop_jp/config.py
+++ b/src/synthpop_jp/config.py
@@ -164,19 +164,45 @@ class AnnealingConfig(BaseModel):
 
 
 class ObjectiveConfig(BaseModel):
-    """目的関数のオプション設定 (Issue #71).
+    """目的関数のオプション設定 (Issue #71 / #76).
+
+    モード組合せ
+    ------------
+    - ``(use_family_type_pyramid=False, exclude_male_female_pyramid=False)``: minimal
+      Murata 式(1) 準拠の 5 統計（A, B, C, D, E）。デフォルト。
+    - ``(True, False)``: extended（研究拡張モード）
+      A, B, C, D, E + family_type × sex pyramid（5 + 2N 統計）。Issue #71 で追加。
+    - ``(True, True)``: strict_extended（Murata 式(3) 準拠）
+      A, B, C + family_type × sex pyramid（3 + 2N 統計）。論文 §3 / 式(3) で
+      D, E を除外する規定に従う（Issue #76）。
+    - ``(False, True)``: 意味不明（A, B, C のみで 3 統計）→ ValidationError。
 
     Attributes
     ----------
     use_family_type_pyramid : bool
-        True で family_type × sex demographic pyramid を minimal 5 統計に追加し、
-        合計 5 + 2N 統計の目的関数で SA を回す。`docs/spec/spec.md` §11.3。
-        デフォルト False（既存挙動維持）。
+        True で family_type × sex demographic pyramid を追加（Issue #71）。
+    exclude_male_female_pyramid : bool
+        True で D (male pyramid) と E (female pyramid) を目的関数から除外
+        （Murata 式(3) 準拠、Issue #76）。``use_family_type_pyramid=True`` と
+        併用する必要がある。
     """
 
     model_config = ConfigDict(extra="forbid")
 
     use_family_type_pyramid: bool = False
+    exclude_male_female_pyramid: bool = False
+
+    @model_validator(mode="after")
+    def validate_objective_mode(self) -> ObjectiveConfig:
+        """``exclude_male_female_pyramid`` は ``use_family_type_pyramid`` と併用が必須."""
+        if self.exclude_male_female_pyramid and not self.use_family_type_pyramid:
+            msg = (
+                "exclude_male_female_pyramid=True を指定するときは "
+                "use_family_type_pyramid=True も必須です（Murata 式(3) 準拠は family_type "
+                "別 pyramid を伴う）"
+            )
+            raise ValueError(msg)
+        return self
 
 
 class Settings(BaseModel):

--- a/src/synthpop_jp/evaluate/aggregate_metrics.py
+++ b/src/synthpop_jp/evaluate/aggregate_metrics.py
@@ -82,12 +82,14 @@ class AggregateStatL1Evaluator:
         *,
         demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
         use_family_type_pyramid: bool = False,
+        exclude_male_female_pyramid: bool = False,
     ) -> None:
         self._age_diff_parent_child = age_diff_parent_child
         self._age_diff_couple = age_diff_couple
         self._demographic_by_age_sex = demographic_by_age_sex
         self._demo_ft_role = demo_ft_role
         self._use_family_type_pyramid = use_family_type_pyramid
+        self._exclude_male_female_pyramid = exclude_male_female_pyramid
 
     def evaluate(self, pop: PopulationArrays) -> dict[str, float]:
         """合成人口の統計別 L1 誤差を計算して dict で返す.
@@ -103,6 +105,8 @@ class AggregateStatL1Evaluator:
             minimal 5 統計の ``aggregate.l1.<stat_name>`` + ``aggregate.l1.total``。
             ``use_family_type_pyramid=True`` のときは
             ``aggregate.l1.pyramid_per_family_type.<ft>.<sex>`` も追加。
+            ``exclude_male_female_pyramid=True`` のときは ``pyramid_male`` /
+            ``pyramid_female`` キーを出力しない（Murata 式(3) 準拠、Issue #76）。
         """
         stats = build_objective_stats(
             arrays=pop,
@@ -114,7 +118,12 @@ class AggregateStatL1Evaluator:
         )
         result: dict[str, float] = {}
         total = 0.0
+        # 0: father_child_age_diff, 1: mother_child_age_diff, 2: couple_age_diff
+        # 3: pyramid_male (D), 4: pyramid_female (E)
+        excluded_indices: tuple[int, ...] = (3, 4) if self._exclude_male_female_pyramid else ()
         for i in range(5):
+            if i in excluded_indices:
+                continue
             l1 = stats[i].l1_score()
             result[f"{self.name}.l1.{_STAT_NAMES[i]}"] = l1
             total += l1

--- a/src/synthpop_jp/optimize/objective.py
+++ b/src/synthpop_jp/optimize/objective.py
@@ -623,6 +623,11 @@ class ObjectiveState:
         拡張オフ時は ``None``（Issue #71）。
     n_family_types : int
         family_type pyramid の対象 family_type 数（拡張オフ時は 0）。
+    excluded_pyramid_indices : tuple[int, ...]
+        Murata 式(3) 準拠で目的関数から除外する pyramid インデックス
+        （Issue #76）。``exclude_male_female_pyramid=True`` のとき ``(3, 4)``
+        を持ち、stats[3] (D: male pyramid) / stats[4] (E: female pyramid) の
+        差分更新と total_score 計算をスキップする。
     """
 
     arrays: PopulationArrays
@@ -630,6 +635,7 @@ class ObjectiveState:
     total_score: float
     family_type_pyramid_offset: int | None = None
     n_family_types: int = 0
+    excluded_pyramid_indices: tuple[int, ...] = ()
 
     @classmethod
     def from_arrays(
@@ -641,6 +647,7 @@ class ObjectiveState:
         *,
         demo_ft_role: list[DemographicByFamilyTypeRoleRow] | None = None,
         use_family_type_pyramid: bool = False,
+        exclude_male_female_pyramid: bool = False,
     ) -> ObjectiveState:
         """PopulationArrays と統計テーブルから ObjectiveState を構築する.
 
@@ -659,11 +666,16 @@ class ObjectiveState:
             ``use_family_type_pyramid=True`` のとき必須。
         use_family_type_pyramid : bool
             True で family_type × sex pyramid を追加する（Issue #71）。
+        exclude_male_female_pyramid : bool
+            True で stats[3] (D: male pyramid) と stats[4] (E: female pyramid)
+            を差分更新と total_score 計算から除外（Murata 式(3) 準拠、Issue #76）。
+            ``use_family_type_pyramid=True`` と併用が前提。
 
         Returns
         -------
         ObjectiveState
-            初期化済みの ObjectiveState。total_score は全統計の L1 合計。
+            初期化済みの ObjectiveState。total_score は全統計の L1 合計
+            （除外指定がある場合はそれを差し引いた値）。
         """
         stats = build_objective_stats(
             arrays=arrays,
@@ -673,7 +685,8 @@ class ObjectiveState:
             demo_ft_role=demo_ft_role,
             use_family_type_pyramid=use_family_type_pyramid,
         )
-        total_score = sum(s.l1_score() for s in stats)
+        excluded: tuple[int, ...] = (3, 4) if exclude_male_female_pyramid else ()
+        total_score = sum(s.l1_score() for i, s in enumerate(stats) if i not in excluded)
         if use_family_type_pyramid:
             offset: int | None = 5
             n_ft = len(arrays.family_reg)
@@ -686,6 +699,7 @@ class ObjectiveState:
             total_score=total_score,
             family_type_pyramid_offset=offset,
             n_family_types=n_ft,
+            excluded_pyramid_indices=excluded,
         )
 
     # -----------------------------------------------------------------------
@@ -720,8 +734,10 @@ class ObjectiveState:
         sex_id = int(self.arrays.sex[person_idx])
         # sex_id=0 → stats[3], sex_id=1 → stats[4]
         pyramid_idx = 3 + sex_id
-        pyramid_stat = self.stats[pyramid_idx]
-        delta += _delta_pyramid(pyramid_stat, old_age, new_age)
+        # Murata 式(3) 準拠モード (Issue #76) では stats[3]/stats[4] をスキップ
+        if pyramid_idx not in self.excluded_pyramid_indices:
+            pyramid_stat = self.stats[pyramid_idx]
+            delta += _delta_pyramid(pyramid_stat, old_age, new_age)
 
         # --- family_type × sex pyramid (Issue #71、拡張オン時のみ) ---
         if self.family_type_pyramid_offset is not None:
@@ -922,8 +938,10 @@ class ObjectiveState:
         """
         sex_id = int(self.arrays.sex[person_idx])
         pyramid_idx = 3 + sex_id
-        pyramid_stat = self.stats[pyramid_idx]
-        _apply_pyramid_update(pyramid_stat, old_age, new_age)
+        # Murata 式(3) 準拠モード (Issue #76) では stats[3]/stats[4] をスキップ
+        if pyramid_idx not in self.excluded_pyramid_indices:
+            pyramid_stat = self.stats[pyramid_idx]
+            _apply_pyramid_update(pyramid_stat, old_age, new_age)
 
         # family_type × sex pyramid (Issue #71)
         if self.family_type_pyramid_offset is not None:

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -178,6 +178,38 @@ class TestEvaluateIntegration:
         assert not report_path.exists()
         assert (tmp_path / "out" / "metrics.json").exists()
 
+    def test_evaluate_strict_extended_omits_pyramid_male_female(self, tmp_path: Path) -> None:
+        """strict_extended config (use_family_type_pyramid + exclude_male_female_pyramid)
+        で metrics.json に pyramid_male/pyramid_female キーが含まれない (Issue #76)."""
+        config_data: dict[str, object] = {
+            "seed": 42,
+            "input_dir": str(SAMPLE_CASE_DIR),
+            "output_dir": str(tmp_path / "out"),
+            "annealing": {
+                "T0": 100.0,
+                "alpha": 0.99,
+                "max_iters": 200,
+                "evals_per_agent": 0,
+                "target_threshold": 0.0,
+                "patience": 0,
+            },
+            "objective": {
+                "use_family_type_pyramid": True,
+                "exclude_male_female_pyramid": True,
+            },
+        }
+        config_path = tmp_path / "config_strict.yaml"
+        config_path.write_text(yaml.dump(config_data))
+        gen_result = runner.invoke(app, ["generate", "--config", str(config_path)])
+        assert gen_result.exit_code == 0, gen_result.output
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0, eval_result.output
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert "aggregate.l1.pyramid_male" not in metrics
+        assert "aggregate.l1.pyramid_female" not in metrics
+        assert "aggregate.l1.father_child_age_diff" in metrics
+        assert any(k.startswith("aggregate.l1.pyramid_per_family_type.") for k in metrics)
+
     def test_evaluate_calls_entry_point_plugins(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/optimize/test_objective_strict_extended.py
+++ b/tests/optimize/test_objective_strict_extended.py
@@ -1,0 +1,270 @@
+"""Tests for strict_extended objective mode (Murata 2017 式(3) 準拠, Issue #76).
+
+`exclude_male_female_pyramid=True` で D (male pyramid), E (female pyramid) を
+目的関数から除外し、A + B + C + family_type×sex pyramid のみで SA を回す
+モードを追加する。
+
+論文 §3 / 式(3): "We do not employ the statistics D) and E) in our previous
+method but employ finer demographic pyramids by sex and family type"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from synthpop_jp.config import ObjectiveConfig
+from synthpop_jp.init.initial_population import InitStats, generate_initial_population
+from synthpop_jp.io.loaders import (
+    load_age_diff_couple,
+    load_age_diff_parent_child,
+    load_children_count_dist,
+    load_demographic_by_age_sex,
+    load_demographic_by_family_type_role,
+    load_family_type_counts,
+    load_family_type_mapping,
+    load_household_size_by_family_type,
+)
+from synthpop_jp.io.schemas import (
+    AgeDiffCoupleRow,
+    AgeDiffParentChildRow,
+    DemographicByAgeSexRow,
+    DemographicByFamilyTypeRoleRow,
+)
+from synthpop_jp.optimize.objective import ObjectiveState
+from synthpop_jp.optimize.state import PopulationArrays
+from synthpop_jp.rng import SeedRegistry
+
+
+class _Input(TypedDict):
+    age_diff_parent_child: list[AgeDiffParentChildRow]
+    age_diff_couple: list[AgeDiffCoupleRow]
+    demographic_by_age_sex: list[DemographicByAgeSexRow]
+    demo_ft_role: list[DemographicByFamilyTypeRoleRow]
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("pyproject.toml not found")
+
+
+_REPO_ROOT = _find_repo_root()
+_DATA_DIR = _REPO_ROOT / "data" / "sample_case"
+_CONFIGS_DIR = _REPO_ROOT / "configs"
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    return SeedRegistry(root=42).rng("init")
+
+
+@pytest.fixture
+def sample_stats() -> InitStats:
+    return InitStats(
+        family_type_counts=load_family_type_counts(_DATA_DIR / "family_type_counts.csv"),
+        children_count_dist=load_children_count_dist(_DATA_DIR / "children_count_dist.csv"),
+        demographic_by_age_sex=load_demographic_by_age_sex(
+            _DATA_DIR / "demographic_by_age_sex.csv"
+        ),
+        family_type_mapping=load_family_type_mapping(_CONFIGS_DIR / "family_type_mapping.yaml"),
+        household_size_by_family_type=load_household_size_by_family_type(
+            _DATA_DIR / "household_size_by_family_type.csv"
+        ),
+        demographic_by_family_type_role=load_demographic_by_family_type_role(
+            _DATA_DIR / "demographic_by_family_type_role.csv"
+        ),
+    )
+
+
+@pytest.fixture
+def sample_arrays(sample_stats: InitStats, rng: np.random.Generator) -> PopulationArrays:
+    return generate_initial_population(sample_stats, rng)
+
+
+@pytest.fixture
+def objective_input(sample_stats: InitStats) -> _Input:
+    return _Input(
+        age_diff_parent_child=load_age_diff_parent_child(_DATA_DIR / "age_diff_parent_child.csv"),
+        age_diff_couple=load_age_diff_couple(_DATA_DIR / "age_diff_couple.csv"),
+        demographic_by_age_sex=sample_stats.demographic_by_age_sex,
+        demo_ft_role=sample_stats.demographic_by_family_type_role or [],
+    )
+
+
+class TestObjectiveConfigValidator:
+    """exclude_male_female_pyramid と use_family_type_pyramid の組合せ検証."""
+
+    def test_default_both_false_is_valid(self) -> None:
+        """default は両方 False で valid."""
+        cfg = ObjectiveConfig()
+        assert cfg.use_family_type_pyramid is False
+        assert cfg.exclude_male_female_pyramid is False
+
+    def test_extended_only_is_valid(self) -> None:
+        """use_family_type_pyramid=True、exclude=False は valid (PR #72 の研究拡張モード)."""
+        cfg = ObjectiveConfig(use_family_type_pyramid=True, exclude_male_female_pyramid=False)
+        assert cfg.use_family_type_pyramid is True
+        assert cfg.exclude_male_female_pyramid is False
+
+    def test_strict_extended_is_valid(self) -> None:
+        """use_family_type_pyramid=True、exclude=True は valid (Murata 式(3) 準拠)."""
+        cfg = ObjectiveConfig(use_family_type_pyramid=True, exclude_male_female_pyramid=True)
+        assert cfg.use_family_type_pyramid is True
+        assert cfg.exclude_male_female_pyramid is True
+
+    def test_exclude_without_family_type_pyramid_rejected(self) -> None:
+        """exclude=True で use_family_type_pyramid=False は ValidationError."""
+        with pytest.raises(ValidationError):
+            ObjectiveConfig(use_family_type_pyramid=False, exclude_male_female_pyramid=True)
+
+
+class TestObjectiveStateStrictExtended:
+    """ObjectiveState が exclude_male_female_pyramid を反映する."""
+
+    def test_total_score_excludes_male_female_pyramid(
+        self, sample_arrays: PopulationArrays, objective_input: _Input
+    ) -> None:
+        """exclude=True の total_score は extended モードより低い (D, E が抜けるため)."""
+        obj_extended = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=False,
+        )
+        obj_strict = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=True,
+        )
+        # D + E の L1 が引かれるので strict は extended 以下
+        assert obj_strict.total_score <= obj_extended.total_score
+        # 厳密には D, E の L1 分だけ違う
+        d_l1 = obj_extended.stats[3].l1_score()
+        e_l1 = obj_extended.stats[4].l1_score()
+        assert abs(obj_extended.total_score - obj_strict.total_score - (d_l1 + e_l1)) < 1e-9
+
+    def test_apply_change_does_not_update_excluded_stats(
+        self, sample_arrays: PopulationArrays, objective_input: _Input
+    ) -> None:
+        """strict モードで age を動かしても D (stats[3]) / E (stats[4]) の observed 不変."""
+        obj = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=True,
+        )
+        before_d = obj.stats[3].observed.copy()
+        before_e = obj.stats[4].observed.copy()
+
+        # 5 人 age を動かす
+        rng = SeedRegistry(root=999).rng("test")
+        for _ in range(5):
+            idx = int(rng.integers(0, sample_arrays.n_persons))
+            old_age = int(sample_arrays.age[idx])
+            new_age = max(18, min(80, old_age + int(rng.choice([-1, 1]))))
+            if new_age != old_age:
+                obj.apply_change(idx, new_age)
+
+        # stats[3] / stats[4] は不変
+        assert np.array_equal(before_d, obj.stats[3].observed), (
+            "exclude モードで D (male pyramid) が変化した"
+        )
+        assert np.array_equal(before_e, obj.stats[4].observed), (
+            "exclude モードで E (female pyramid) が変化した"
+        )
+
+    def test_diff_update_consistent_with_recompute(
+        self, sample_arrays: PopulationArrays, objective_input: _Input
+    ) -> None:
+        """strict モードでも差分更新と再計算が一致."""
+        obj = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=True,
+        )
+        rng = SeedRegistry(root=999).rng("test")
+        for _ in range(5):
+            idx = int(rng.integers(0, sample_arrays.n_persons))
+            old_age = int(sample_arrays.age[idx])
+            new_age = max(18, min(80, old_age + int(rng.choice([-1, 1]))))
+            if new_age != old_age:
+                obj.apply_change(idx, new_age)
+
+        obj_recomputed = ObjectiveState.from_arrays(
+            arrays=sample_arrays,
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=True,
+        )
+        assert abs(obj.total_score - obj_recomputed.total_score) < 1e-9
+
+
+class TestAggregateStatL1EvaluatorStrictExtended:
+    """AggregateStatL1Evaluator が exclude モードで pyramid_male/female を出力しない."""
+
+    def test_strict_mode_omits_pyramid_male_female_keys(
+        self, sample_arrays: PopulationArrays, objective_input: _Input
+    ) -> None:
+        from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+
+        evaluator = AggregateStatL1Evaluator(
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=True,
+        )
+        result = evaluator.evaluate(sample_arrays)
+        assert "aggregate.l1.pyramid_male" not in result
+        assert "aggregate.l1.pyramid_female" not in result
+        # A, B, C は残る
+        assert "aggregate.l1.father_child_age_diff" in result
+        assert "aggregate.l1.mother_child_age_diff" in result
+        assert "aggregate.l1.couple_age_diff" in result
+        # family_type pyramid は残る
+        assert any(k.startswith("aggregate.l1.pyramid_per_family_type.") for k in result)
+        # total は残る
+        assert "aggregate.l1.total" in result
+
+    def test_extended_mode_keeps_pyramid_male_female_keys(
+        self, sample_arrays: PopulationArrays, objective_input: _Input
+    ) -> None:
+        """exclude=False (現状の研究拡張モード) では pyramid_male/female が残る (regression)."""
+        from synthpop_jp.evaluate.aggregate_metrics import AggregateStatL1Evaluator
+
+        evaluator = AggregateStatL1Evaluator(
+            age_diff_parent_child=objective_input["age_diff_parent_child"],
+            age_diff_couple=objective_input["age_diff_couple"],
+            demographic_by_age_sex=objective_input["demographic_by_age_sex"],
+            demo_ft_role=objective_input["demo_ft_role"],
+            use_family_type_pyramid=True,
+            exclude_male_female_pyramid=False,
+        )
+        result = evaluator.evaluate(sample_arrays)
+        assert "aggregate.l1.pyramid_male" in result
+        assert "aggregate.l1.pyramid_female" in result


### PR DESCRIPTION
## 背景

Issue #76 起票時は「残り 6 統計を実装」と書いたが、Murata 2017 PDF (`docs/papers/murata_2017.pdf`) の §3 / 式(3) を精査した結果、本質は別だった:

- 論文式(3) の 21 統計 = A (father-child diff) + B (mother-child diff) + C (couple diff) + F〜W (9 family types × 2 sex pyramid = 18)
- 論文 p.516 明記: **"We do not employ the statistics D) and E)" — 式(3) では粗い男女別 pyramid (D, E) を使わない**
- PR #72 (`use_family_type_pyramid=True`) は D, E と family_type pyramid を併存させており、式(3) 準拠ではなく **研究拡張モード** に相当する

スコープ再定義: **D, E 除外モードの追加** に絞る。9 family types フル (21 統計達成) は sample_case 拡張が必要なので別 Issue。

Closes #76

## この変更で提供する価値

`objective.use_family_type_pyramid: true` + `objective.exclude_male_female_pyramid: true` の config で、Murata 式(3) 準拠の **strict_extended モード** で SA を回せる。§15.1 Murata 再現実験で論文準拠モードを使う前提が整う。

## 変更内容

- `src/synthpop_jp/config.py`: `ObjectiveConfig.exclude_male_female_pyramid: bool = False` 追加 + model_validator (use_family_type_pyramid との併用必須)
- `src/synthpop_jp/optimize/objective.py`:
  - `ObjectiveState.excluded_pyramid_indices: tuple[int, ...]` attribute
  - `from_arrays`: total_score から除外 stat の L1 を引く
  - `_compute_delta_for_change`: stats[3]/stats[4] の delta 計算をスキップ
  - `_update_histograms`: stats[3]/stats[4] の histogram 更新をスキップ
- `src/synthpop_jp/evaluate/aggregate_metrics.py`: `exclude_male_female_pyramid=True` で `pyramid_male` / `pyramid_female` キー不出力
- `src/synthpop_jp/cli.py`: generate / evaluate で新フラグを通す
- 単体 9 件 + CLI 統合 1 件追加

## 影響範囲

- 変更モジュール: `config.py`, `optimize/objective.py`, `evaluate/aggregate_metrics.py`, `cli.py`
- 他モジュールへの影響: なし (default は both False で既存挙動と一致)
- 既存 API の互換性: 維持
- 依存関係の変化: なし

## テスト

- 追加テスト: 10 件
- 変更テスト: 0
- カバレッジ: 維持

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest
All checks passed!
115 files already formatted
0 errors, 13 warnings
531 passed, 10 skipped in 9.62s
```

</details>

## レビュー時に確認してほしい点

1. ObjectiveConfig の 4 通り組合せ (False/False, True/False, True/True, False/True) のうち、最後を ValidationError で禁止する判断
2. `excluded_pyramid_indices: tuple[int, ...]` attribute の設計（将来 D/E 以外の除外も拡張可能）
3. stats[3], stats[4] 自体は構築されたまま残し、SA 中だけ変化させない設計（情報源として参照可能）

## 関連

- Issue #76（本 PR）
- 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/76#issuecomment-4342234672
- 自己レビュー: https://github.com/gghatano/synth-pop-harada-2024/issues/76#issuecomment-4342273432
- 前段: PR #72 (extended objective 第 1 弾)
- 論文: `docs/papers/murata_2017.pdf` §3 / 式(3) (p.515-516)
- 後続: 9 family types 対応 (sample_case 拡張) は別 Issue、Issue #77 (初期生成誤差 0 化) は本 PR の後

🤖 Generated with [Claude Code](https://claude.com/claude-code)