### PR TITLE
[#92] PM が make merge-pr を GitHub Actions ベース PR でも実用できるようにする

### DIFF
--- a/scripts/merge_pr.py
+++ b/scripts/merge_pr.py
@@ -83,6 +83,13 @@ def check_pr_status(
     PR データは gh pr view --json state,mergeable,headRefName,statusCheckRollup
     の出力を想定する。
 
+    statusCheckRollup の各要素は ``__typename`` によって結果キーが異なる:
+
+    - ``CheckRun`` (GitHub Actions): ``conclusion`` キーに SUCCESS / FAILURE 等
+    - ``StatusContext`` (旧式 status API): ``state`` キーに SUCCESS / FAILURE 等
+
+    本関数は両方を許容し、``state`` を優先しつつ無ければ ``conclusion`` を見る。
+
     Parameters
     ----------
     pr_data:
@@ -109,9 +116,10 @@ def check_pr_status(
     if state != "OPEN":
         return "error", state, head_ref
 
-    # CI チェックが存在する場合、最後の状態が SUCCESS でなければ失敗
+    # CI チェックが存在する場合、最後の結果が SUCCESS でなければ失敗
     if status_checks:
-        last_status = status_checks[-1].get("state", "")
+        last_check = status_checks[-1]
+        last_status = last_check.get("state") or last_check.get("conclusion") or ""
         if last_status != "SUCCESS":
             return "ci_failed", state, head_ref
 

--- a/tests/scripts/test_merge_pr.py
+++ b/tests/scripts/test_merge_pr.py
@@ -631,3 +631,84 @@ class TestCheckPRStatus:
 
         status, _state, _head_ref = m.check_pr_status(pr_data)
         assert status == "ci_failed"
+
+    def test_checkrun_success_returns_ok(self) -> None:
+        """GitHub Actions CheckRun（conclusion=SUCCESS）→ 'ok'。
+
+        gh pr view --json statusCheckRollup の実出力では、CheckRun は
+        ``state`` キーを持たず ``conclusion`` キーが結果を保持する。
+        """
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/90-progress-docs",
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "conclusion": "SUCCESS",
+                    "status": "COMPLETED",
+                    "name": "py3.12 / ubuntu-latest",
+                    "workflowName": "CI",
+                }
+            ],
+        }
+
+        status, state, head_ref = m.check_pr_status(pr_data)
+        assert status == "ok"
+        assert state == "OPEN"
+        assert head_ref == "feature/90-progress-docs"
+
+    def test_checkrun_failure_returns_ci_failed(self) -> None:
+        """GitHub Actions CheckRun（conclusion=FAILURE）→ 'ci_failed'。"""
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/90-progress-docs",
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "conclusion": "FAILURE",
+                    "status": "COMPLETED",
+                    "name": "py3.12 / ubuntu-latest",
+                    "workflowName": "CI",
+                }
+            ],
+        }
+
+        status, _state, _head_ref = m.check_pr_status(pr_data)
+        assert status == "ci_failed"
+
+    def test_pr_91_actual_rollup_returns_ok(self) -> None:
+        """Issue #92 回帰: PR #91 で観測した実 JSON で 'ok' を返す。
+
+        本テストは Issue #92 で報告されたバグ（GitHub Actions 環境の
+        全 PR で make merge-pr が CI fail と誤判定する）の回帰防止のため、
+        実際の ``gh pr view 91 --json statusCheckRollup`` 出力をそのまま
+        fixture として使う。
+        """
+        m = _import_merge_pr()
+
+        pr_data = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "feature/90-progress-docs",
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "completedAt": "2026-04-30T07:01:00Z",
+                    "conclusion": "SUCCESS",
+                    "detailsUrl": "https://github.com/gghatano/synth-pop-harada-2024/actions/runs/25151952761/job/73724392232",
+                    "name": "py3.12 / ubuntu-latest",
+                    "startedAt": "2026-04-30T06:59:06Z",
+                    "status": "COMPLETED",
+                    "workflowName": "CI",
+                }
+            ],
+        }
+
+        status, _state, _head_ref = m.check_pr_status(pr_data)
+        assert status == "ok"


### PR DESCRIPTION
## 背景

PR #91 で `make merge-pr PR=91` が「CI が SUCCESS ではありません」で停止した。`scripts/merge_pr.py::check_pr_status` が `statusCheckRollup[-1]["state"]` を見ているが、GitHub Actions の CheckRun には `state` キーが無く `conclusion` が正解だったため、すべての GitHub Actions ベース PR で誤判定が発生していた。

Closes #92

## この変更で提供する価値

PM が GitHub Actions ベースの PR でも `make merge-pr PR=N` 1 コマンドで ready→merge→worktree 削除→develop 同期を完結できるようになる。PR #50 で導入した「1 コマンド化」の本来の価値が回復する。

## 変更内容

- `check_pr_status` の statusCheckRollup 判定で `state` を優先しつつ無ければ `conclusion` を見る形に変更（CheckRun と StatusContext の両対応）
- 既存テストで仮定していた StatusContext (`state` キー) 形式に加え、CheckRun (`conclusion` キー) 形式の単体テストを 2 件追加（SUCCESS / FAILURE）
- 回帰テスト 1 件追加: PR #91 の `gh pr view --json statusCheckRollup` 実出力をそのまま fixture 化
- docstring を更新し、typename ごとのキー差を明記

## 影響範囲

- 変更モジュール: `scripts/merge_pr.py` (1 箇所、2 行) / `tests/scripts/test_merge_pr.py` (3 ケース追加)
- 他モジュールへの影響: なし
- 既存 API の互換性: `state` を優先するため、StatusContext 形式の既存挙動は完全に維持
- 依存関係の変化: なし

## テスト

- 追加テスト: 3 件（CheckRun SUCCESS / FAILURE / PR #91 実出力回帰）
- 変更テスト: 0 件（既存 5 件の StatusContext 系テストはそのまま pass）
- カバレッジ: `tests/scripts/test_merge_pr.py` 27 passed
- 全体: 599 passed / 10 skipped
- CI parity: ruff check / ruff format --check / pyright / pytest すべて green

## 確認してほしいポイント

- StatusContext と CheckRun の両形式対応で OK か（他に `__typename` 系があるが、本 PR では非スコープ）
- `state or conclusion` の優先順序（既存の StatusContext 互換のため `state` を優先しているが、逆の方が安全との判断もありうる）
- 複数 check の AND 評価（現状 `[-1]` で last-wins）は別 Issue で扱う方針で問題ないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)