### PR TITLE
[#90] 第三者が進捗と手法を 2 本のドキュメントで把握できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,57 @@ e-Stat からの実データ取得は `scripts/fetch_estat.py`（Phase 2 以降�
 
 ---
 
-## 8. ロードマップ（要約）
+## 8. 実験結果と進捗レポート
+
+「いま何が動いて、何が分かっているか」をまとめたドキュメント群です。初めて触る人や久しぶりに戻ってきた人は、最初の 2 本（オーバービューと使い方ガイド）を読むと現在地と使い方が把握できます。
+
+### まず読むべき 2 本
+
+| ドキュメント | 内容 |
+|---|---|
+| [`docs/reports/2026-04-30-progress-overview.md`](docs/reports/2026-04-30-progress-overview.md) | Phase 1〜3 の到達点・主要な数値・残課題を 1 枚に統合した進捗オーバービュー |
+| [`docs/guides/how-it-works.md`](docs/guides/how-it-works.md) | SA・遷移・目的関数・評価器・compare runner・CLI の使い方を非技術者にも読める形で順に解説した読み物 |
+
+### 個別レポート（時系列のスナップショット）
+
+| 時期 | レポート | 内容 |
+|---|---|---|
+| Phase 2 | [`docs/reports/phase-02-benchmarks.md`](docs/reports/phase-02-benchmarks.md) | SA 性能ベンチ（1,000 世帯 × 20 万反復が median 5.2 秒、目標を 5.8 倍上回る） |
+| Phase 3 中盤 | [`docs/reports/2026-04-29-phase3-handoff.md`](docs/reports/2026-04-29-phase3-handoff.md) | age-swap / aggregate L1 / rare cell 着地時点の引き継ぎ |
+| Phase 3 拡張 | [`docs/reports/2026-04-29-phase3-extended-summary.md`](docs/reports/2026-04-29-phase3-extended-summary.md) | hybrid 遷移・CAP/TCAP・extended objective までの方法論まとめ（応用可能性も議論） |
+
+### 実験記録
+
+| 日付 | 実験 | 何を確かめたか |
+|---|---|---|
+| 2026-04-25 | [`experiments/2026-04-25-quickstart-sample-case/`](experiments/2026-04-25-quickstart-sample-case/) | Phase 1 初期生成（100 世帯 / 266 人）と HTML レポートの動作確認 |
+| 2026-04-29 | [`experiments/2026-04-29-sa-memory-profile/`](experiments/2026-04-29-sa-memory-profile/) | SA の RAM 消費を 1k〜100k 世帯で実測（100k 世帯でも 358MB） |
+
+過去の実験は内容を書き換えず、新しい知見は日付付きで「追記（時系列）」セクションに足していく運用です。
+
+---
+
+## 9. ロードマップ（要約）
 
 - **v0.1 (alpha)** — Phase 2 完了時点。`synthpop-jp quickstart` が 10 秒で動く。sample_case ダミー、age-change のみ、日英 README、LICENSE、CITATION.cff、CI 整備済
 - **v0.2** — Phase 4 完了時点。age-swap / hybrid、ARD を含む評価、e-Stat adapter、mkdocs サイト、3 本の notebook チュートリアル、SDV 比較表
 - **v0.3** — Phase 5 完了時点。改善ループ（rule_based / Pareto）、複数 trial、比較レポート自動生成、plugin entry_points 公開
 - **v1.0** — 論文公開と同時。Murata 2017 再現結果を `paper_results/` に固定、Zenodo DOI、CITATION.cff 更新、英語ドキュメント完備
 
-詳細は [`docs/reviews/action-plan.md`](docs/reviews/action-plan.md) §3 および [`docs/spec/spec.md`](docs/spec/spec.md) §16。
+### 2026-04-30 時点の到達状況
+
+- **Phase 1**: 完了（初期生成・I/O・決定性・CLI quickstart / validate-config）
+- **Phase 2**: 完了（SA MVP・差分更新・HTML レポート・性能ゲート達成）
+- **Phase 3a**: 主要要件達成（age-swap / hybrid 遷移、extended / strict_extended objective、初期誤差 0 化、family_type × role × sex サンプリング保証）。残: extended objective 21 統計フル対応、9 family types フル対応
+- **Phase 3.5**: 完了（aggregate L1 / rare cell / CAP/TCAP の 3 評価器、entry_points プラグイン、Table 13 形式 report.md）
+- **Phase 3b**: 完了（`compare` サブコマンド、Welch / Wilcoxon + Holm 補正、bootstrap CI）
+- **次のターゲット**: Phase 4（e-Stat 実データ adapter、mkdocs サイト、ARD 評価）
+
+詳細は [`docs/reports/2026-04-30-progress-overview.md`](docs/reports/2026-04-30-progress-overview.md)、[`docs/reviews/action-plan.md`](docs/reviews/action-plan.md) §3 および [`docs/spec/spec.md`](docs/spec/spec.md) §16 を参照してください。
 
 ---
 
-## 9. コントリビューション
+## 10. コントリビューション
 
 歓迎します。開発環境のセットアップ、Issue 駆動フロー、ブランチ / worktree 配置規約、新 family_type / 評価器の追加手順は [`CONTRIBUTING.md`](CONTRIBUTING.md) にまとめています。
 
@@ -159,7 +198,7 @@ e-Stat からの実データ取得は `scripts/fetch_estat.py`（Phase 2 以降�
 
 ---
 
-## 10. ライセンス
+## 11. ライセンス
 
 [Apache License 2.0](LICENSE)。依存ライブラリのクレジット骨子は [`NOTICE`](NOTICE) を参照（Phase 1 で `uv.lock` から自動生成に更新）。
 

--- a/docs/guides/how-it-works.md
+++ b/docs/guides/how-it-works.md
@@ -1,0 +1,323 @@
+# 仕組みと使い方ガイド — synthpop-jp が何をどう動かしているか
+
+このドキュメントは、`synthpop-jp` を使う人が「いま自分の手元で何が起きているのか」を理解しながら使えるように、**手法と CLI の使い方を順序立てて 1 ファイルにまとめた読み物** です。
+
+専門用語が初めて登場する箇所では、一言の補足を必ず添えています。深く知りたい場合は各セクションのリンク先（spec / 個別レポート）に進んでください。
+
+最初に読むべき関連ドキュメント:
+- 現在地と Phase ごとの実績は [`docs/reports/2026-04-30-progress-overview.md`](../reports/2026-04-30-progress-overview.md)
+- インストールと最短実行は [`README.md`](../../README.md) §3〜§4
+
+---
+
+## 1. 何のための道具か
+
+公開されている統計（家族類型別世帯数、年齢分布、世帯サイズ分布など、すでに集計済みの表）だけを材料に、**統計と整合する世帯と個人の人工的な個票** を作るための道具です。
+
+実在する個人の情報を使わずに集計表だけから個票を作るので、プライバシーを守りつつ、「もし個票があったら何ができるか」をシミュレーションできます。例えば、政策効果の推計や、データ分析パイプラインのテスト用データとして使えます。
+
+ただし、出来上がるのは **統計的な意味で** 整合した架空の人口です。実在する個人の代理ではありません。
+
+---
+
+## 2. 全体像 — 4 つの軸
+
+このプロトタイプは、4 つの軸を独立に組み合わせて動かす設計になっています。
+
+| 軸 | 役割 | 具体例 |
+|---|---|---|
+| **作る** | 統計を満たす初期人口を作る／少しずつ動かす | 初期生成、遷移（transition） |
+| **整える** | 「どれだけ統計に合っているか」を数値化する | 目的関数（objective） |
+| **評価する** | 出来上がった人口の品質・リスクを測る | 評価器（evaluator） |
+| **比較する** | 異なる設定の SA を回して優劣を判定する | compare runner |
+
+「整える」までは合成データを作る最適化ループの内側です。「評価する」「比較する」は完成した合成データに対する後付けの分析で、最適化ループの外側です。
+
+この分離により、新しい遷移や評価指標を足したいときも、他の軸に手を入れずに 1 ファイル単位で拡張できます。
+
+---
+
+## 3. 作る軸 — 初期生成と遷移
+
+### 3.1 初期人口を「ゼロから」作る
+
+最初の合成人口は、9 種類の家族類型（夫婦のみ、夫婦と子ども、単身世帯、母子世帯、…）について、世帯数の集計表に従って世帯を並べることから始まります。続いて、それぞれの世帯に属する個人の年齢を、役割（戸主・配偶者・子・親）と性別の条件付き分布からサンプリングします。
+
+このとき、`use_zero_error_init=true` を指定すると、Largest Remainder 法（決定論的な丸め方の 1 つ。各カテゴリの「割当数の小数部」が大きい順に切り上げる）で「世帯数の合計が統計と完全一致する」状態にできます。SA が始まる時点で初期誤差を 0 にできるので、最適化の伸びしろが目的関数の改善だけに集中します。
+
+詳細: spec §3、`src/synthpop_jp/initial/`
+
+### 3.2 SA で少しずつ動かす — 焼きなまし法とは
+
+初期人口は統計の一部しか合っていないため、それを目的関数（次節）に従って少しずつ修正します。この修正に使うアルゴリズムが SA（Simulated Annealing、焼きなまし法）です。
+
+SA のふるまいは次のとおりです。
+
+1. 現在の人口にちょっとした変更（**遷移**）を加える候補を提示する
+2. その変更で目的関数が下がる（良くなる）なら、必ず受け入れる
+3. 上がる（悪くなる）場合でも、ある確率で受け入れる
+4. 反復を進めるにつれて、悪化を受け入れる確率を下げていく
+
+「悪化も時々受け入れる」のは、近視眼的な改善（局所最適）に閉じ込められないためです。冷却スケジュール（温度を下げる速さ）を `T0` と `alpha` で制御します（`T_next = T_current × alpha`）。
+
+### 3.3 3 種類の遷移
+
+具体的な変更操作は次の 3 種類です。
+
+| 遷移 | 内容 | spec |
+|---|---|---|
+| `AgeChangeTransition` | 1 人の年齢を、同じ家族類型・役割・性別の条件付き分布からサンプリングし直す | §12.2A |
+| `AgeSwapTransition` | 同じ家族類型・性別の 2 人の年齢を交換する。**家族類型別の年齢ピラミッドを保ったまま** 個人の組み合わせだけを変えられる | §12.2B |
+| `HybridTransition` | age-change と age-swap を確率 `p_change` で混ぜる。`linear` スケジュールを使うと、序盤は age-change 中心、終盤は age-swap 中心に切り替わる | §12.2C |
+
+ハード制約（「親は子より 14 歳以上年上」「夫婦の片方が未成年でない」など spec §11.5 の制約）は、遷移の段階で `propose` がリトライして弾きます。目的関数には入れず、**遷移の中で物理的に守る** 設計です。
+
+詳細: `src/synthpop_jp/optimize/transitions.py`
+
+---
+
+## 4. 整える軸 — 目的関数
+
+目的関数 f(A) は「現在の合成集団 A が目標の統計群からどれだけずれているか」を数値化したものです。SA はこの値を下げる方向に人口を動かします。
+
+### 4.1 3 つのモード
+
+`configs/base.yaml` の `objective_mode` で 3 種類を選択できます。
+
+| モード | 統計数 | 内容 |
+|---|---|---|
+| `minimal` | 5 | 家族類型別世帯数、年齢分布、世帯サイズ分布、性別比、役割比 |
+| `extended` | 5 + 10 + 2N | minimal に family_type × sex の人口ピラミッド 10 統計を追加（PR #72） |
+| `strict_extended` | 3 + 2N | Murata 式 (3) に厳密に準拠（D, E 統計を除外、PR #85） |
+
+`extended` で増えるのは「家族類型ごとに男女別の年齢ピラミッドが、目標の家族類型別ピラミッドにどれだけ一致するか」です。家族構造に依存した年齢パターンをきちんと再現したいときに有効です。
+
+### 4.2 差分更新が性能の鍵
+
+人口は数百万人規模になりますが、1 step で動くのは 1〜2 人です。そのため、目的関数を毎回ゼロから計算し直すのではなく、変更された分だけ差分で更新する仕組み（`ObjectiveState._compute_delta_for_change`）を入れています。
+
+これにより 1 step あたりの計算時間が 1.5 μs 程度に収まり、20 万反復でも 5 秒程度で終わります（[Phase 2 ベンチマーク](../reports/phase-02-benchmarks.md)）。
+
+ただし、差分更新の実装にバグがあると SA が誤った勾配で動き続けるため、`test_apply_change_keeps_score_consistent`（差分更新と全再計算の一致テスト）を必ず残しています。
+
+詳細: `src/synthpop_jp/optimize/objective.py`、spec §11.3
+
+---
+
+## 5. 評価する軸 — 3 つの評価器
+
+SA で出来上がった合成人口を、3 種類の評価器で測ります。すべて `synthpop-jp evaluate` で同時実行され、結果は `metrics.json` に書き出されます。
+
+### 5.1 統計誤差（aggregate L1）
+
+目的関数と同じ統計群について、**目標値からの絶対誤差の合計**（L1 距離）を統計種別ごとに分けて出力します。`aggregate.l1.total` / `aggregate.l1.family_type` / `aggregate.l1.age` のように細分化されているため、「どの統計が合わせきれていないか」が一目で分かります。
+
+目的関数の値そのものよりも、人間が読んで意味を取りやすい数値です。
+
+### 5.2 rare cell（低頻度カテゴリ監視）
+
+目的関数を強く最適化すると、低頻度のカテゴリ（例: 80 歳以上の特定の家族構成）に過適合し、「合成データには出現するが現実にはありえない組み合わせ」が混じることがあります。
+
+`RareCellEvaluator` は family_type × age の cell ごとに「人数が k 人以下の cell の割合」を計算します。`rare_cell.unique_rate`（k=1）が高いと過適合の兆候です。
+
+### 5.3 CAP / TCAP（属性推論リスク）
+
+合成データから個人の属性をどれだけ推論できるかを測る指標です（Harada 2024 §5.2、spec/metrics.md §5.2）。
+
+- **CAP**（Generalized CAP）: 合成集団内で同じ属性パターンを持つレコード群の中に、ある target カテゴリがどれだけ集中しているか
+- **TCAP**: それを実集団の真の分布に対して校正した値
+
+合成データだけからは「個人の特定」までは行けない作りでも、**特定の属性パターンを持つ人の他の属性が高確率で当たる** ようなら問題です。CAP/TCAP はこの「集中度」を 0〜1 の値で出します。
+
+CAP は実個票（`real-persons-csv`）を渡したときだけ計算されます。**目的関数には入れず観測のみ** という設計判断は spec §11.6 の「目的関数を強く最小化すると低頻度カテゴリが過適合し、属性推論耐性が下がる」という警告に対応しています。
+
+### 5.4 評価器の追加方法
+
+`synthpop_jp.evaluators` の entry_point に新しい Evaluator を登録すると、`evaluate` コマンドが自動的に拾います。Evaluator は次の Protocol を満たすだけで OK です。
+
+```python
+class Evaluator(Protocol):
+    name: str
+    def evaluate(self, pop: PopulationArrays) -> dict[str, float]: ...
+```
+
+詳細: `src/synthpop_jp/evaluate/`、spec §13
+
+---
+
+## 6. 比較する軸 — compare runner
+
+「config A と config B、どっちが本当に良いのか？」を統計的に判定する仕組みです。
+
+### 6.1 何をしているか
+
+`synthpop-jp compare -c configs/A.yaml -c configs/B.yaml --n-seeds 10` を実行すると、
+
+1. 各 config を 10 個の独立した seed で SA 実行する
+2. 指定した metric（デフォルトは `aggregate.l1.total`）の分布を 2 つ得る
+3. 両者の差を Welch's t-test と Wilcoxon signed-rank で検定する
+4. 複数 metric を比較する場合は Holm 補正で多重検定の影響を抑える
+5. percentile bootstrap で 95% 信頼区間を出す
+
+結果は `outputs/compare/compare.json`（機械可読）と `compare.md`（人間可読）に書き出されます。
+
+### 6.2 なぜ必要か
+
+SA は乱数に依存するため、同じ config でも seed が違えば結果が変わります。「config A の方が L1 が小さかった」が **たまたまの seed の差** なのか **本当の手法の差** なのかを切り分けるには、複数 seed で回して統計検定するしかありません。
+
+10〜30 seed あれば、Phase 3 規模の比較なら有意差は検出できる範囲に入ります（spec §15.2 の比較計画）。
+
+詳細: `src/synthpop_jp/compare/`、PR #87 / #88
+
+---
+
+## 7. CLI の使い方 — 一連の流れ
+
+ここまでの 4 軸が、コマンドラインからは次の順序で使えます。
+
+### Step 1: インストール確認
+
+```bash
+git clone https://github.com/gghatano/synth-pop-harada-2024.git
+cd synth-pop-harada-2024
+uv sync --frozen
+uv run synthpop-jp --help
+```
+
+### Step 2: 設定の妥当性チェック
+
+```bash
+uv run synthpop-jp validate-config configs/base.yaml
+# ✓ Config is valid: configs/base.yaml
+```
+
+YAML が壊れていたり値が範囲外だと、行番号付きでエラーが出ます。
+
+### Step 3: 動作確認 — quickstart
+
+同梱のダミーデータを使って、初期生成だけを実行します（SA は走りません）。
+
+```bash
+uv run synthpop-jp quickstart --seed 42
+# outputs/quickstart/synthetic_households.csv
+# outputs/quickstart/synthetic_persons.csv
+# outputs/quickstart/metrics.json
+```
+
+10 秒以内（実測 1.1 秒）に 3 つのファイルが出来上がります。中身は CSV なので、Excel や pandas でそのまま開けます。
+
+### Step 4: SA 最適化 — generate
+
+`generate` は初期生成のあとに SA を回します。`configs/base.yaml` の `annealing` セクションで温度・反復数・冷却率を制御します。
+
+```bash
+uv run synthpop-jp generate --config configs/base.yaml --seed 42
+```
+
+SA の進行は `metrics.json` の `best_score` などから追えます。長時間の実行を中断したいときは Ctrl+C で止め、`--resume <checkpoint>` で続きから再開できます。
+
+### Step 5: 評価 — evaluate
+
+`generate` が出力した `synthetic_persons.csv` を読み込み、3 種の評価器を順次実行します。
+
+```bash
+uv run synthpop-jp evaluate --config configs/base.yaml
+# metrics.json に aggregate.l1.* / rare_cell.* キーが追記される
+# report.md に Harada 2024 Table 13 形式の表が追記される
+```
+
+CAP/TCAP も計算したい場合は、実個票（あれば）を渡します。
+
+```bash
+uv run synthpop-jp evaluate --config configs/base.yaml --real-persons-csv data/real/persons.csv
+# metrics.json に cap.* キーも追記される
+```
+
+### Step 6: 比較実験 — compare
+
+複数の config を統計検定付きで比較します。
+
+```bash
+uv run synthpop-jp compare \
+  -c configs/minimal.yaml \
+  -c configs/extended.yaml \
+  --n-seeds 10 \
+  --metrics aggregate.l1.total,rare_cell.unique_rate \
+  --output-dir outputs/compare-2026-04-30
+```
+
+数分〜数十分かかります（n_seeds × max_iters に比例）。終了すると `compare.md` に「config A vs config B、p-value=0.012、95%CI=[-0.04, -0.01]」のような表が並びます。
+
+---
+
+## 8. 設定ファイルの読み方
+
+`configs/base.yaml` は次のような構造です。
+
+```yaml
+seed: 42                          # 乱数シード（同じ seed なら bitwise 一致で再現）
+input_dir: data/sample_case       # 入力 CSV のディレクトリ
+output_dir: outputs/quickstart    # 出力先
+
+annealing:
+  T0: 100.0                       # 初期温度（高いほど序盤に広く探索）
+  alpha: 0.999                    # 冷却率（1.0 に近いほどゆっくり冷える）
+  max_iters: 1000000              # 最大反復回数
+  evals_per_agent: 1000           # 1 人あたりの評価回数上限
+  target_threshold: 0.0           # この値以下になったら停止（0 で無効）
+  patience: 0                     # best_score 不改善反復の上限（0 で無効）
+```
+
+設定を変えるときの典型的なシナリオ:
+
+| やりたいこと | 変えるところ |
+|---|---|
+| もう少し精度を上げたい | `max_iters` を 10 倍、`alpha` を 0.9999 に |
+| 早く終わらせたい | `max_iters` を 1/10、`patience` を 1000 などに |
+| 違う統計目標で動かす | `input_dir` を別ディレクトリへ |
+| 別の遷移方式を試す | `transitions:` セクション（spec §12.2C を参照）を編集 |
+
+詳細なフィールド定義は `src/synthpop_jp/config.py` の `Settings` モデルを参照してください。pydantic v2 のモデルなので、フィールド名・型・デフォルト値・バリデーション規則がコードからそのまま読めます。
+
+---
+
+## 9. もっと深く知りたいときに
+
+### 仕組みについて
+
+| 知りたいこと | 参照先 |
+|---|---|
+| Murata 2017 の元の式 | [`docs/spec/spec.md`](../spec/spec.md) §11〜§12 |
+| Harada 2024 の評価軸 | [`docs/spec/metrics.md`](../spec/metrics.md) |
+| 評価器の数式定義 | [`docs/spec/metrics.md`](../spec/metrics.md) §5〜§6 |
+
+### 過去の実験から学ぶ
+
+| 知りたいこと | 参照先 |
+|---|---|
+| 性能はどれくらい出るか | [`docs/reports/phase-02-benchmarks.md`](../reports/phase-02-benchmarks.md) |
+| メモリ消費はどうか | [`experiments/2026-04-29-sa-memory-profile/report.md`](../../experiments/2026-04-29-sa-memory-profile/report.md) |
+| Phase 3 拡張の方法論 | [`docs/reports/2026-04-29-phase3-extended-summary.md`](../reports/2026-04-29-phase3-extended-summary.md) |
+
+### 自分で実装に手を入れたい
+
+| 知りたいこと | 参照先 |
+|---|---|
+| 開発フロー全体 | [`docs/getting-started/development-workflow.md`](../getting-started/development-workflow.md) |
+| Issue 駆動 | [`docs/rules/issue-driven-development.md`](../rules/issue-driven-development.md) |
+| TDD ルール | [`docs/rules/tdd.md`](../rules/tdd.md) |
+| 新しい評価器の追加 | [`CONTRIBUTING.md`](../../CONTRIBUTING.md) |
+
+### コントリビュート
+
+新しい遷移や評価器を追加したいときは、対応する Protocol を満たすクラスを書き、entry_points に登録するだけです。詳細は [`CONTRIBUTING.md`](../../CONTRIBUTING.md) を参照してください。
+
+---
+
+## 10. このドキュメントの位置付け
+
+- **本ガイド (`how-it-works.md`)**: 「読みながら手元で動かして覚える」目的の読み物
+- **進捗オーバービュー** ([`docs/reports/2026-04-30-progress-overview.md`](../reports/2026-04-30-progress-overview.md)): 「現在地・実績・残課題」の 1 枚要約
+- **個別レポート** (`docs/reports/*.md`、`experiments/*/report.md`): その時点のスナップショット。書き換えず追記する
+
+仕組みや CLI の挙動が変わったら、本ガイドも更新します。

--- a/docs/reports/2026-04-30-progress-overview.md
+++ b/docs/reports/2026-04-30-progress-overview.md
@@ -1,0 +1,222 @@
+# 2026-04-30 進捗オーバービュー — Phase 1〜3 の到達点と実験結果
+
+このドキュメントは、リポジトリを初めて触る人や、しばらく離れていた人が **「いま何が動いて、何が分かっていて、次に何をすれば良いか」を 1 ファイルで把握できる** ことを目的としています。
+
+専門用語が出てくる箇所には一言の補足を添えています。詳細は各セクションのリンク先（spec / 個別レポート / 実験記録）に逃がしてあります。
+
+- 対象 develop SHA: `60f00d9`（PR #50 merged 直後）
+- 本体テスト: 560 passed / 10 skipped
+- 関連レポート: `docs/reports/2026-04-29-phase3-extended-summary.md`、`docs/reports/2026-04-29-phase3-handoff.md`、`docs/reports/phase-02-benchmarks.md`
+
+---
+
+## 1. 非技術者向け要約
+
+合成人口（公開されている統計だけを材料に、人工的に作った世帯と個人のデータ）を作る道具を、Python で作っています。
+
+これまでに次の 3 つが揃いました。
+
+- **作る**: 統計に合うように、世帯と個人の合成データをコマンド 1 つで生成できる
+- **整える**: 焼きなまし法（後述）と呼ばれる仕組みで、生成したデータを少しずつ統計に近づけられる
+- **評価する**: 出来上がった合成データが「統計にどれくらい一致しているか」「個人を特定されるリスクがどれくらいか」を数値で測れる
+
+これらをすべて、コマンドラインから一連の流れとして使えます。性能面でも目標を上回っており（後述、1,000 世帯規模なら数秒で生成）、研究プロトタイプとしては実用段階に入りました。
+
+残っているのは、より多くの統計に対応すること（家族類型を 9 種類フル対応に増やす、目的関数を 21 統計まで広げる）と、e-Stat（政府統計の総合窓口）の実データを直接読み込む配管の整備です。
+
+---
+
+## 2. 現在地（一目で）
+
+### 何ができるか
+
+| 区分 | コマンド | 役割 |
+|---|---|---|
+| 生成 | `synthpop-jp quickstart` | 同梱ダミーデータから合成世帯・個人を 10 秒以内に生成 |
+| 生成 | `synthpop-jp generate --config foo.yaml` | 任意の設定で合成人口を生成（SA 含む） |
+| 検証 | `synthpop-jp validate-config configs/base.yaml` | 設定 YAML の妥当性チェック |
+| 評価 | `synthpop-jp evaluate <persons.csv>` | 統計誤差・rare cell・CAP/TCAP を `metrics.json` に書き出し |
+| 比較 | `synthpop-jp compare <config1> <config2> --seeds 10` | 複数 config × n seed で SA を回し、統計検定（Welch / Wilcoxon + Holm 補正）と bootstrap CI 付きの比較レポートを出す |
+
+使い方の詳細は [`docs/guides/how-it-works.md`](../guides/how-it-works.md) を参照してください。
+
+### 主要な数値
+
+- **生成性能**: 1,000 世帯 × 200,000 反復 SA が median 5.2 秒（目標 30 秒に対し 5.8 倍余裕）
+- **メモリ消費**: 100,000 世帯規模でも SA peak RSS は 358MB（25.8GB 物理 RAM の 1.4%）
+- **テスト**: 本体 560 passed / 10 skipped、CI smoke ベンチも組み込み済み
+- **評価器**: aggregate L1（5 統計＋extended で +10）/ rare cell / CAP/TCAP の 3 種が同時実行可能
+
+### コードの分離
+
+3 つの軸が独立に拡張できる構造になっています（spec §11〜§13、Protocol で分離）。
+
+- **作る** （遷移 / Transition）: `src/synthpop_jp/optimize/transitions.py`
+- **整える** （目的関数 / Objective）: `src/synthpop_jp/optimize/objective.py`
+- **評価する** （Evaluator / PrivacyMetric）: `src/synthpop_jp/evaluate/`
+
+新しい遷移や評価指標を足すときは、それぞれ独立に PR 1 本で完結できます。
+
+---
+
+## 3. Phase ごとの到達点
+
+### Phase 1（基盤と初期生成）— 完了
+
+「何もない状態から、統計に合った合成世帯と個人を生成できる」状態に到達しました。
+
+- pydantic v2 ベースの設定ローダ（壊れた CSV を渡すと行番号付きでエラーが出る）
+- `SeedRegistry` による階層的乱数管理（同じ seed なら bitwise 一致で再現）
+- `PopulationArrays` + Registry + Household / Person のドメインモデル
+- 9 種の `family_type` に対応する初期人口生成（SA を経ない段階での統計整合性は完全一致）
+- `synthpop-jp quickstart` / `validate-config` の 2 サブコマンド
+
+実例レポート: [`experiments/2026-04-25-quickstart-sample-case/report.md`](../../experiments/2026-04-25-quickstart-sample-case/report.md)
+
+### Phase 2（SA MVP と性能ゲート）— 完了
+
+初期生成した合成人口を、焼きなまし法（SA: Simulated Annealing、ランダムに少しずつ変更しながら段階的に良い解を探す確率的最適化）で統計に近づける機能と、その性能を担保する仕組みが揃いました。
+
+- `AgeChangeTransition`（1 人の年齢を動かす遷移）と `ObjectiveState`（目的関数の差分更新）
+- SA 1 step あたり 1.5 μs（差分更新による）、目標 100 μs を 67 倍上回る
+- benchmark 一式（CI で smoke 版が毎 PR 走り、本格版は手動 `make bench`）
+- メモリ実測（100k 世帯 × 200k 反復で 358MB、`trace.jsonl` は streaming で蓄積しない）
+- HTML レポート基盤（plotly inline、self-contained で 1MB 以内）
+
+ベンチマーク詳細: [`docs/reports/phase-02-benchmarks.md`](phase-02-benchmarks.md)
+メモリ実測詳細: [`experiments/2026-04-29-sa-memory-profile/report.md`](../../experiments/2026-04-29-sa-memory-profile/report.md)
+
+### Phase 3a（Murata 拡張: 作る軸）— 主要要件達成
+
+SA に乗せる遷移と目的関数を、Murata 2017 論文 §11〜§12 の仕様に合わせて拡張しました。
+
+- `AgeSwapTransition`（同じ家族類型・性別の 2 人の年齢を交換、§12.2B）
+- `HybridTransition`（age-change と age-swap を確率混合、§12.2C 前半）
+- 動的 `p_change` スケジュール（反復進行に応じて混合率を線形に変化、§12.2C 後半）
+- extended objective 第 1 弾（family_type × sex pyramid を 10 統計追加）
+- strict_extended モード（D, E 統計を除外、Murata 式(3) 準拠）
+- 初期生成の F-W 統計誤差 0 化（決定論的 Largest Remainder で開始時点の誤差を 0 に）
+- family_type × role × sex 分布の年齢サンプリング保証テスト
+
+残っているのは extended objective の 21 統計フル対応と 9 family types フル対応です。
+
+### Phase 3.5（評価器骨格）— 完了
+
+「合成データを評価する」軸に 3 種類の指標が揃いました。
+
+- `AggregateStatL1Evaluator`（統計別 L1 誤差レポータ、目的関数と同じ統計群）
+- `RareCellEvaluator`（rare cell 監視、低頻度カテゴリへの過適合を検出）
+- `CAP / TCAP Evaluator`（属性推論リスクのベースライン、Harada 2024 §5.2）
+- `evaluate` サブコマンドが上記を順次呼ぶ形（`metrics.json` に書き出し）
+- entry_points プラグイン機構（外部パッケージから評価器を差し込める）
+- Table 13 形式の `report.md` 自動追記
+
+### Phase 3b（比較 runner）— 完了
+
+複数 config × 複数 seed の SA を回して、統計的に有意な差があるかを判定する仕組みが揃いました。
+
+- `synthpop-jp compare <config>...` サブコマンド
+- n=10〜30 seed の SA を並列実行
+- Welch's t-test / Wilcoxon 検定 + Holm 補正
+- bootstrap CI（percentile 法 2,000 回）
+
+詳細な方法論まとめ: [`docs/reports/2026-04-29-phase3-extended-summary.md`](2026-04-29-phase3-extended-summary.md)
+
+---
+
+## 4. 実験結果ハイライト
+
+### 実験 1: quickstart 初期生成（Phase 1 確認）
+
+- 100 世帯 / 266 人の合成人口が約 1.1 秒で生成される
+- 家族構成の分布が入力統計と完全一致（SA 前なので当然）
+- HTML レポート（plotly 円グラフ + 人口ピラミッド + 整合性棒グラフ）が 1MB 以内で出力される
+
+含意: 生成パイプラインの土台は安定しており、Phase 2 以降の SA はこの初期人口を出発点として使える。
+
+詳細: [`experiments/2026-04-25-quickstart-sample-case/report.md`](../../experiments/2026-04-25-quickstart-sample-case/report.md)
+
+### 実験 2: SA メモリプロファイル（Phase 2 後半）
+
+- 100,000 世帯規模でも SA peak RSS は 358MB（物理 25.8GB の 1.4%）
+- 反復回数を 20k → 200k に 10 倍してもメモリはほぼ不変（trace.jsonl が streaming である裏付け）
+- HTML レポート生成は別プロセスで最大 179MB（100k 規模時）
+- 100k × 200k は時間的には 12〜30 分かかる（O(N) 候補生成のオーバーヘッド）
+
+含意: 「PC が固まる」のは SA 単独ではなく、複数の Claude Code エージェントとの同居が原因。100k 世帯以上は heavy 扱いとし、並列エージェントを控える運用ルールに反映済み（Issue #52）。
+
+詳細: [`experiments/2026-04-29-sa-memory-profile/report.md`](../../experiments/2026-04-29-sa-memory-profile/report.md)
+
+### 性能ベンチマーク（Phase 2 Exit gate）
+
+| ベンチ | 実測 | 目標 | 結果 |
+|---|---|---|---|
+| `ObjectiveState.propose_change` | 1.5 μs | < 100 μs | 67 倍速い |
+| `AgeChangeTransition.propose` | 7.5 μs | < 10 μs | 達成 |
+| SA 1,000 世帯 × 20 万反復 | 5.2 s | < 30 s | 5.8 倍余裕 |
+
+含意: 差分更新（O(1) 更新）が効いている証拠。21 統計フルに広げる場合でも、1 step あたりの差分計算は ~20% 増程度で収まることが PR #72 の実測で確認済み。
+
+詳細: [`docs/reports/phase-02-benchmarks.md`](phase-02-benchmarks.md)
+
+---
+
+## 5. 残課題と次の方向性
+
+### Phase 3a の残り
+
+- **extended objective の 21 統計フル対応**: 現状 5+10 = 15 統計まで。残り 6 統計（spec §11.3 の式定義）
+- **9 family types フル対応**: 現状 sample_case で扱う型のみ。残りの型を追加して `data/sample_case/` を拡張
+
+### Phase 4 以降（構想中）
+
+- **e-Stat 実データの取り込み配管**: `scripts/fetch_estat.py` を整備し、ダミーデータでなく国勢調査の実集計表で動かせるようにする
+- **改善ループ（rule_based / Pareto）**: 評価結果を見て config を自動調整する Phase 5 の準備
+- **mkdocs サイト化**: ドキュメント全体を Web で公開可能な形に
+
+詳細な作業計画: [`docs/reviews/action-plan.md`](../reviews/action-plan.md) §3.5 以降
+
+---
+
+## 6. ドキュメント全体地図
+
+### このプロジェクトを理解したい人向け
+
+| 目的 | 参照先 |
+|---|---|
+| 何ができるか / インストール | [`README.md`](../../README.md) |
+| 手法と CLI の使い方（本オーバービューと同じ並び） | [`docs/guides/how-it-works.md`](../guides/how-it-works.md) |
+| 開発フロー全体像 | [`docs/getting-started/development-workflow.md`](../getting-started/development-workflow.md) |
+| 仕様 | [`docs/spec/spec.md`](../spec/spec.md) |
+| 評価指標の定義 | [`docs/spec/metrics.md`](../spec/metrics.md) |
+
+### Phase ごとの実績を辿りたい人向け
+
+| Phase | レポート |
+|---|---|
+| Phase 1 実例 | [`experiments/2026-04-25-quickstart-sample-case/report.md`](../../experiments/2026-04-25-quickstart-sample-case/report.md) |
+| Phase 2 ベンチ | [`docs/reports/phase-02-benchmarks.md`](phase-02-benchmarks.md) |
+| Phase 2 メモリ | [`experiments/2026-04-29-sa-memory-profile/report.md`](../../experiments/2026-04-29-sa-memory-profile/report.md) |
+| Phase 3 中盤 handoff | [`docs/reports/2026-04-29-phase3-handoff.md`](2026-04-29-phase3-handoff.md) |
+| Phase 3 拡張まとめ | [`docs/reports/2026-04-29-phase3-extended-summary.md`](2026-04-29-phase3-extended-summary.md) |
+
+### 開発に参加する人向け
+
+| 目的 | 参照先 |
+|---|---|
+| Issue 駆動フロー | [`docs/rules/issue-driven-development.md`](../rules/issue-driven-development.md) |
+| TDD | [`docs/rules/tdd.md`](../rules/tdd.md) |
+| worktree 配置 | [`docs/rules/git-worktree.md`](../rules/git-worktree.md) |
+| ブランチ戦略 | [`docs/rules/branch-strategy.md`](../rules/branch-strategy.md) |
+| 実験管理 | [`docs/rules/experiment-management.md`](../rules/experiment-management.md) |
+| 文章スタイル | [`docs/rules/documentation-style.md`](../rules/documentation-style.md) |
+
+---
+
+## 7. このドキュメントの位置付け
+
+- **オーバービュー（本ドキュメント）**: 現在地と方向性の 1 枚要約。読み手が次にどのドキュメントを開くべきかの分岐点
+- **手法と使い方** ([`how-it-works.md`](../guides/how-it-works.md)): 「何をどう動かしているのか」を順を追って説明する読み物
+- **個別レポート** (`docs/reports/*.md`): その時点の進捗チェックポイント。書き換えず、新しいスナップショットを追加していく
+
+オーバービューは Phase の節目ごとに更新します（次回は Phase 4 着手時を想定）。


### PR DESCRIPTION
## 背景

Phase 1〜3 と複数の実験を経てプロトタイプが Phase 3a/3b/3.5 主要要件達成段階に到達したが、進捗・手法解説・実験結果が `docs/reports/` `experiments/` `docs/spec/` に分散しており、第三者（将来の開発者・PM・非エンジニアのレビュアー）が現在地と使い方を一読で把握できなかった。

Closes #90

## この変更で提供する価値

第三者が README と新規 2 本のドキュメントを読むだけで、本プロトタイプの **現在地・手法・使い方** を 1 セッションで把握できるようになる。

## 変更内容

- `docs/reports/2026-04-30-progress-overview.md` を新規作成: Phase 1〜3 の到達点・主要数値・実験結果・残課題を 1 枚に統合した進捗オーバービュー。既存 reports と experiments を横断して参照する索引も兼ねる
- `docs/guides/how-it-works.md` を新規作成: SA・3 種の遷移・目的関数 3 モード・評価器（aggregate L1 / rare cell / CAP/TCAP）・compare runner・CLI 6 サブコマンド・設定 YAML の読み方を、専門用語に補足を添えた読み物形式で解説
- README に §8「実験結果と進捗レポート」セクションを追加し、新規 2 本 + 既存 reports 3 本 + experiments 2 件への導線を整備（既存 §8〜§10 を §9〜§11 に繰り下げ）
- README §9 ロードマップに 2026-04-30 時点の Phase 別到達状況（Phase 1/2/3.5/3b 完了、Phase 3a 主要要件達成）を併記

## 影響範囲

- 変更モジュール: docs/ のみ。コードは無変更
- 他モジュールへの影響: なし
- 既存 API の互換性: なし（ドキュメントのみ）
- 依存関係の変化: なし
- 既存 reports / experiments の内容は書き換えていない（参照のみ）

## テスト

- 追加テスト: 0 件（ドキュメント変更のため）
- カバレッジ: 維持
- リンク存在確認: README から参照する 7 つのリンク先（progress-overview / how-it-works / phase-02-benchmarks / 2 件の phase3 reports / 2 件の experiments）と、両ドキュメントから参照する spec / rules / templates / CONTRIBUTING がすべて実在することを `test -f` で確認済み

## 確認してほしいポイント

- 用語の補足が初見の読者に通じるか（特に SA / 遷移 / 目的関数 / CAP/TCAP の説明箇所）
- Phase 別到達状況の記述が現状認識と一致しているか（Phase 3a 主要要件達成、Phase 3.5 / 3b 完了）
- 既存 §8〜§10 の繰り下げで意図せぬリンク切れが生じていないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)