### PR TITLE
[simplify] post-merge cleanup: utility / markdown helpers

### DIFF
--- a/src/synthpop_jp/evaluate/utility/broad.py
+++ b/src/synthpop_jp/evaluate/utility/broad.py
@@ -174,6 +174,19 @@ def _correlation_ratio(num: np.ndarray, cat: np.ndarray) -> float:
     return float(np.sqrt(eta_squared))
 
 
+def _pair_correlation(a: str, b: str, columns: dict[str, np.ndarray]) -> float:
+    """属性ペア (a, b) の相関値を返す（対称）."""
+    a_num = a in _NUMERIC_ATTRIBUTES
+    b_num = b in _NUMERIC_ATTRIBUTES
+    if a_num and b_num:
+        return 1.0
+    if a_num:
+        return _correlation_ratio(columns[a], columns[b])
+    if b_num:
+        return _correlation_ratio(columns[b], columns[a])
+    return _cramers_v(columns[a], columns[b])
+
+
 def _build_correlation_matrix(
     columns: dict[str, np.ndarray],
     attrs: tuple[str, ...],
@@ -181,24 +194,15 @@ def _build_correlation_matrix(
     """属性ペアの相関を要素とする対称行列（n × n）を組み立てる.
 
     対角は 1.0、非対角は (連続,カテゴリ) → eta、(カテゴリ,カテゴリ) → V。
-    age を含む組合せは Correlation Ratio、それ以外は Cramér's V。
+    対称行列なので上三角のみ計算してミラーする（重複計算を避ける）。
     """
     n = len(attrs)
-    mat = np.zeros((n, n), dtype=np.float64)
-    for i, a in enumerate(attrs):
-        for j, b in enumerate(attrs):
-            if i == j:
-                mat[i, j] = 1.0
-                continue
-            if a in _NUMERIC_ATTRIBUTES and b in _NUMERIC_ATTRIBUTES:
-                # 同一の age と age はあり得ないし、age 以外の連続変数は無い
-                mat[i, j] = 1.0
-            elif a in _NUMERIC_ATTRIBUTES:
-                mat[i, j] = _correlation_ratio(columns[a], columns[b])
-            elif b in _NUMERIC_ATTRIBUTES:
-                mat[i, j] = _correlation_ratio(columns[b], columns[a])
-            else:
-                mat[i, j] = _cramers_v(columns[a], columns[b])
+    mat = np.eye(n, dtype=np.float64)
+    for i in range(n):
+        for j in range(i + 1, n):
+            v = _pair_correlation(attrs[i], attrs[j], columns)
+            mat[i, j] = v
+            mat[j, i] = v
     return mat
 
 

--- a/src/synthpop_jp/evaluate/utility/narrow.py
+++ b/src/synthpop_jp/evaluate/utility/narrow.py
@@ -54,25 +54,43 @@ if TYPE_CHECKING:
     from synthpop_jp.optimize.state import PopulationArrays
 
 
-def _household_features(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """各 person に household-level 特徴量（household_size, n_children）を broadcast する.
+class _HouseholdAggregates:
+    """``_household_features_full`` の戻り値を保持する小さい構造体."""
 
-    Returns
-    -------
-    household_size : np.ndarray
-        各 person の所属世帯のメンバー数。shape=(n_persons,)。
-    n_children : np.ndarray
-        各 person の所属世帯の child 数。shape=(n_persons,)。
-    family_type_per_household : np.ndarray
-        household_id 出現順での family_type 配列（Task B で使用）。
+    __slots__ = (
+        "child_count",
+        "ft_per_household",
+        "household_size_per_person",
+        "member_count",
+        "n_children_per_person",
+    )
+
+    def __init__(
+        self,
+        household_size_per_person: np.ndarray,
+        n_children_per_person: np.ndarray,
+        member_count: np.ndarray,
+        child_count: np.ndarray,
+        ft_per_household: np.ndarray,
+    ) -> None:
+        self.household_size_per_person = household_size_per_person
+        self.n_children_per_person = n_children_per_person
+        self.member_count = member_count
+        self.child_count = child_count
+        self.ft_per_household = ft_per_household
+
+
+def _household_aggregates(pop: PopulationArrays) -> _HouseholdAggregates:
+    """``pop`` から household 集計（メンバー数・child 数・family_type）を 1 度だけ計算.
+
+    Task A は household_size_per_person、Task B は member_count / child_count /
+    ft_per_household を使う。同じ集計を Task ごとに繰り返さないようまとめる。
     """
     n = pop.n_persons
     if n == 0:
-        return (
-            np.empty(0, dtype=np.int64),
-            np.empty(0, dtype=np.int64),
-            np.empty(0, dtype=np.int64),
-        )
+        empty_i64 = np.empty(0, dtype=np.int64)
+        return _HouseholdAggregates(empty_i64, empty_i64, empty_i64, empty_i64, empty_i64)
+
     hids = np.asarray(pop.household_id, dtype=np.int64)
     fts = np.asarray(pop.family_type, dtype=np.int64)
     roles = np.asarray(pop.role, dtype=np.int64)
@@ -80,10 +98,10 @@ def _household_features(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray, 
     try:
         child_role_id = pop.role_reg.id_of("child")
     except KeyError:
-        child_role_id = -1  # role に "child" 未登録なら 0 件扱い
+        child_role_id = -1
 
-    # household_id ごとにメンバー数と child 数を集計
-    unique_hids, inverse = np.unique(hids, return_inverse=True)
+    # household_id ごとに集計（unique は出現順を保つ）
+    unique_hids, first_idx, inverse = np.unique(hids, return_index=True, return_inverse=True)
     member_count = np.bincount(inverse, minlength=unique_hids.shape[0]).astype(np.int64)
     child_count = np.bincount(
         inverse,
@@ -91,20 +109,27 @@ def _household_features(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray, 
         minlength=unique_hids.shape[0],
     ).astype(np.int64)
 
-    # 各 person に broadcast
-    household_size_per_person = member_count[inverse]
-    n_children_per_person = child_count[inverse]
+    # household 単位の family_type は「各世帯で最初に現れた person」の family_type。
+    # np.unique(return_index=True) は unique_hids[k] が最初に現れた位置を返すので
+    # それを使って Python ループを排除する。
+    ft_per_household = fts[first_idx]
 
-    # household 単位の family_type（household_id ごとに最初に現れた値）
-    ft_per_household = np.empty(unique_hids.shape[0], dtype=np.int64)
-    seen = np.zeros(unique_hids.shape[0], dtype=bool)
-    for i in range(n):
-        h = int(inverse[i])
-        if not seen[h]:
-            ft_per_household[h] = int(fts[i])
-            seen[h] = True
+    return _HouseholdAggregates(
+        household_size_per_person=member_count[inverse],
+        n_children_per_person=child_count[inverse],
+        member_count=member_count,
+        child_count=child_count,
+        ft_per_household=ft_per_household,
+    )
 
-    return household_size_per_person, n_children_per_person, ft_per_household
+
+def _household_features(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """後方互換ラッパー: ``(household_size_per_person, n_children_per_person, ft_per_household)``.
+
+    既存テストや外部コードのために残す。新規呼び出しは ``_household_aggregates`` を使うこと。
+    """
+    agg = _household_aggregates(pop)
+    return agg.household_size_per_person, agg.n_children_per_person, agg.ft_per_household
 
 
 def _features_task_a(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray]:
@@ -126,36 +151,13 @@ def _features_task_a(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray]:
 
 def _features_task_b(pop: PopulationArrays) -> tuple[np.ndarray, np.ndarray]:
     """Task B: features=[family_type, n_children], target=household_size（household 単位）."""
-    n = pop.n_persons
-    if n == 0:
+    if pop.n_persons == 0:
         return np.empty((0, 2), dtype=np.float64), np.empty(0, dtype=np.float64)
-    hids = np.asarray(pop.household_id, dtype=np.int64)
-    fts = np.asarray(pop.family_type, dtype=np.int64)
-    try:
-        child_role_id = pop.role_reg.id_of("child")
-    except KeyError:
-        child_role_id = -1
-    roles = np.asarray(pop.role, dtype=np.int64)
-
-    unique_hids, inverse = np.unique(hids, return_inverse=True)
-    member_count = np.bincount(inverse, minlength=unique_hids.shape[0]).astype(np.int64)
-    child_count = np.bincount(
-        inverse,
-        weights=(roles == child_role_id).astype(np.int64),
-        minlength=unique_hids.shape[0],
-    ).astype(np.int64)
-
-    # household 単位の family_type
-    ft_per_household = np.empty(unique_hids.shape[0], dtype=np.int64)
-    seen = np.zeros(unique_hids.shape[0], dtype=bool)
-    for i in range(n):
-        h = int(inverse[i])
-        if not seen[h]:
-            ft_per_household[h] = int(fts[i])
-            seen[h] = True
-
-    x = np.column_stack([ft_per_household.astype(np.float64), child_count.astype(np.float64)])
-    y = member_count.astype(np.float64)
+    agg = _household_aggregates(pop)
+    x = np.column_stack(
+        [agg.ft_per_household.astype(np.float64), agg.child_count.astype(np.float64)]
+    )
+    y = agg.member_count.astype(np.float64)
     return x, y
 
 

--- a/src/synthpop_jp/reports/markdown.py
+++ b/src/synthpop_jp/reports/markdown.py
@@ -71,59 +71,66 @@ def _render_family_type_pyramid(rows: dict[str, dict[str, float]]) -> list[str]:
     return lines
 
 
+def _render_kv_table(rows: dict[str, float]) -> list[str]:
+    """``{指標: 値}`` を 2 列 Markdown table に整形."""
+    if not rows:
+        return []
+    out = ["| 指標 | 値 |", "|---|---:|"]
+    out.extend(f"| {k} | {_format_value(rows[k])} |" for k in sorted(rows.keys()))
+    out.append("")
+    return out
+
+
+def _render_per_ft_table(
+    per_ft: dict[str, dict[str, float]],
+    columns: tuple[str, ...],
+    caption: str,
+) -> list[str]:
+    """family_type × 指標 のクロス表を整形（rare_cell / cap で共通）."""
+    if not per_ft:
+        return []
+    out = [f"**{caption}:**", ""]
+    header = " | ".join(("family_type", *columns))
+    sep = " | ".join(("---", *(["---:"] * len(columns))))
+    out.append(f"| {header} |")
+    out.append(f"| {sep} |")
+    for ft in sorted(per_ft.keys()):
+        sub = per_ft[ft]
+        cells = " | ".join(_format_value(sub.get(c, 0.0)) for c in columns)
+        out.append(f"| {ft} | {cells} |")
+    out.append("")
+    return out
+
+
 def _render_rare_cell(
     global_rows: dict[str, float], per_ft: dict[str, dict[str, float]]
 ) -> list[str]:
-    lines: list[str] = []
     if not global_rows and not per_ft:
-        return lines
-    lines.append("### 2.1 rare cell (proxy)")
-    lines.append("")
-    if global_rows:
-        lines.append("| 指標 | 値 |")
-        lines.append("|---|---:|")
-        for k in sorted(global_rows.keys()):
-            lines.append(f"| {k} | {_format_value(global_rows[k])} |")
-        lines.append("")
-    if per_ft:
-        lines.append("**family_type 別 (fraction_below_5 / fraction_unique):**")
-        lines.append("")
-        lines.append("| family_type | fraction_below_5 | fraction_unique |")
-        lines.append("|---|---:|---:|")
-        for ft in sorted(per_ft.keys()):
-            sub = per_ft[ft]
-            lines.append(
-                f"| {ft} | {_format_value(sub.get('fraction_below_5', 0.0))} | "
-                f"{_format_value(sub.get('fraction_unique', 0.0))} |"
-            )
-        lines.append("")
+        return []
+    lines = ["### 2.1 rare cell (proxy)", ""]
+    lines.extend(_render_kv_table(global_rows))
+    lines.extend(
+        _render_per_ft_table(
+            per_ft,
+            ("fraction_below_5", "fraction_unique"),
+            "family_type 別 (fraction_below_5 / fraction_unique)",
+        )
+    )
     return lines
 
 
 def _render_cap(global_rows: dict[str, float], per_ft: dict[str, dict[str, float]]) -> list[str]:
-    lines: list[str] = []
     if not global_rows and not per_ft:
-        return lines
-    lines.append("### 2.2 CAP / TCAP (attribute inference)")
-    lines.append("")
-    if global_rows:
-        lines.append("| 指標 | 値 |")
-        lines.append("|---|---:|")
-        for k in sorted(global_rows.keys()):
-            lines.append(f"| {k} | {_format_value(global_rows[k])} |")
-        lines.append("")
-    if per_ft:
-        lines.append("**family_type 別 (generalized / targeted):**")
-        lines.append("")
-        lines.append("| family_type | generalized | targeted |")
-        lines.append("|---|---:|---:|")
-        for ft in sorted(per_ft.keys()):
-            sub = per_ft[ft]
-            lines.append(
-                f"| {ft} | {_format_value(sub.get('generalized', 0.0))} | "
-                f"{_format_value(sub.get('targeted', 0.0))} |"
-            )
-        lines.append("")
+        return []
+    lines = ["### 2.2 CAP / TCAP (attribute inference)", ""]
+    lines.extend(_render_kv_table(global_rows))
+    lines.extend(
+        _render_per_ft_table(
+            per_ft,
+            ("generalized", "targeted"),
+            "family_type 別 (generalized / targeted)",
+        )
+    )
     return lines
 
 


### PR DESCRIPTION
## 背景

直近で merge された 7 PR (#95–#102) に対して \`/simplify\` レビュー（reuse / quality / efficiency の 3 軸）を実行し、検出された **近重複・冗長計算** を 1 PR にまとめて解消する。

## 変更内容

3 ファイル、+133 / −120 行。挙動は変えない。

### 1. \`src/synthpop_jp/evaluate/utility/broad.py\`

**\`_build_correlation_matrix\` を上三角のみ計算してミラー**。対称行列なので Cramér's V / Correlation Ratio の呼び出し回数が **半減**（4 属性なら 12 回 → 6 回）。\`_pair_correlation\` ヘルパを抽出し、(連続/カテゴリ) 判定を 1 か所に集約。

### 2. \`src/synthpop_jp/evaluate/utility/narrow.py\`

\`_household_aggregates\` 構造体を導入し、\`member_count\` / \`child_count\` / \`ft_per_household\` / per-person broadcast を **1 度の集計で再利用**。Task A / B が同じ集計を独立に走らせていた重複を解消。

副次的効果:
- \`_features_task_b\` の Python ループ（\`for i in range(n): if not seen[h]: ...\`）を \`np.unique(return_index=True)\` でベクトル化
- \`_household_features\` は後方互換ラッパーとして残す

### 3. \`src/synthpop_jp/reports/markdown.py\`

\`_render_kv_table\` と \`_render_per_ft_table\` を抽出。\`_render_rare_cell\` と \`_render_cap\` の near-duplicate（同じ「グローバル kv table + family_type 別 cross table」パターン）を統合し、~30 行削減。

## 影響範囲

- 変更モジュール: \`evaluate/utility/\`, \`reports/\`
- 他モジュールへの影響: なし
- 既存 API の互換性: **維持**（パブリックなクラス・関数のシグネチャ無変更）
- 依存関係の変化: なし

## テスト

- 追加テスト: 0 件（リファクタなので）
- 既存 645 + 10 = **655 passed, 10 skipped** を維持
- ruff / format / pyright すべて clean

## 残課題（別 Issue で扱う）

- \`broad.py\` / \`privacy_metrics.py\` で重複している Population→numpy matrix 変換は、\`PopulationArrays.column(name)\` メソッドを生やすか shared utility にまとめる方が clean
- \`broad.py:_cramers_v\` / \`_pair_dist\` の Python loop を \`np.add.at\` でベクトル化
- \`cli.py\` の \`if real_persons_csv is not None:\` ブロックの registry 化

## レビュアーに特に見てほしい点

- \`_build_correlation_matrix\` の上三角化（数値が同じ対称行列を返すか）
- \`_household_aggregates\` 構造体の API
- \`_household_features\` を後方互換ラッパーとして残した判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)