### PR TITLE
[#96] 研究者が合成データの全体一致度を 1 コマンドで測れるようにする

### DIFF
--- a/docs/plans/issue-96.md
+++ b/docs/plans/issue-96.md
@@ -1,0 +1,137 @@
+# 計画: Issue #96 — broad utility 評価器
+
+対象 Issue: #96
+計画作成日: 2026-04-30
+担当: Claude (autonomous)
+
+---
+
+## 1. 再確認: 成功条件
+
+| 成功条件 | 担保方法 |
+|---|---|
+| `BroadUtilityEvaluator` が独立クラスとして実装される | `src/synthpop_jp/evaluate/utility/broad.py` |
+| 単変量 TV / L1 per attribute、属性ペア joint TV、相関 Frobenius 差の 3 指標が `metrics.json` に出力される | `evaluate(synthetic, holdout)` の戻り値キーで保証 |
+| `synthpop-jp evaluate` から自動呼び出しされる | CLI に `--real-persons-csv` がある場合に実行 |
+| 既知の小データで数値計算が手計算と一致するユニットテスト | `tests/evaluate/test_broad_utility.py` |
+| Table 13 形式 `report.md` に該当セクションが追記される | `src/synthpop_jp/reports/markdown.py` 拡張 |
+
+## 2. 設計方針
+
+### 2.1 評価器の構造
+
+CAPEvaluator と同様、**`evaluate(synthetic, holdout)` シグネチャ** を採用する（broad utility は real reference を要するため）。`Evaluator` Protocol（`evaluate(pop)`）には適合しないが、CAPEvaluator が同じ理由で外れているのと同型の判断。`PrivacyMetric` Protocol も借用しない（layer が異なる）。
+
+将来 `UtilityMetric` Protocol を追加する場合は別 Issue で扱う。本 PR は **クラス単体で成立する MVP** に絞る。
+
+### 2.2 計算する指標
+
+`docs/spec/spec.md` §13.2 / `docs/spec/metrics.md` §3 に基づき、以下を MVP として実装する。
+
+| カテゴリ | 指標 | 出力キー |
+|---|---|---|
+| 単変量 | TV (Total Variation distance) | `broad_utility.tv.<attr>` |
+| 単変量 | L1 (= 2*TV) | `broad_utility.l1.<attr>` |
+| ペア | joint TV per pair | `broad_utility.pair_tv.<a>__<b>` |
+| 相関 | Frobenius diff（混合型相関行列） | `broad_utility.correlation_frobenius_diff` |
+| 相関 | max-abs diff | `broad_utility.correlation_max_abs_diff` |
+| 集約 | sum_pair_tv（ペア TV の総和） | `broad_utility.sum_pair_tv` |
+
+対象属性は `("age", "sex", "role", "family_type")` の 4 つ（household_id は粒度が細か過ぎ、analysis 対象外）。
+
+### 2.3 混合型相関の実装（dython 準拠）
+
+外部依存 `dython` を **追加しない**（テストの数値一致は手計算 fixture で達成）。
+
+| 組合せ | 計算 |
+|---|---|
+| age × age（同一） | 1.0（自己相関） |
+| age × {sex, role, family_type} | Correlation Ratio（連続→カテゴリ） |
+| {sex, role, family_type} 内ペア | Cramér's V（カテゴリ→カテゴリ、補正なし） |
+
+Theil's U / Pearson は MVP では不採用（age はこのデータでは唯一の連続変数のため Pearson が出る組合せが無い）。Theil's U は asymmetric なため対称行列にならない → Frobenius 差を素直に取れない、対象外。
+
+実装は `numpy` + `scipy.stats.chi2_contingency` で完結。
+
+## 3. 実装方針
+
+### 追加するファイル
+
+- `src/synthpop_jp/evaluate/utility/__init__.py` — 空ファイル
+- `src/synthpop_jp/evaluate/utility/broad.py` — `BroadUtilityEvaluator` 実装
+- `tests/evaluate/test_broad_utility.py` — ユニットテスト（手計算 fixture）
+
+### 変更するファイル
+
+- `src/synthpop_jp/cli.py` — `evaluate` 関数に `BroadUtilityEvaluator` を組み込む（`--real-persons-csv` 有のとき呼ぶ）
+- `src/synthpop_jp/reports/markdown.py` — Broad utility セクションを report.md に追加（既存の Table 13 セクション末尾に追記）
+- `tests/cli/test_evaluate.py` — CLI 経由で broad_utility キーが出力されるテスト追加
+- `tests/reports/test_markdown.py` — broad utility セクション出力テスト追加
+
+### 着手順（小さい TDD サイクル）
+
+1. **Cycle 1**: 単変量 TV / L1 のテストを書く（家族構成の小サンプルで手計算）→ 実装
+2. **Cycle 2**: ペア joint TV のテスト → 実装
+3. **Cycle 3**: Cramér's V / Correlation Ratio の単体テスト → 実装
+4. **Cycle 4**: correlation_frobenius_diff / max_abs_diff のテスト → 実装
+5. **Cycle 5**: CLI 統合テスト → CLI 修正
+6. **Cycle 6**: report.md セクションテスト → markdown 修正
+
+## 4. テスト観点
+
+### 単体テスト
+
+- [ ] `_tv(p, q)` が手計算と一致（既知配列）
+- [ ] `_univariate_tv(synth, real, attr)` が age・sex・role・family_type で動く
+- [ ] `_pair_joint_tv(synth, real, a, b)` が手計算と一致
+- [ ] `_cramers_v(x, y)` が独立性で 0、完全従属で 1
+- [ ] `_correlation_ratio(num_x, cat_y)` がグループ平均一定で 0
+- [ ] `BroadUtilityEvaluator.evaluate(synth, real)` が期待キーをすべて含む
+- [ ] 同一データを synth/real に渡すと TV=0、frobenius=0
+
+### 結合テスト
+
+- [ ] CLI 経由で `--real-persons-csv` を渡したとき `metrics.json` に `broad_utility.*` キーが含まれる
+- [ ] `--real-persons-csv` 未指定なら broad_utility は出力されない
+
+### 回帰テスト
+
+- 既存 605 テストが grenshouse green を維持
+
+## 5. 実験計画
+
+該当なし（評価器自体の動作確認は単体テストで十分。実データでの数値感はフォローアップ Issue で）。
+
+## 6. リスクと代替案
+
+### 想定される失敗モード
+
+- **dython と数値が完全一致しない**: Cramér's V には bias correction が複数バージョンある。本 PR は **bias correction 無しの素朴な V**（Bergsma 補正なし）で固定し、テストでも同じ式の手計算を期待値とする。dython の選択肢との微小差は別 Issue。
+- **household_id を分析に含めるべきか**: 含めない（unique 値が大きすぎてカテゴリ相関が無意味）。Issue #96 のスコープ外として明記。
+
+### Plan B
+
+dython と完全一致が要求された場合は別 Issue として `dython` を dev-dependency 化し、参照値テストを追加する。
+
+## 7. 作成した worktree / branch
+
+- worktree: `gitworktree/feature-96-broad-utility/`
+- branch: `feature/96-broad-utility`
+- 派生元: `origin/develop` @ `9d188c5`（#95 マージ後）
+
+## 8. レビュー段階で確認したい論点
+
+- `dython` を dev-dep に追加せず手計算 fixture でテストする判断
+- `Theil's U` を MVP 不採用とした判断（asymmetric のため Frobenius と整合しない）
+- `household_id` を broad utility 対象外とした判断
+- CLI の `--real-persons-csv` 条件分岐方針
+
+---
+
+## チェックリスト
+
+- [x] 成功条件を再確認した
+- [x] 設計方針・実装方針・テスト観点・リスクの 4 項目が揃っている
+- [x] 実験は伴わない（該当なし）
+- [x] worktree / branch が作成済み
+- [ ] PR 本文から Issue にリンク

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -38,6 +38,13 @@
       "reportCallIssue": "none",
       "reportAttributeAccessIssue": "none",
       "reportPrivateUsage": "none"
+    },
+    {
+      "root": "tests/evaluate/test_broad_utility.py",
+      "reportPrivateUsage": "none",
+      "reportUnknownMemberType": "none",
+      "reportUnknownVariableType": "none",
+      "reportUnknownArgumentType": "none"
     }
   ]
 }

--- a/src/synthpop_jp/cli.py
+++ b/src/synthpop_jp/cli.py
@@ -757,12 +757,20 @@ def evaluate(
                 f"[red]エラー:[/red] --real-persons-csv が見つかりません: {real_persons_csv}"
             )
             raise typer.Exit(code=1)
-        console.print(f"[bold]CAP holdout:[/bold] {real_persons_csv}")
+        console.print(f"[bold]CAP / broad utility holdout:[/bold] {real_persons_csv}")
         holdout = reconstruct_population_arrays_from_persons_csv(real_persons_csv)
         cap_evaluator = CAPEvaluator()
         metrics.update(cap_evaluator.evaluate(arrays, holdout))
+
+        # Issue #96: broad utility (synthetic vs real reference)
+        from synthpop_jp.evaluate.utility.broad import BroadUtilityEvaluator
+
+        broad_evaluator = BroadUtilityEvaluator()
+        metrics.update(broad_evaluator.evaluate(arrays, holdout))
     else:
-        console.print("[yellow]--real-persons-csv 未指定のため CAP/TCAP はスキップ[/yellow]")
+        console.print(
+            "[yellow]--real-persons-csv 未指定のため CAP/TCAP・broad utility はスキップ[/yellow]"
+        )
 
     # metrics.json に追記（既存キーは保持）
     metrics_path = settings.output_dir / "metrics.json"

--- a/src/synthpop_jp/evaluate/utility/__init__.py
+++ b/src/synthpop_jp/evaluate/utility/__init__.py
@@ -1,0 +1,1 @@
+"""Utility metrics: broad utility (Phase 4a, Issue #96), narrow utility (Phase 4a, Issue #97)."""

--- a/src/synthpop_jp/evaluate/utility/broad.py
+++ b/src/synthpop_jp/evaluate/utility/broad.py
@@ -34,7 +34,9 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.stats import chi2_contingency  # pyright: ignore[reportMissingTypeStubs]
+from scipy.stats import (
+    chi2_contingency,  # pyright: ignore[reportMissingTypeStubs, reportUnknownVariableType]
+)
 
 if TYPE_CHECKING:
     from synthpop_jp.optimize.state import PopulationArrays

--- a/src/synthpop_jp/evaluate/utility/broad.py
+++ b/src/synthpop_jp/evaluate/utility/broad.py
@@ -1,0 +1,281 @@
+"""Broad utility evaluator (Phase 4a, Issue #96).
+
+合成データと参照（"real"）データの **全体としての一致度** を 3 つの指標で測る。
+
+提供するもの
+------------
+- :class:`BroadUtilityEvaluator`: synth と real の 2 入力で broad utility を計算する評価器
+
+出力キー命名規則
+----------------
+- ``broad_utility.tv.<attr>``: 単変量 Total Variation distance（0〜1）
+- ``broad_utility.l1.<attr>``: 単変量 L1 距離（= 2 × TV）
+- ``broad_utility.pair_tv.<a>__<b>``: 属性ペアの joint TV（pair は alphabetical 順）
+- ``broad_utility.sum_pair_tv``: 全 pair_tv の合計（属性ペア間の相関歪みのスカラ要約）
+- ``broad_utility.correlation_frobenius_diff``: 混合型相関行列の Frobenius norm 差
+- ``broad_utility.correlation_max_abs_diff``: 混合型相関行列の max-abs 差
+
+仕様参照
+--------
+- ``docs/spec/spec.md`` §13.2 / ``docs/spec/metrics.md`` §3
+- 混合型相関は dython.associations 準拠（Cramér's V / Correlation Ratio）。
+  本実装は外部依存 ``dython`` を導入せず ``scipy.stats`` で計算する。
+
+スコープ外
+----------
+- Theil's U (asymmetric なため Frobenius と整合しない、別 Issue)
+- Pearson 相関（age 以外の連続変数が無い前提）
+- ``household_id`` を解析対象に含めない（unique 値が多すぎる）
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.stats import chi2_contingency  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from synthpop_jp.optimize.state import PopulationArrays
+
+
+_DEFAULT_ATTRIBUTES: tuple[str, ...] = ("age", "sex", "role", "family_type")
+_NUMERIC_ATTRIBUTES: frozenset[str] = frozenset({"age"})
+
+
+def _column(pop: PopulationArrays, name: str) -> np.ndarray:
+    """``PopulationArrays`` から属性列を取り出す."""
+    if name == "age":
+        return np.asarray(pop.age, dtype=np.int64)
+    if name == "sex":
+        return np.asarray(pop.sex, dtype=np.int64)
+    if name == "role":
+        return np.asarray(pop.role, dtype=np.int64)
+    if name == "family_type":
+        return np.asarray(pop.family_type, dtype=np.int64)
+    if name == "household_id":
+        return np.asarray(pop.household_id, dtype=np.int64)
+    msg = f"Unknown attribute: {name!r}"
+    raise ValueError(msg)
+
+
+def _categorical_dist(values: np.ndarray) -> dict[int, float]:
+    """1D 配列を ``{value: probability}`` 形式の正規化分布に変換."""
+    n = int(values.shape[0])
+    if n == 0:
+        return {}
+    unique, counts = np.unique(values, return_counts=True)
+    return {int(v): float(c) / n for v, c in zip(unique.tolist(), counts.tolist(), strict=True)}
+
+
+def _tv_from_dicts(p: dict[int, float], q: dict[int, float]) -> float:
+    """2 つの離散分布の Total Variation 距離を計算（共通サポート上の和）."""
+    keys = set(p.keys()) | set(q.keys())
+    return 0.5 * sum(abs(p.get(k, 0.0) - q.get(k, 0.0)) for k in keys)
+
+
+def _univariate_tv(synth: np.ndarray, real: np.ndarray) -> float:
+    """同一属性の synth/real 配列から TV 距離を計算する（純関数）.
+
+    どちらか一方が空のときは 0.0 を返す（評価不能 → 中立値）。
+    """
+    if synth.shape[0] == 0 or real.shape[0] == 0:
+        return 0.0
+    return _tv_from_dicts(_categorical_dist(synth), _categorical_dist(real))
+
+
+def _pair_dist(x: np.ndarray, y: np.ndarray) -> dict[tuple[int, int], float]:
+    """2 つの 1D 配列から joint 分布を計算する."""
+    n = int(x.shape[0])
+    if n == 0:
+        return {}
+    pairs = list(zip(x.tolist(), y.tolist(), strict=True))
+    counts: dict[tuple[int, int], int] = {}
+    for a, b in pairs:
+        key = (int(a), int(b))
+        counts[key] = counts.get(key, 0) + 1
+    return {k: v / n for k, v in counts.items()}
+
+
+def _pair_joint_tv(
+    synth_x: np.ndarray, synth_y: np.ndarray, real_x: np.ndarray, real_y: np.ndarray
+) -> float:
+    """2 つの属性 (x, y) の joint TV 距離を計算する（純関数）."""
+    if synth_x.shape[0] == 0 or real_x.shape[0] == 0:
+        return 0.0
+    p = _pair_dist(synth_x, synth_y)
+    q = _pair_dist(real_x, real_y)
+    keys = set(p.keys()) | set(q.keys())
+    return 0.5 * sum(abs(p.get(k, 0.0) - q.get(k, 0.0)) for k in keys)
+
+
+def _cramers_v(x: np.ndarray, y: np.ndarray) -> float:
+    """Cramér's V を計算（カテゴリ × カテゴリ、bias 補正なし）.
+
+    定義: V = sqrt(chi2 / (n * min(r-1, c-1)))
+    片方の配列が定数（unique 値が 1）のときは 0 を返す（独立とみなす）。
+    """
+    n = int(x.shape[0])
+    if n == 0:
+        return 0.0
+    ux = np.unique(x)
+    uy = np.unique(y)
+    if ux.shape[0] < 2 or uy.shape[0] < 2:
+        return 0.0
+    # contingency table
+    table = np.zeros((ux.shape[0], uy.shape[0]), dtype=np.int64)
+    x_idx = {int(v): i for i, v in enumerate(ux.tolist())}
+    y_idx = {int(v): j for j, v in enumerate(uy.tolist())}
+    for xi, yi in zip(x.tolist(), y.tolist(), strict=True):
+        table[x_idx[int(xi)], y_idx[int(yi)]] += 1
+    chi2_stat, _, _, _ = chi2_contingency(table, correction=False)
+    chi2_val = float(chi2_stat)  # type: ignore[arg-type]
+    denom = float(n) * float(min(ux.shape[0] - 1, uy.shape[0] - 1))
+    if denom <= 0.0:
+        return 0.0
+    v_squared = chi2_val / denom
+    if v_squared < 0.0:
+        v_squared = 0.0
+    if v_squared > 1.0:
+        v_squared = 1.0
+    return float(np.sqrt(v_squared))
+
+
+def _correlation_ratio(num: np.ndarray, cat: np.ndarray) -> float:
+    """Correlation Ratio (eta) を計算する（連続 × カテゴリ）.
+
+    定義: eta = sqrt(SS_between / SS_total)。
+    SS_total が 0（全データが同値）のときは 0 を返す。
+    """
+    n = int(num.shape[0])
+    if n == 0:
+        return 0.0
+    num = num.astype(np.float64)
+    cat = cat.astype(np.int64)
+    total_mean = float(num.mean())
+    ss_total = float(((num - total_mean) ** 2).sum())
+    if ss_total == 0.0:
+        return 0.0
+    ss_between = 0.0
+    for c in np.unique(cat):
+        group = num[cat == c]
+        if group.shape[0] == 0:
+            continue
+        gm = float(group.mean())
+        ss_between += float(group.shape[0]) * (gm - total_mean) ** 2
+    eta_squared = ss_between / ss_total
+    if eta_squared < 0.0:
+        eta_squared = 0.0
+    if eta_squared > 1.0:
+        eta_squared = 1.0
+    return float(np.sqrt(eta_squared))
+
+
+def _build_correlation_matrix(
+    columns: dict[str, np.ndarray],
+    attrs: tuple[str, ...],
+) -> np.ndarray:
+    """属性ペアの相関を要素とする対称行列（n × n）を組み立てる.
+
+    対角は 1.0、非対角は (連続,カテゴリ) → eta、(カテゴリ,カテゴリ) → V。
+    age を含む組合せは Correlation Ratio、それ以外は Cramér's V。
+    """
+    n = len(attrs)
+    mat = np.zeros((n, n), dtype=np.float64)
+    for i, a in enumerate(attrs):
+        for j, b in enumerate(attrs):
+            if i == j:
+                mat[i, j] = 1.0
+                continue
+            if a in _NUMERIC_ATTRIBUTES and b in _NUMERIC_ATTRIBUTES:
+                # 同一の age と age はあり得ないし、age 以外の連続変数は無い
+                mat[i, j] = 1.0
+            elif a in _NUMERIC_ATTRIBUTES:
+                mat[i, j] = _correlation_ratio(columns[a], columns[b])
+            elif b in _NUMERIC_ATTRIBUTES:
+                mat[i, j] = _correlation_ratio(columns[b], columns[a])
+            else:
+                mat[i, j] = _cramers_v(columns[a], columns[b])
+    return mat
+
+
+def _all_pairs(attrs: Iterable[str]) -> list[tuple[str, str]]:
+    """属性のすべてのユニークなペア（順序固定）を返す."""
+    items = list(attrs)
+    pairs: list[tuple[str, str]] = []
+    for i in range(len(items)):
+        for j in range(i + 1, len(items)):
+            pairs.append((items[i], items[j]))
+    return pairs
+
+
+class BroadUtilityEvaluator:
+    """Broad utility 評価器（``synthetic`` と ``holdout`` の 2 入力）.
+
+    Attributes
+    ----------
+    name : str
+        ``"broad_utility"`` 固定。``metrics.json`` のキー prefix。
+    attributes : tuple[str, ...]
+        評価対象の属性名タプル。デフォルトは
+        ``("age", "sex", "role", "family_type")``。``household_id`` は
+        unique 値が多いため対象外（Issue #96 計画 §6 参照）。
+    """
+
+    name: str = "broad_utility"
+
+    def __init__(self, attributes: tuple[str, ...] = _DEFAULT_ATTRIBUTES) -> None:
+        self.attributes = attributes
+
+    def evaluate(
+        self,
+        synthetic: PopulationArrays,
+        holdout: PopulationArrays,
+    ) -> dict[str, float]:
+        """``synthetic`` と ``holdout`` の broad utility 指標を計算する.
+
+        Parameters
+        ----------
+        synthetic : PopulationArrays
+            合成人口（評価対象）。
+        holdout : PopulationArrays
+            real 個票（参照）。
+
+        Returns
+        -------
+        dict[str, float]
+            ``broad_utility.*`` キーを含む dict。
+            空人口でも 0 除算しない（中立値 0.0 を返す）。
+        """
+        synth_cols = {a: _column(synthetic, a) for a in self.attributes}
+        real_cols = {a: _column(holdout, a) for a in self.attributes}
+
+        result: dict[str, float] = {}
+
+        # 単変量 TV / L1
+        for attr in self.attributes:
+            tv = _univariate_tv(synth_cols[attr], real_cols[attr])
+            result[f"{self.name}.tv.{attr}"] = tv
+            result[f"{self.name}.l1.{attr}"] = 2.0 * tv
+
+        # ペア joint TV
+        sum_pair_tv = 0.0
+        for a, b in _all_pairs(self.attributes):
+            tv = _pair_joint_tv(synth_cols[a], synth_cols[b], real_cols[a], real_cols[b])
+            result[f"{self.name}.pair_tv.{a}__{b}"] = tv
+            sum_pair_tv += tv
+        result[f"{self.name}.sum_pair_tv"] = sum_pair_tv
+
+        # 混合型相関 Frobenius / max-abs
+        if synthetic.n_persons == 0 or holdout.n_persons == 0:
+            result[f"{self.name}.correlation_frobenius_diff"] = 0.0
+            result[f"{self.name}.correlation_max_abs_diff"] = 0.0
+        else:
+            mat_s = _build_correlation_matrix(synth_cols, self.attributes)
+            mat_r = _build_correlation_matrix(real_cols, self.attributes)
+            diff = mat_s - mat_r
+            result[f"{self.name}.correlation_frobenius_diff"] = float(np.linalg.norm(diff))
+            result[f"{self.name}.correlation_max_abs_diff"] = float(np.abs(diff).max())
+
+        return result

--- a/src/synthpop_jp/reports/markdown.py
+++ b/src/synthpop_jp/reports/markdown.py
@@ -127,11 +127,58 @@ def _render_cap(global_rows: dict[str, float], per_ft: dict[str, dict[str, float
     return lines
 
 
+def _render_broad_utility(
+    univariate: dict[str, dict[str, float]],
+    pair_tv: dict[str, float],
+    scalars: dict[str, float],
+) -> list[str]:
+    """Broad utility セクションを Markdown で組み立てる (Issue #96).
+
+    ``univariate`` は ``{attr: {"tv": ..., "l1": ...}}``、
+    ``pair_tv`` は ``{"a__b": value}``、
+    ``scalars`` は ``{"sum_pair_tv": ..., "correlation_frobenius_diff": ...,
+    "correlation_max_abs_diff": ...}`` を期待する。
+    """
+    lines: list[str] = []
+    if not (univariate or pair_tv or scalars):
+        return lines
+    lines.append("## 3. 有用性: broad utility")
+    lines.append("")
+    if univariate:
+        lines.append("### 単変量 TV / L1")
+        lines.append("")
+        lines.append("| 属性 | TV | L1 |")
+        lines.append("|---|---:|---:|")
+        for attr in sorted(univariate.keys()):
+            row = univariate[attr]
+            tv = _format_value(row.get("tv", 0.0))
+            l1 = _format_value(row.get("l1", 0.0))
+            lines.append(f"| {attr} | {tv} | {l1} |")
+        lines.append("")
+    if pair_tv:
+        lines.append("### 属性ペア joint TV")
+        lines.append("")
+        lines.append("| ペア | joint TV |")
+        lines.append("|---|---:|")
+        for k in sorted(pair_tv.keys()):
+            lines.append(f"| {k} | {_format_value(pair_tv[k])} |")
+        lines.append("")
+    if scalars:
+        lines.append("### スカラ要約")
+        lines.append("")
+        lines.append("| 指標 | 値 |")
+        lines.append("|---|---:|")
+        for k in sorted(scalars.keys()):
+            lines.append(f"| {k} | {_format_value(scalars[k])} |")
+        lines.append("")
+    return lines
+
+
 def _render_others(rows: dict[str, float]) -> list[str]:
     lines: list[str] = []
     if not rows:
         return lines
-    lines.append("## 3. その他 / プラグイン")
+    lines.append("## 4. その他 / プラグイン")
     lines.append("")
     lines.append("| キー | 値 |")
     lines.append("|---|---:|")
@@ -161,6 +208,9 @@ def render_metrics_table13(metrics: dict[str, float]) -> str:
     rare_cell_per_ft: dict[str, dict[str, float]] = defaultdict(dict)
     cap_global: dict[str, float] = {}
     cap_per_ft: dict[str, dict[str, float]] = defaultdict(dict)
+    broad_univariate: dict[str, dict[str, float]] = defaultdict(dict)
+    broad_pair_tv: dict[str, float] = {}
+    broad_scalars: dict[str, float] = {}
     others: dict[str, float] = {}
 
     for key, value in metrics.items():
@@ -200,6 +250,18 @@ def render_metrics_table13(metrics: dict[str, float]) -> str:
         elif key.startswith("cap."):
             metric = key.removeprefix("cap.")
             cap_global[metric] = float(value)
+        elif key.startswith("broad_utility.tv."):
+            attr = key.removeprefix("broad_utility.tv.")
+            broad_univariate[attr]["tv"] = float(value)
+        elif key.startswith("broad_utility.l1."):
+            attr = key.removeprefix("broad_utility.l1.")
+            broad_univariate[attr]["l1"] = float(value)
+        elif key.startswith("broad_utility.pair_tv."):
+            pair_key = key.removeprefix("broad_utility.pair_tv.")
+            broad_pair_tv[pair_key] = float(value)
+        elif key.startswith("broad_utility."):
+            scalar_key = key.removeprefix("broad_utility.")
+            broad_scalars[scalar_key] = float(value)
         else:
             others[key] = float(value)
 
@@ -219,7 +281,10 @@ def render_metrics_table13(metrics: dict[str, float]) -> str:
         lines.extend(_render_rare_cell(rare_cell_global, rare_cell_per_ft))
         lines.extend(_render_cap(cap_global, cap_per_ft))
 
-    # 3. その他
+    # 3. 有用性 broad utility (Issue #96)
+    lines.extend(_render_broad_utility(dict(broad_univariate), broad_pair_tv, broad_scalars))
+
+    # 4. その他
     if others:
         lines.extend(_render_others(others))
 

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -139,6 +139,44 @@ class TestEvaluateIntegration:
         # holdout = synthetic なので perfect coverage
         assert abs(metrics["cap.coverage"] - 1.0) < 1e-9
 
+    def test_evaluate_appends_broad_utility_keys_with_real_persons_csv(
+        self, tmp_path: Path
+    ) -> None:
+        """``--real-persons-csv`` を指定すると ``broad_utility.*`` キーも追記される（Issue #96）."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        synthetic_csv = tmp_path / "out" / "synthetic_persons.csv"
+        eval_result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                "--config",
+                str(config_path),
+                "--real-persons-csv",
+                str(synthetic_csv),
+            ],
+        )
+        assert eval_result.exit_code == 0, eval_result.output
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        # 単変量 / pair / scalar の代表キーが揃っていること
+        for attr in ("age", "sex", "role", "family_type"):
+            assert f"broad_utility.tv.{attr}" in metrics
+            assert f"broad_utility.l1.{attr}" in metrics
+        assert "broad_utility.pair_tv.age__sex" in metrics
+        assert "broad_utility.correlation_frobenius_diff" in metrics
+        # synth=real なので TV / Frobenius は 0 のはず
+        assert metrics["broad_utility.tv.age"] == 0.0
+        assert metrics["broad_utility.correlation_frobenius_diff"] == 0.0
+
+    def test_evaluate_skips_broad_utility_without_real_persons_csv(self, tmp_path: Path) -> None:
+        """``--real-persons-csv`` 未指定時は ``broad_utility.*`` が含まれない（Issue #96）."""
+        config_path = _make_config_yaml(tmp_path)
+        runner.invoke(app, ["generate", "--config", str(config_path)])
+        eval_result = runner.invoke(app, ["evaluate", "--config", str(config_path)])
+        assert eval_result.exit_code == 0
+        metrics = json.loads((tmp_path / "out" / "metrics.json").read_text(encoding="utf-8"))
+        assert not any(k.startswith("broad_utility.") for k in metrics)
+
     def test_evaluate_fails_with_missing_real_persons_csv(self, tmp_path: Path) -> None:
         """``--real-persons-csv`` のパスが無ければ exit code 1（Issue #65）."""
         config_path = _make_config_yaml(tmp_path)

--- a/tests/evaluate/test_broad_utility.py
+++ b/tests/evaluate/test_broad_utility.py
@@ -233,9 +233,7 @@ class TestBroadUtilityEvaluator:
 
     def test_empty_populations_yield_zeros(self) -> None:
         ev = BroadUtilityEvaluator()
-        empty = _make_pop(
-            age=[], sex=[], role=[], family_type=[], household_id=[]
-        )
+        empty = _make_pop(age=[], sex=[], role=[], family_type=[], household_id=[])
         result = ev.evaluate(synthetic=empty, holdout=empty)
         # 空でも 0 除算しない
         for k, v in result.items():

--- a/tests/evaluate/test_broad_utility.py
+++ b/tests/evaluate/test_broad_utility.py
@@ -1,0 +1,242 @@
+"""Tests for BroadUtilityEvaluator (Issue #96).
+
+`docs/spec/spec.md` §13.2 / `docs/spec/metrics.md` §3 に基づく broad utility
+評価器のユニットテスト。手計算 fixture と独立性 / 完全従属 ケースで数値を
+確認する。
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from synthpop_jp.domain.registry import FamilyTypeRegistry, RoleRegistry, SexRegistry
+from synthpop_jp.evaluate.utility.broad import (
+    BroadUtilityEvaluator,
+    _correlation_ratio,
+    _cramers_v,
+    _pair_joint_tv,
+    _univariate_tv,
+)
+from synthpop_jp.optimize.state import PopulationArrays
+
+
+def _make_pop(
+    age: list[int],
+    sex: list[int],
+    role: list[int],
+    family_type: list[int],
+    household_id: list[int],
+) -> PopulationArrays:
+    """Tests 用に小さな PopulationArrays を組み立てる."""
+    role_reg = RoleRegistry()
+    sex_reg = SexRegistry()
+    family_reg = FamilyTypeRegistry()
+    # 出てくる id を全部登録（観測されない id でも問題ない）
+    for r in sorted(set(role)):
+        role_reg.register(f"role_{r}")
+    for s in sorted(set(sex)):
+        sex_reg.register(f"sex_{s}")
+    for f in sorted(set(family_type)):
+        family_reg.register(f"ft_{f}")
+    return PopulationArrays(
+        age=np.array(age, dtype=np.int16),
+        sex=np.array(sex, dtype=np.int8),
+        role=np.array(role, dtype=np.int8),
+        family_type=np.array(family_type, dtype=np.int8),
+        household_id=np.array(household_id, dtype=np.int32),
+        _role_reg=role_reg,
+        _sex_reg=sex_reg,
+        _family_reg=family_reg,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 純関数: TV / Cramér's V / Correlation Ratio
+# ---------------------------------------------------------------------------
+
+
+class TestUnivariateTV:
+    def test_identical_distributions_yield_zero(self) -> None:
+        a = np.array([1, 2, 3, 1, 2, 3], dtype=np.int64)
+        b = np.array([1, 2, 3, 1, 2, 3], dtype=np.int64)
+        assert _univariate_tv(a, b) == pytest.approx(0.0)
+
+    def test_disjoint_supports_yield_one(self) -> None:
+        a = np.array([1, 1, 1], dtype=np.int64)
+        b = np.array([2, 2, 2], dtype=np.int64)
+        # P(a=1)=1, Q(a=2)=1 → TV = 0.5 * (1 + 1) = 1.0
+        assert _univariate_tv(a, b) == pytest.approx(1.0)
+
+    def test_handworked_case(self) -> None:
+        # synth: {10:2, 20:2} → {10:0.5, 20:0.5}
+        # real: {10:1, 20:1, 30:1, 40:1} → {10:0.25, 20:0.25, 30:0.25, 40:0.25}
+        # TV = 0.5 * (|0.5-0.25| + |0.5-0.25| + |0-0.25| + |0-0.25|) = 0.5
+        a = np.array([10, 20, 10, 20], dtype=np.int64)
+        b = np.array([10, 20, 30, 40], dtype=np.int64)
+        assert _univariate_tv(a, b) == pytest.approx(0.5)
+
+
+class TestPairJointTV:
+    def test_identical_pairs_yield_zero(self) -> None:
+        ax = np.array([1, 2, 3], dtype=np.int64)
+        ay = np.array([10, 20, 30], dtype=np.int64)
+        bx = ax.copy()
+        by = ay.copy()
+        assert _pair_joint_tv(ax, ay, bx, by) == pytest.approx(0.0)
+
+    def test_handworked_case(self) -> None:
+        # synth pairs: {(1,10):2, (2,20):2} → {(1,10):0.5, (2,20):0.5}
+        # real pairs:  {(1,10):1, (2,20):1, (3,30):1, (4,40):1} → 各 0.25
+        # TV = 0.5 * (|0.5-0.25| + |0.5-0.25| + |0-0.25| + |0-0.25|) = 0.5
+        ax = np.array([1, 2, 1, 2], dtype=np.int64)
+        ay = np.array([10, 20, 10, 20], dtype=np.int64)
+        bx = np.array([1, 2, 3, 4], dtype=np.int64)
+        by = np.array([10, 20, 30, 40], dtype=np.int64)
+        assert _pair_joint_tv(ax, ay, bx, by) == pytest.approx(0.5)
+
+
+class TestCramersV:
+    def test_perfect_dependence(self) -> None:
+        # x=y → V = 1.0
+        x = np.array([0, 0, 1, 1, 2, 2], dtype=np.int64)
+        y = np.array([0, 0, 1, 1, 2, 2], dtype=np.int64)
+        assert _cramers_v(x, y) == pytest.approx(1.0, abs=1e-9)
+
+    def test_independence_close_to_zero(self) -> None:
+        # x と y が独立: 一様な分布 → chi2 が小さく V もほぼ 0
+        x = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int64)
+        y = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.int64)
+        assert _cramers_v(x, y) == pytest.approx(0.0, abs=1e-9)
+
+    def test_constant_input_returns_zero(self) -> None:
+        # x が定数なら V は定義されないので 0 を返す
+        x = np.array([5, 5, 5, 5], dtype=np.int64)
+        y = np.array([0, 1, 0, 1], dtype=np.int64)
+        assert _cramers_v(x, y) == pytest.approx(0.0)
+
+
+class TestCorrelationRatio:
+    def test_constant_groups_yield_zero(self) -> None:
+        # cat: [0,0,1,1], num: [10,10,10,10] → group means 等しい → eta=0
+        num = np.array([10, 10, 10, 10], dtype=np.float64)
+        cat = np.array([0, 0, 1, 1], dtype=np.int64)
+        assert _correlation_ratio(num, cat) == pytest.approx(0.0)
+
+    def test_perfect_separation_yields_one(self) -> None:
+        # cat=0 → num=10, cat=1 → num=20 で群内分散 0 → eta=1
+        num = np.array([10.0, 10.0, 20.0, 20.0], dtype=np.float64)
+        cat = np.array([0, 0, 1, 1], dtype=np.int64)
+        assert _correlation_ratio(num, cat) == pytest.approx(1.0)
+
+    def test_handworked_case(self) -> None:
+        # cat: [0,0,1,1], num: [10,12,18,20]
+        # group_mean(0) = 11, group_mean(1) = 19, total_mean = 15
+        # SS_between = 2*(11-15)^2 + 2*(19-15)^2 = 32 + 32 = 64
+        # SS_total = (10-15)^2+(12-15)^2+(18-15)^2+(20-15)^2 = 25+9+9+25 = 68
+        # eta^2 = 64 / 68 ≈ 0.9412
+        # eta = sqrt(64/68) ≈ 0.9701
+        num = np.array([10.0, 12.0, 18.0, 20.0], dtype=np.float64)
+        cat = np.array([0, 0, 1, 1], dtype=np.int64)
+        assert _correlation_ratio(num, cat) == pytest.approx(math.sqrt(64.0 / 68.0))
+
+
+# ---------------------------------------------------------------------------
+# BroadUtilityEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestBroadUtilityEvaluator:
+    def test_evaluator_name(self) -> None:
+        ev = BroadUtilityEvaluator()
+        assert ev.name == "broad_utility"
+
+    def test_identical_pops_yield_zero_metrics(self) -> None:
+        ev = BroadUtilityEvaluator()
+        pop = _make_pop(
+            age=[10, 20, 10, 20],
+            sex=[0, 0, 1, 1],
+            role=[0, 0, 1, 1],
+            family_type=[0, 0, 1, 1],
+            household_id=[0, 0, 1, 1],
+        )
+        result = ev.evaluate(synthetic=pop, holdout=pop)
+        # 単変量 TV / L1 はすべて 0
+        for attr in ("age", "sex", "role", "family_type"):
+            assert result[f"broad_utility.tv.{attr}"] == pytest.approx(0.0)
+            assert result[f"broad_utility.l1.{attr}"] == pytest.approx(0.0)
+        # ペア TV すべて 0
+        attrs = ("age", "sex", "role", "family_type")
+        for i in range(len(attrs)):
+            for j in range(i + 1, len(attrs)):
+                key = f"broad_utility.pair_tv.{attrs[i]}__{attrs[j]}"
+                assert result[key] == pytest.approx(0.0)
+        # 相関 Frobenius / max-abs は 0
+        assert result["broad_utility.correlation_frobenius_diff"] == pytest.approx(0.0)
+        assert result["broad_utility.correlation_max_abs_diff"] == pytest.approx(0.0)
+        # 集約
+        assert result["broad_utility.sum_pair_tv"] == pytest.approx(0.0)
+
+    def test_age_distribution_diff(self) -> None:
+        ev = BroadUtilityEvaluator()
+        synth = _make_pop(
+            age=[10, 20, 10, 20],
+            sex=[0, 0, 1, 1],
+            role=[0, 0, 1, 1],
+            family_type=[0, 0, 1, 1],
+            household_id=[0, 0, 1, 1],
+        )
+        real = _make_pop(
+            age=[10, 20, 30, 40],
+            sex=[0, 0, 1, 1],
+            role=[0, 0, 1, 1],
+            family_type=[0, 0, 1, 1],
+            household_id=[0, 0, 1, 1],
+        )
+        result = ev.evaluate(synthetic=synth, holdout=real)
+        # age 単変量 TV = 0.5, L1 = 1.0
+        assert result["broad_utility.tv.age"] == pytest.approx(0.5)
+        assert result["broad_utility.l1.age"] == pytest.approx(1.0)
+        # sex / role / family_type は同分布なので 0
+        assert result["broad_utility.tv.sex"] == pytest.approx(0.0)
+        assert result["broad_utility.tv.role"] == pytest.approx(0.0)
+        assert result["broad_utility.tv.family_type"] == pytest.approx(0.0)
+        # pair TV: age を含むペアは差分あり
+        assert result["broad_utility.pair_tv.age__sex"] > 0.0
+        assert result["broad_utility.pair_tv.age__role"] > 0.0
+        assert result["broad_utility.pair_tv.age__family_type"] > 0.0
+        # sex × role など age を含まないペアは差分 0
+        assert result["broad_utility.pair_tv.sex__role"] == pytest.approx(0.0)
+
+    def test_keys_present_for_all_pairs(self) -> None:
+        ev = BroadUtilityEvaluator()
+        pop = _make_pop(
+            age=[10, 20, 30, 40],
+            sex=[0, 0, 1, 1],
+            role=[0, 0, 1, 1],
+            family_type=[0, 0, 1, 1],
+            household_id=[0, 0, 1, 1],
+        )
+        result = ev.evaluate(synthetic=pop, holdout=pop)
+        attrs = ("age", "sex", "role", "family_type")
+        for attr in attrs:
+            assert f"broad_utility.tv.{attr}" in result
+            assert f"broad_utility.l1.{attr}" in result
+        for i in range(len(attrs)):
+            for j in range(i + 1, len(attrs)):
+                assert f"broad_utility.pair_tv.{attrs[i]}__{attrs[j]}" in result
+        assert "broad_utility.correlation_frobenius_diff" in result
+        assert "broad_utility.correlation_max_abs_diff" in result
+        assert "broad_utility.sum_pair_tv" in result
+
+    def test_empty_populations_yield_zeros(self) -> None:
+        ev = BroadUtilityEvaluator()
+        empty = _make_pop(
+            age=[], sex=[], role=[], family_type=[], household_id=[]
+        )
+        result = ev.evaluate(synthetic=empty, holdout=empty)
+        # 空でも 0 除算しない
+        for k, v in result.items():
+            assert v == pytest.approx(0.0), f"{k}: {v}"

--- a/tests/reports/test_markdown.py
+++ b/tests/reports/test_markdown.py
@@ -102,6 +102,49 @@ class TestOthersSection:
         assert "plugin_dummy" in md or "99.0" in md
 
 
+class TestBroadUtilitySection:
+    """broad utility セクション（Issue #96）."""
+
+    def test_univariate_table_present(self) -> None:
+        metrics: dict[str, float] = {
+            "broad_utility.tv.age": 0.25,
+            "broad_utility.l1.age": 0.50,
+            "broad_utility.tv.sex": 0.10,
+            "broad_utility.l1.sex": 0.20,
+        }
+        md = render_metrics_table13(metrics)
+        assert "broad utility" in md
+        assert "age" in md
+        assert "sex" in md
+        # TV / L1 の値が含まれる
+        assert "0.25" in md or "0.3" in md  # 値の四捨五入差を許容
+
+    def test_pair_tv_table_present(self) -> None:
+        metrics: dict[str, float] = {
+            "broad_utility.pair_tv.age__sex": 0.33,
+            "broad_utility.pair_tv.age__role": 0.44,
+        }
+        md = render_metrics_table13(metrics)
+        assert "age__sex" in md
+        assert "age__role" in md
+
+    def test_correlation_scalars_present(self) -> None:
+        metrics: dict[str, float] = {
+            "broad_utility.correlation_frobenius_diff": 1.23,
+            "broad_utility.correlation_max_abs_diff": 0.55,
+            "broad_utility.sum_pair_tv": 1.10,
+        }
+        md = render_metrics_table13(metrics)
+        assert "correlation_frobenius_diff" in md
+        assert "correlation_max_abs_diff" in md
+        assert "sum_pair_tv" in md
+
+    def test_broad_utility_section_skipped_when_empty(self) -> None:
+        # broad_utility キーが無いとセクション自体が出ない
+        md = render_metrics_table13({"aggregate.l1.total": 1.0})
+        assert "broad utility" not in md.lower() or "## 3. 有用性" not in md
+
+
 class TestStructure:
     """全体構造."""
 


### PR DESCRIPTION
## 背景

`docs/reviews/action-plan.md` §3.8 Phase 4a で broad utility（mixed-type 相関 / 全属性ペア TV / Frobenius 差）が定義されているが未実装。`AggregateStatL1Evaluator` で統計別 L1 は出せるが、属性間の相関構造の歪みを見る指標が無く、Harada 2024 §5.1 の broad utility 軸を揃えられない状態だった。

Closes #96

## この変更で提供する価値

研究者が `synthpop-jp evaluate --real-persons-csv real.csv` を実行するだけで、合成データの「全体としての形」が実データに近いかを **3 種の broad utility 指標で 1 コマンドで測定** できるようになる。`metrics.json` と `report.md` に結果が自動追記される。

## 変更内容

- `src/synthpop_jp/evaluate/utility/broad.py` 新規（249 行）: `BroadUtilityEvaluator` 実装。
  - 単変量 TV / L1（attr ごと）
  - 属性ペア joint TV（C(4,2)=6 ペア）
  - 混合型相関行列 Frobenius 差 / max-abs 差（Cramér's V + Correlation Ratio）
  - sum_pair_tv（スカラ要約）
- `src/synthpop_jp/cli.py`: `evaluate` で `--real-persons-csv` 指定時に呼び出し
- `src/synthpop_jp/reports/markdown.py`: §3「有用性: broad utility」セクションを自動生成
- 既存 §3「その他」を §4 に繰り下げ
- `pyrightconfig.json`: `tests/evaluate/test_broad_utility.py` に `pytest.approx` の `Partially unknown` 緩和

## 影響範囲

- 変更モジュール: `evaluate/utility/`, `cli.py`, `reports/markdown.py`
- 他モジュールへの影響: なし（追加機能のみ、既存 API は維持）
- 既存 API の互換性: 維持（`--real-persons-csv` 未指定時は既存挙動と同一）
- 依存関係の変化: なし（`scipy.stats.chi2_contingency` のみ。dython 不採用）

## テスト

- 追加テスト: 22 件
  - `test_broad_utility.py`: 16 件（純関数 + Evaluator）
  - `test_evaluate.py`: 2 件（CLI 統合）
  - `test_markdown.py`: 4 件（report 出力）
- すべて GREEN
- 既存テスト: 605 + 22 = **627 passed, 10 skipped**

<details>
<summary>CI parity 4 コマンドの結果</summary>

\`\`\`
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
133 files already formatted

$ uv run pyright
0 errors, 15 warnings (既存 stubs 警告のみ)

$ uv run pytest
627 passed, 10 skipped in 17.44s
\`\`\`

</details>

## 設計選択

- **dython 不採用**: 同等の Cramér's V / Correlation Ratio を `scipy.stats` で実装。dependency 追加を避け、テストは手計算 fixture で数値一致を検証
- **Theil's U / Pearson 不採用**: Theil's U は asymmetric なため Frobenius と整合しない。Pearson は age 以外の連続変数が無く出番なし。スコープ外（計画 §2.3）
- **`household_id` を解析対象外**: unique 値が多すぎてカテゴリ相関が無意味（計画 §6）
- **`Evaluator` Protocol 不適合**: broad utility は real reference を要するため `evaluate(synth, holdout)` の 2 引数。CAPEvaluator と同じ理由で Protocol を外れる（将来 `UtilityMetric` Protocol を追加する場合は別 Issue）

## 残課題

- **dython 完全一致テスト**: 必要であれば dev-dep 化。現状は手計算 fixture で代替（計画 §6 Plan B）
- **Pearson 相関**: age 以外の連続変数が増えたら追加（別 Issue）
- **Theil's U**: 非対称指標として別 metric キーで追加するなら別 Issue

## レビュアーに特に見てほしい点

- `_build_correlation_matrix` の組合せルール（age 含むなら eta、それ以外は V）
- `pyrightconfig.json` の executionEnvironment 追加（`tests/evaluate/test_broad_utility.py` のみに緩和）
- report.md セクション §3 の構造（単変量 / pair TV / スカラ要約の 3 サブセクション）

## 関連

- Issue #96（本 PR）
- Issue #97（narrow utility、後続）
- spec §13.2 / metrics.md §3
- 計画: `docs/plans/issue-96.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)