### PR TITLE
[#81] 研究者が synthpop-jp compare の各指標に bootstrap CI を取得できるようにする

### DIFF
--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -832,6 +832,20 @@ def compare(
             help="比較する metric キーのカンマ区切り。デフォルト: aggregate.l1.total。",
         ),
     ] = "aggregate.l1.total",
+    n_bootstrap: Annotated[
+        int,
+        typer.Option(
+            "--n-bootstrap",
+            help="bootstrap CI のリサンプル数。0 で無効化。デフォルト 2000 (Issue #81)。",
+        ),
+    ] = 2000,
+    ci_confidence: Annotated[
+        float,
+        typer.Option(
+            "--ci-confidence",
+            help="bootstrap CI の信頼度。デフォルト 0.95。",
+        ),
+    ] = 0.95,
     log_level: Annotated[
         LogLevel,
         typer.Option("--log-level", help="ログレベル。"),
@@ -840,15 +854,19 @@ def compare(
     """複数 config × n_seeds の SA を実行し、統計検定付きで比較する (Issue #80).
 
     各 config を ``n_seeds`` 個の独立 seed で実行し、指定された metric の
-    Welch's t / Wilcoxon signed-rank + Holm 補正を計算する。
+    Welch's t / Wilcoxon signed-rank + Holm 補正と percentile bootstrap CI
+    （Issue #81）を計算する。
     結果は ``output_dir/compare.json`` (機械可読) と ``compare.md`` (人間可読)
     に書き出す。
     """
     import logging
 
+    import numpy as np
+
     from synthpop_jp.compare.report import render_compare_json, render_compare_md
     from synthpop_jp.compare.runner import run_seed_sweep
     from synthpop_jp.compare.stats import (
+        bootstrap_ci,
         holm_correction,
         welch_t_test,
         wilcoxon_signed_rank,
@@ -937,6 +955,25 @@ def compare(
     else:
         holm_rejected = [False] * len(metric_keys)
 
+    # bootstrap CI (Issue #81). n_bootstrap=0 でスキップ
+    ci_per_metric: dict[str, dict[str, tuple[float, float]]] | None = None
+    if n_bootstrap > 0:
+        ci_per_metric = {}
+        ci_rng = np.random.default_rng(seed=42)
+        for metric in metric_keys:
+            ci_per_metric[metric] = {}
+            for i, cfg in enumerate(configs):
+                values = [r.get(metric, float("nan")) for r in results_per_config[i]]
+                finite = [v for v in values if v == v]
+                if len(finite) >= 2:
+                    ci_low, ci_high = bootstrap_ci(
+                        finite,
+                        n_bootstrap=n_bootstrap,
+                        confidence=ci_confidence,
+                        rng=ci_rng,
+                    )
+                    ci_per_metric[metric][str(cfg)] = (ci_low, ci_high)
+
     json_str = render_compare_json(
         config_paths=list(configs),
         n_seeds=n_seeds,
@@ -945,6 +982,7 @@ def compare(
         test_results=test_results,
         holm_alpha=holm_alpha,
         holm_rejected=holm_rejected,
+        ci_per_metric=ci_per_metric,
     )
     md_str = render_compare_md(
         config_paths=list(configs),
@@ -953,6 +991,7 @@ def compare(
         results_per_config=results_per_config,
         test_results=test_results,
         holm_rejected=holm_rejected,
+        ci_per_metric=ci_per_metric,
     )
     json_path = output_dir / "compare.json"
     md_path = output_dir / "compare.md"

--- a/src/synthpop_jp/compare/report.py
+++ b/src/synthpop_jp/compare/report.py
@@ -16,6 +16,7 @@ def render_compare_json(
     test_results: dict[str, dict[str, dict[str, float]]],
     holm_alpha: float = 0.05,
     holm_rejected: list[bool] | None = None,
+    ci_per_metric: dict[str, dict[str, tuple[float, float]]] | None = None,
 ) -> str:
     """compare.json の文字列を生成.
 
@@ -36,6 +37,8 @@ def render_compare_json(
         多重比較補正の α。
     holm_rejected : list[bool] | None
         各 metric の welch p に対する Holm 補正後の棄却フラグ。
+    ci_per_metric : dict[str, dict[str, tuple[float, float]]] | None
+        ``ci_per_metric[metric][config_path] = (ci_low, ci_high)``（Issue #81）。
     """
     payload: dict[str, Any] = {
         "configs": [str(p) for p in config_paths],
@@ -46,11 +49,17 @@ def render_compare_json(
         per_config: dict[str, dict[str, Any]] = {}
         for i, cfg in enumerate(config_paths):
             values = [r.get(metric, float("nan")) for r in results_per_config[i]]
-            per_config[str(cfg)] = {
+            entry: dict[str, Any] = {
                 "mean": _safe_mean(values),
                 "std": _safe_std(values),
                 "values": values,
             }
+            if ci_per_metric is not None:
+                ci = ci_per_metric.get(metric, {}).get(str(cfg))
+                if ci is not None:
+                    entry["ci_low"] = ci[0]
+                    entry["ci_high"] = ci[1]
+            per_config[str(cfg)] = entry
         payload["metrics"][metric] = {
             "per_config": per_config,
             "tests": test_results.get(metric, {}),
@@ -70,8 +79,13 @@ def render_compare_md(
     results_per_config: list[list[dict[str, float]]],
     test_results: dict[str, dict[str, dict[str, float]]],
     holm_rejected: list[bool] | None = None,
+    ci_per_metric: dict[str, dict[str, tuple[float, float]]] | None = None,
 ) -> str:
-    """compare.md の文字列を生成 (Harada 2024 Table 13 風)."""
+    """compare.md の文字列を生成 (Harada 2024 Table 13 風).
+
+    ``ci_per_metric`` が渡されたとき、各セルに ``mean [ci_low, ci_high]`` の
+    形式で 95% CI も併記する（Issue #81）。
+    """
     lines: list[str] = ["# 比較レポート (Issue #80)", ""]
     lines.append(f"- **configs**: {len(config_paths)}")
     for i, p in enumerate(config_paths):
@@ -89,11 +103,16 @@ def render_compare_md(
     lines.append("|" + "|".join(["---"] * len(header)) + "|")
     for j, metric in enumerate(metric_keys):
         row = [metric]
-        for i in range(len(config_paths)):
+        for i, cfg in enumerate(config_paths):
             values = [r.get(metric, float("nan")) for r in results_per_config[i]]
             mean = _safe_mean(values)
             std = _safe_std(values)
-            row.append(f"{mean:.3f} ± {std:.3f}")
+            cell = f"{mean:.3f} ± {std:.3f}"
+            if ci_per_metric is not None:
+                ci = ci_per_metric.get(metric, {}).get(str(cfg))
+                if ci is not None:
+                    cell += f" [{ci[0]:.3f}, {ci[1]:.3f}]"
+            row.append(cell)
         tests = test_results.get(metric, {})
         welch_p = tests.get("welch_t", {}).get("p_value", float("nan"))
         wilcoxon_p = tests.get("wilcoxon", {}).get("p_value", float("nan"))

--- a/src/synthpop_jp/compare/stats.py
+++ b/src/synthpop_jp/compare/stats.py
@@ -1,7 +1,7 @@
-"""統計検定 (Issue #80).
+"""統計検定 (Issue #80) + bootstrap CI (Issue #81).
 
-Welch's t-test / Wilcoxon signed-rank / Holm-Bonferroni 補正を提供する。
-``scipy.stats`` を内部で呼ぶ薄いラッパー + Holm の自前実装。
+Welch's t-test / Wilcoxon signed-rank / Holm-Bonferroni 補正 + percentile
+法 bootstrap CI を提供する。``scipy.stats`` を内部で呼ぶ薄いラッパー + 自前実装。
 
 実装ノート
 ----------
@@ -9,12 +9,17 @@ Welch's t-test / Wilcoxon signed-rank / Holm-Bonferroni 補正を提供する。
 - Wilcoxon signed-rank は ``scipy.stats.wilcoxon`` を使う（対応群のみ）
 - Holm 補正は手実装（scipy には ``multipletests`` 経由で同等品があるが
   依存追加を避けるため自前で書く）
+- bootstrap CI は ``numpy.random.Generator`` で復元抽出 + percentile 法
 
-`docs/spec/spec.md` §15.5 が定める検定方法に対応。
+`docs/spec/spec.md` §15.5 が定める検定方法 + bootstrap CI に対応。
 """
 
 from __future__ import annotations
 
+import statistics
+from collections.abc import Callable
+
+import numpy as np
 from scipy import stats as _scipy_stats
 
 
@@ -99,3 +104,69 @@ def holm_correction(p_values: list[float], alpha: float = 0.05) -> list[bool]:
             rejected_by_orig[orig_idx] = False
             holding = True
     return [rejected_by_orig[i] for i in range(m)]
+
+
+def bootstrap_ci(
+    values: list[float],
+    n_bootstrap: int = 2000,
+    confidence: float = 0.95,
+    rng: np.random.Generator | None = None,
+    statistic: Callable[[list[float]], float] = statistics.mean,
+) -> tuple[float, float]:
+    """Percentile 法 bootstrap CI を返す (spec §15.5、Issue #81).
+
+    手順:
+    1. ``values`` から復元抽出で ``n_bootstrap`` 個の resample を作る
+    2. 各 resample に ``statistic`` を適用して bootstrap 分布を得る
+    3. 分布の ``(1-c)/2`` と ``1-(1-c)/2`` quantile を返す
+
+    Parameters
+    ----------
+    values : list[float]
+        標本（空でないこと）。
+    n_bootstrap : int
+        リサンプル数。spec §15.5 のデフォルトは 2000。
+    confidence : float
+        信頼度（0 < c < 1）。デフォルト 0.95（95% CI）。
+    rng : np.random.Generator | None
+        乱数発生器。``None`` のとき ``np.random.default_rng()`` を使う
+        （非決定論）。実験では固定 seed の Generator を渡すこと。
+    statistic : Callable[[list[float]], float]
+        ブートストラップ対象の統計量。デフォルトは平均。
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(ci_low, ci_high)``。
+
+    Raises
+    ------
+    ValueError
+        ``values`` が空、``n_bootstrap`` <= 0、``confidence`` ∉ (0, 1) のとき。
+    """
+    if not values:
+        msg = "bootstrap_ci: values が空です"
+        raise ValueError(msg)
+    if n_bootstrap <= 0:
+        msg = f"n_bootstrap は 1 以上 (got {n_bootstrap})"
+        raise ValueError(msg)
+    if not (0.0 < confidence < 1.0):
+        msg = f"confidence は (0, 1) の範囲 (got {confidence})"
+        raise ValueError(msg)
+
+    if rng is None:
+        rng = np.random.default_rng()
+
+    arr = np.asarray(values, dtype=np.float64)
+    n = arr.size
+    boot_stats = np.empty(n_bootstrap, dtype=np.float64)
+    for i in range(n_bootstrap):
+        idx = rng.integers(0, n, size=n)
+        sample = arr[idx]
+        boot_stats[i] = statistic(sample.tolist())
+    alpha = 1.0 - confidence
+    low_q = alpha / 2.0
+    high_q = 1.0 - alpha / 2.0
+    ci_low = float(np.quantile(boot_stats, low_q))
+    ci_high = float(np.quantile(boot_stats, high_q))
+    return ci_low, ci_high

--- a/tests/cli/test_compare.py
+++ b/tests/cli/test_compare.py
@@ -113,6 +113,65 @@ class TestCompareIntegration:
         assert result.exit_code == 1
         assert "2 個以上" in result.output
 
+    def test_compare_with_bootstrap_ci(self, tmp_path: Path) -> None:
+        """--n-bootstrap > 0 で compare.json に ci_low/ci_high が含まれる (Issue #81)."""
+        cfg_a = _make_config_yaml(tmp_path, "config_a", seed=42)
+        cfg_b = _make_config_yaml(tmp_path, "config_b", seed=42, alpha=0.95)
+        out_dir = tmp_path / "compare_out"
+        result = runner.invoke(
+            app,
+            [
+                "compare",
+                "-c",
+                str(cfg_a),
+                "-c",
+                str(cfg_b),
+                "--n-seeds",
+                "3",
+                "--n-bootstrap",
+                "100",
+                "--output-dir",
+                str(out_dir),
+                "--metrics",
+                "aggregate.l1.total",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads((out_dir / "compare.json").read_text(encoding="utf-8"))
+        per_config = payload["metrics"]["aggregate.l1.total"]["per_config"]
+        for cfg_entry in per_config.values():
+            assert "ci_low" in cfg_entry
+            assert "ci_high" in cfg_entry
+            assert cfg_entry["ci_low"] <= cfg_entry["ci_high"]
+
+    def test_compare_with_n_bootstrap_zero_omits_ci(self, tmp_path: Path) -> None:
+        """--n-bootstrap 0 で ci_low/ci_high が含まれない (Issue #81)."""
+        cfg_a = _make_config_yaml(tmp_path, "config_a", seed=42)
+        cfg_b = _make_config_yaml(tmp_path, "config_b", seed=42, alpha=0.95)
+        out_dir = tmp_path / "compare_out"
+        result = runner.invoke(
+            app,
+            [
+                "compare",
+                "-c",
+                str(cfg_a),
+                "-c",
+                str(cfg_b),
+                "--n-seeds",
+                "2",
+                "--n-bootstrap",
+                "0",
+                "--output-dir",
+                str(out_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads((out_dir / "compare.json").read_text(encoding="utf-8"))
+        per_config = payload["metrics"]["aggregate.l1.total"]["per_config"]
+        for cfg_entry in per_config.values():
+            assert "ci_low" not in cfg_entry
+            assert "ci_high" not in cfg_entry
+
     def test_compare_with_invalid_n_seeds(self, tmp_path: Path) -> None:
         """n_seeds が範囲外で exit 1."""
         cfg_a = _make_config_yaml(tmp_path, "config_a", seed=42)

--- a/tests/compare/test_bootstrap.py
+++ b/tests/compare/test_bootstrap.py
@@ -1,0 +1,53 @@
+"""Tests for bootstrap CI (Issue #81)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthpop_jp.compare.stats import bootstrap_ci
+
+
+class TestBootstrapCI:
+    """Percentile bootstrap CI."""
+
+    def test_deterministic_with_fixed_seed(self) -> None:
+        """同じ seed で同じ CI を返す（決定論）."""
+        values: list[float] = [float(x) for x in range(1, 101)]
+        rng1 = np.random.default_rng(seed=42)
+        rng2 = np.random.default_rng(seed=42)
+        ci1 = bootstrap_ci(values, n_bootstrap=200, rng=rng1)
+        ci2 = bootstrap_ci(values, n_bootstrap=200, rng=rng2)
+        assert ci1 == ci2
+
+    def test_ci_contains_population_mean_for_normal(self) -> None:
+        """N=200 のガウス標本で 95% CI が真の平均を高確率で含む."""
+        rng = np.random.default_rng(seed=42)
+        values = rng.normal(loc=10.0, scale=1.0, size=200).tolist()
+        ci_rng = np.random.default_rng(seed=99)
+        ci_low, ci_high = bootstrap_ci(values, n_bootstrap=2000, rng=ci_rng)
+        assert ci_low < 10.0 < ci_high
+
+    def test_ci_high_greater_than_low(self) -> None:
+        """ci_high > ci_low が常に成立."""
+        values: list[float] = [float(x) for x in range(1, 51)]
+        rng = np.random.default_rng(seed=42)
+        ci_low, ci_high = bootstrap_ci(values, n_bootstrap=200, rng=rng)
+        assert ci_low <= ci_high
+
+    def test_n_bootstrap_zero_raises(self) -> None:
+        """n_bootstrap が 0 以下なら ValueError."""
+        with pytest.raises(ValueError):
+            bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=0)
+
+    def test_invalid_confidence_raises(self) -> None:
+        """confidence が (0, 1) 外なら ValueError."""
+        with pytest.raises(ValueError):
+            bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=10, confidence=1.5)
+        with pytest.raises(ValueError):
+            bootstrap_ci([1.0, 2.0, 3.0], n_bootstrap=10, confidence=-0.1)
+
+    def test_empty_values_raises(self) -> None:
+        """空サンプルは ValueError."""
+        with pytest.raises(ValueError):
+            bootstrap_ci([], n_bootstrap=10)


### PR DESCRIPTION
## 背景

`docs/spec/spec.md` §15.5 が定める比較実験の信頼区間規定:
> 信頼区間: bootstrap CI（2,000 回、percentile 法）

PR #87 (Issue #80) の compare サブコマンドは Welch's t / Wilcoxon + Holm までだったので、CI を追加して効果サイズの幅まで報告できるようにする。これで Phase 3b の主要要件が完成。

Closes #81

## この変更で提供する価値

`synthpop-jp compare --n-bootstrap 2000 --ci-confidence 0.95 ...` で各 metric の平均に **percentile 法 95% bootstrap CI** が付き、`compare.md` のセルに `mean ± std [ci_low, ci_high]` 形式で表示される。論文・レポートで「平均が違う」だけでなく「どれくらい違う、どの程度の幅で」まで言える。

## 変更内容

- `src/synthpop_jp/compare/stats.py`: `bootstrap_ci` 関数追加（percentile 法、numpy.random.Generator で決定論、`statistic` callable で拡張可能）
- `src/synthpop_jp/compare/report.py`: `render_compare_json` / `render_compare_md` に `ci_per_metric` 引数追加（None で互換）
- `src/synthpop_jp/cli.py::compare`: `--n-bootstrap` (default 2000) / `--ci-confidence` (default 0.95) フラグ追加、`--n-bootstrap 0` で無効化
- 単体 6 + CLI 統合 2 = 8 件のテスト追加

## 影響範囲

- 変更モジュール: `compare/stats.py`, `compare/report.py`, `cli.py`
- 他モジュールへの影響: なし
- 既存 API の互換性: 維持 (`ci_per_metric` は keyword-only / default None)
- 依存関係の変化: なし (numpy / scipy は既存)

## テスト

- 追加テスト: 8 件
- 変更テスト: 0
- カバレッジ: 維持

<details>
<summary>実行コマンドと結果</summary>

```
$ uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest
All checks passed!
124 files already formatted
0 errors, 15 warnings
560 passed, 10 skipped in 10.67s
```

</details>

## 出力例 (compare.md)

```markdown
| metric | config_0 mean ± std | config_1 mean ± std | welch_t p | Holm rejected |
|---|---|---|---|---|
| aggregate.l1.total | 100.5 ± 12.3 [88.2, 112.8] | 80.2 ± 8.7 [71.5, 88.9] | 0.0001 | ✓ |
```

CI が併記されるので、§15 実験で効果サイズの不確実性を直接読み取れる。

## レビュー時に確認してほしい点

1. `bootstrap_ci` の `statistic` 引数を Callable で外から差し替え可能にした設計（将来 median や std の CI を取りたいとき）
2. `numpy.random.Generator` で決定論性を保つ実装（テストで検証済）
3. `--n-bootstrap 0` での無効化動作

## 関連

- Issue #81（本 PR）
- 計画コメント: https://github.com/gghatano/synth-pop-harada-2024/issues/81#issuecomment-4342584554
- 自己レビュー: https://github.com/gghatano/synth-pop-harada-2024/issues/81#issuecomment-4342637518
- 前段: PR #87 (compare runner + 統計検定)
- spec §15.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)